### PR TITLE
Changed  idtype to default to module to align with AIS expectations

### DIFF
--- a/packages/debian/postinst
+++ b/packages/debian/postinst
@@ -119,7 +119,7 @@ register_adu_user_and_process_with_eis() {
         if [ -d "$eis_idservice_dir" ]; then
 
             if [ ! -f "$eis_idservice_dir/$adu_eis_conf_file" ]; then
-                printf "[[principal]]\n name=\"deviceupdate\"\n idtype=[\"module\"]\n uid= $(id -u $adu_user)\n" > "$eis_idservice_dir/$adu_eis_conf_file"
+                printf "[[principal]]\n name=\"IoTHubDeviceUpdate\"\n idtype=[\"module\"]\n uid= $(id -u $adu_user)\n" > "$eis_idservice_dir/$adu_eis_conf_file"
                 chown aziotid:aziotid "$eis_idservice_dir/$adu_eis_conf_file"
                 chmod u=rw "$eis_idservice_dir/$adu_eis_conf_file"
             fi

--- a/packages/debian/postinst
+++ b/packages/debian/postinst
@@ -19,7 +19,6 @@ adu_shell_dir=/usr/lib/adu
 adu_shell_file=adu-shell
 
 adu_eis_conf_file=adu.toml
-adu_eis_idtype=device
 eis_idservice_dir=/etc/aziot/identityd/config.d
 
 # adu_user is the user that the ADU Agent daemon will run as.
@@ -120,7 +119,7 @@ register_adu_user_and_process_with_eis() {
         if [ -d "$eis_idservice_dir" ]; then
 
             if [ ! -f "$eis_idservice_dir/$adu_eis_conf_file" ]; then
-                printf "[[principal]]\n name=\"adu\"\n idtype=[\"$adu_eis_idtype\"]\n uid= $(id -u $adu_user)\n" > "$eis_idservice_dir/$adu_eis_conf_file"
+                printf "[[principal]]\n name=\"adu\"\n idtype=[\"module\"]\n uid= $(id -u $adu_user)\n" > "$eis_idservice_dir/$adu_eis_conf_file"
                 chown aziotid:aziotid "$eis_idservice_dir/$adu_eis_conf_file"
                 chmod u=rw "$eis_idservice_dir/$adu_eis_conf_file"
             fi

--- a/packages/debian/postinst
+++ b/packages/debian/postinst
@@ -119,7 +119,7 @@ register_adu_user_and_process_with_eis() {
         if [ -d "$eis_idservice_dir" ]; then
 
             if [ ! -f "$eis_idservice_dir/$adu_eis_conf_file" ]; then
-                printf "[[principal]]\n name=\"adu\"\n idtype=[\"module\"]\n uid= $(id -u $adu_user)\n" > "$eis_idservice_dir/$adu_eis_conf_file"
+                printf "[[principal]]\n name=\"deviceupdate\"\n idtype=[\"module\"]\n uid= $(id -u $adu_user)\n" > "$eis_idservice_dir/$adu_eis_conf_file"
                 chown aziotid:aziotid "$eis_idservice_dir/$adu_eis_conf_file"
                 chmod u=rw "$eis_idservice_dir/$adu_eis_conf_file"
             fi


### PR DESCRIPTION
- Changed the idtype to module to align with AIS expectations

This means that AIS will attempt to provision an ADU module unless the user changes the generated principal for ADU located in the adu.toml. 

