### PR TITLE
Bug 32047995: ENABLE_ADU_TELEMETRY_REPORTING- arm64 yaml missing

### DIFF
--- a/azurepipelines/adu-debian-arm32-build.yml
+++ b/azurepipelines/adu-debian-arm32-build.yml
@@ -12,7 +12,7 @@ variables:
   ADUC_VERSION_PRERELEASE: $(version.pre-release)
   ADUC_VERSION_BUILD: $(version.build)
   ENABLE_ADU_TELEMETRY_REPORTING: true
-  # aducBuilderIdentifier will be set to "DU" short for Device Update by default, for ADUC-sourced builder
+  # aducBuilderIdentifier will be set to "DU" short for Device Update by default, for Devcie Update-sourced builder
   ADUC_BUILDER_IDENTIFIER: DU
   # DO requires gcc greater than 6 for c++17 support.
   # gcc-8 matches what is built with poky warrior.
@@ -27,7 +27,7 @@ resources:
 trigger:
   branches:
     include:
-      - master
+      - main
       - release/*
   paths:
     exclude:
@@ -39,11 +39,12 @@ trigger:
       - tools/*
       - docker/*
       - scripts/*
+      - licenses/*
 
 pr:
   branches:
     include:
-      - master
+      - main
       - release/*
       - feature/*
       # TODO(shiyipeng): Task 27290511: Debian arm32 64 pipeline - improve build time

--- a/azurepipelines/adu-ubuntu-amd64-build.yml
+++ b/azurepipelines/adu-ubuntu-amd64-build.yml
@@ -18,7 +18,7 @@ variables:
   ADUC_VERSION_PRERELEASE: $(version.pre-release)
   ADUC_VERSION_BUILD: $(version.build)
   ENABLE_ADU_TELEMETRY_REPORTING: true
-  # aducBuilderIdentifier will be set to "DU" short for Device Update by default, for ADUC-sourced builder
+  # aducBuilderIdentifier will be set to "DU" short for Device Update by default, for Devcie Update-sourced builder
   ADUC_BUILDER_IDENTIFIER: DU
   # DO requires gcc greater than 6 for c++17 support.
   # gcc-8 matches what is built with poky warrior.

--- a/azurepipelines/adu-ubuntu-arm64-build.yml
+++ b/azurepipelines/adu-ubuntu-arm64-build.yml
@@ -10,6 +10,9 @@ variables:
     ADUC_VERSION_PATCH: $(version.patch)
     ADUC_VERSION_PRERELEASE: $(version.pre-release)
     ADUC_VERSION_BUILD: $(version.build)
+    ENABLE_ADU_TELEMETRY_REPORTING: true
+    # aducBuilderIdentifier will be set to "DU" short for Device Update by default, for Devcie Update-sourced builder
+    ADUC_BUILDER_IDENTIFIER: DU
     # DO requires gcc greater than 6 for c++17 support.
     # gcc-8 matches what is built with poky warrior.
     CC: gcc-8
@@ -23,7 +26,7 @@ resources:
 trigger:
   branches:
     include:
-      - master
+      - main
       - release/*
   paths:
     exclude:
@@ -35,11 +38,12 @@ trigger:
       - tools/*
       - docker/*
       - scripts/*
+      - licenses/*
 
 pr:
   branches:
     include:
-      - master
+      - main
       - release/*
       - feature/*
       # TODO(shiyipeng): Task 27290511: Debian arm32 64 pipeline - improve build time


### PR DESCRIPTION
ENABLE_ADU_TELEMETRY_REPORTING and ADUC_BUILDER_IDENTIFIER were missing in arm64 yaml were missing, this change adds them back.