### PR TITLE
Support agentRestartRequired property in APT Manifest

### DIFF
--- a/src/content_handlers/apt_handler/inc/aduc/apt_parser.hpp
+++ b/src/content_handlers/apt_handler/inc/aduc/apt_parser.hpp
@@ -29,12 +29,18 @@
  */
 #define ADU_APT_FIELDNAME_VERSION "version"
 
+/**
+ * @brief JSON field name for agentRestartRequired property
+ */
+#define ADU_APT_FIELDNAME_AGENT_RESTART_REQUIRED "agentRestartRequired"
+
 struct AptContent
 {
     std::string Id;
     std::string Name;
     std::string Version;
     std::list<std::string> Packages;
+    bool AgentRestartRequired;
 };
 
 namespace AptParser

--- a/src/content_handlers/apt_handler/src/apt_handler.cpp
+++ b/src/content_handlers/apt_handler/src/apt_handler.cpp
@@ -29,9 +29,6 @@
 
 namespace adushconst = Adu::Shell::Const;
 
-// Indicates that the agent should restart when applying the update.
-static bool g_restartRequiredAfterApplied = false;
-
 /**
  * @brief Constructor
  * This function locates and parses APT file using APTParser.
@@ -212,7 +209,6 @@ ADUC_Result AptHandlerImpl::Install()
     _applied = false;
     std::string aptOutput;
     int aptExitCode = -1;
-    bool installingADUAgent = false;
 
     ADUC_Result result = { ADUC_DownloadResult_Success };
     try
@@ -235,17 +231,6 @@ ADUC_Result AptHandlerImpl::Install()
         std::stringstream data;
         for (const std::string& package : _packages)
         {
-            // Are we installing adu-agent package?
-            // Currently, we are assuming adu-agent* is an ADU Agent package.
-            if (!installingADUAgent && (package.find_first_of("adu-agent") == 0))
-            {
-                installingADUAgent = true;
-                Log_Info(
-                    "The ADU Agent restart is required after installation task completed. (package:%s)",
-                    package.c_str());
-                g_restartRequiredAfterApplied = true;
-            }
-
             data << package << " ";
         }
         args.emplace_back(adushconst::target_data_opt);
@@ -288,7 +273,7 @@ ADUC_Result AptHandlerImpl::Apply()
         return ADUC_Result{ ADUC_ApplyResult_Failure, ADUC_ERC_APT_HANDLER_INSTALLCRITERIA_PERSIST_FAILURE };
     }
 
-    if (g_restartRequiredAfterApplied)
+    if (_aptContent->AgentRestartRequired)
     {
         // Always require a agent restart after self updated.
         Log_Debug("The install task completed successfully, ADU Agent restart is required for this update.");

--- a/src/content_handlers/apt_handler/src/apt_handler.cpp
+++ b/src/content_handlers/apt_handler/src/apt_handler.cpp
@@ -275,8 +275,7 @@ ADUC_Result AptHandlerImpl::Apply()
 
     if (_aptContent->AgentRestartRequired)
     {
-        // Always require a agent restart after self updated.
-        Log_Debug("The install task completed successfully, ADU Agent restart is required for this update.");
+        Log_Debug("The install task completed successfully, DU Agent restart is required for this update.");
         return ADUC_Result{ ADUC_ApplyResult_SuccessAgentRestartRequired };
     }
 

--- a/src/content_handlers/apt_handler/src/apt_parser.cpp
+++ b/src/content_handlers/apt_handler/src/apt_parser.cpp
@@ -92,16 +92,13 @@ std::unique_ptr<AptContent> GetAptContentFromRootValue(JSON_Value* rootValue)
                     ADUC_ERC_APT_HANDLER_INVALID_PACKAGE_DATA);
             }
 
-            // Note: For backward compatibility.
-            //
-            // Are we installing adu-agent package?
-            // Currently, we are assuming adu-agent* or du-agent* is an ADU Agent package.
-            if (!aptContent->AgentRestartRequired
-                && ((name.find_first_of("adu-agent") == 0) || (name.find_first_of("deviceupdate-agent") == 0)))
+            // Are we installing deviceupdate-agent package?
+            // Currently, we are assuming deviceupdate-agent* is a Device Update Agent package.
+            if (!aptContent->AgentRestartRequired && (name.find_first_of("deviceupdate-agent") == 0))
             {
                 aptContent->AgentRestartRequired = true;
                 Log_Info(
-                    "The ADU Agent restart is required after installation task completed. (package:%s)", name.c_str());
+                    "The DU Agent restart is required after installation task completed. (package:%s)", name.c_str());
             }
 
             // NOTE: Version is optional.

--- a/src/content_handlers/apt_handler/src/apt_parser.cpp
+++ b/src/content_handlers/apt_handler/src/apt_parser.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<AptContent> GetAptContentFromRootValue(JSON_Value* rootValue)
     aptContent->Name = aptName;
     aptContent->Version = aptVersion;
 
-    // Note: json_object_get_boolen returns -1 on fail.
+    // Note: json_object_get_boolean returns -1 on fail.
     const int agentRestartRequired = json_object_get_boolean(rootObject, ADU_APT_FIELDNAME_AGENT_RESTART_REQUIRED);
     aptContent->AgentRestartRequired = (agentRestartRequired > 0);
 

--- a/src/content_handlers/apt_handler/src/apt_parser.cpp
+++ b/src/content_handlers/apt_handler/src/apt_parser.cpp
@@ -67,6 +67,10 @@ std::unique_ptr<AptContent> GetAptContentFromRootValue(JSON_Value* rootValue)
     aptContent->Name = aptName;
     aptContent->Version = aptVersion;
 
+    // Note: json_object_get_boolen returns -1 on fail.
+    const int agentRestartRequired = json_object_get_boolean(rootObject, ADU_APT_FIELDNAME_AGENT_RESTART_REQUIRED);
+    aptContent->AgentRestartRequired = (agentRestartRequired > 0);
+
     // Parse package list.
     JSON_Array* packages = json_object_get_array(rootObject, ADU_APT_FIELDNAME_PACKAGES);
     if (packages != nullptr)
@@ -86,6 +90,18 @@ std::unique_ptr<AptContent> GetAptContentFromRootValue(JSON_Value* rootValue)
                 throw AptParser::ParserException(
                     "APT Handler configuration data contains empty package name.",
                     ADUC_ERC_APT_HANDLER_INVALID_PACKAGE_DATA);
+            }
+
+            // Note: For backward compatibility.
+            //
+            // Are we installing adu-agent package?
+            // Currently, we are assuming adu-agent* or du-agent* is an ADU Agent package.
+            if (!aptContent->AgentRestartRequired
+                && ((name.find_first_of("adu-agent") == 0) || (name.find_first_of("deviceupdate-agent") == 0)))
+            {
+                aptContent->AgentRestartRequired = true;
+                Log_Info(
+                    "The ADU Agent restart is required after installation task completed. (package:%s)", name.c_str());
             }
 
             // NOTE: Version is optional.

--- a/src/content_handlers/apt_handler/tests/apt_parser_ut.cpp
+++ b/src/content_handlers/apt_handler/tests/apt_parser_ut.cpp
@@ -83,18 +83,6 @@ const char* aptContentWithAgentRestartRequiredFalse =
             R"(])"
     R"(})";
 
-
-const char* aptContentWithAgentRestartRequiredUsingNameAduAgent = 
-    R"({)"
-        R"( "name":"com-microsoft-eds-adu-testapt", )"
-        R"( "version":"1.0.1", )"
-        R"( "packages": [ )"
-            R"({)"
-                R"( "name":"adu-agent" )"
-            R"(})"
-            R"(])"
-    R"(})";
-
 const char* aptContentWithAgentRestartRequiredUsingNameDuAgent = 
     R"({)"
         R"( "name":"com-microsoft-eds-adu-testapt", )"
@@ -139,13 +127,6 @@ TEST_CASE("APT Parser AgentRestartRequired(false) Test")
     std::unique_ptr<AptContent> aptContent =
         AptParser::ParseAptContentFromString(aptContentWithAgentRestartRequiredFalse);
     CHECK_FALSE(aptContent->AgentRestartRequired);
-}
-
-TEST_CASE("APT Parser AgentRestartRequired(adu-agent package name) Test")
-{
-    std::unique_ptr<AptContent> aptContent =
-        AptParser::ParseAptContentFromString(aptContentWithAgentRestartRequiredUsingNameAduAgent);
-    CHECK(aptContent->AgentRestartRequired);
 }
 
 TEST_CASE("APT Parser AgentRestartRequired(du-agent package name) Test")

--- a/src/content_handlers/apt_handler/tests/apt_parser_ut.cpp
+++ b/src/content_handlers/apt_handler/tests/apt_parser_ut.cpp
@@ -57,6 +57,55 @@ const char* aptContentWithOnePackage =
             R"(])"
     R"(})";
 
+const char* aptContentWithAgentRestartRequired = 
+    R"({)"
+        R"( "name":"com-microsoft-eds-adu-testapt", )"
+        R"( "version":"1.0.1", )"
+        R"( "agentRestartRequired":true, )"
+        R"( "packages": [ )"
+            R"({)"
+                R"( "name":"moby-engine", )"
+                R"( "version":"1.0.0.0" )"
+            R"(})"
+            R"(])"
+    R"(})";
+
+const char* aptContentWithAgentRestartRequiredFalse = 
+    R"({)"
+        R"( "name":"com-microsoft-eds-adu-testapt", )"
+        R"( "version":"1.0.1", )"
+        R"( "agentRestartRequired":false, )"
+        R"( "packages": [ )"
+            R"({)"
+                R"( "name":"moby-engine", )"
+                R"( "version":"1.0.0.0" )"
+            R"(})"
+            R"(])"
+    R"(})";
+
+
+const char* aptContentWithAgentRestartRequiredUsingNameAduAgent = 
+    R"({)"
+        R"( "name":"com-microsoft-eds-adu-testapt", )"
+        R"( "version":"1.0.1", )"
+        R"( "packages": [ )"
+            R"({)"
+                R"( "name":"adu-agent" )"
+            R"(})"
+            R"(])"
+    R"(})";
+
+const char* aptContentWithAgentRestartRequiredUsingNameDuAgent = 
+    R"({)"
+        R"( "name":"com-microsoft-eds-adu-testapt", )"
+        R"( "version":"1.0.1", )"
+        R"( "packages": [ )"
+            R"({)"
+                R"( "name":"deviceupdate-agent" )"
+            R"(})"
+            R"(])"
+    R"(})";
+
 // clang-format on
 
 TEST_CASE("APT Parser Tests")
@@ -76,4 +125,32 @@ TEST_CASE("APT Parser Tests 2")
     CHECK(aptContent->Packages.size() == 1);
     const auto package = aptContent->Packages.front();
     CHECK_THAT(package, Equals("moby-engine=1.0.0.0"));
+    CHECK_FALSE(aptContent->AgentRestartRequired);
+}
+
+TEST_CASE("APT Parser AgentRestartRequired Test")
+{
+    std::unique_ptr<AptContent> aptContent = AptParser::ParseAptContentFromString(aptContentWithAgentRestartRequired);
+    CHECK(aptContent->AgentRestartRequired);
+}
+
+TEST_CASE("APT Parser AgentRestartRequired(false) Test")
+{
+    std::unique_ptr<AptContent> aptContent =
+        AptParser::ParseAptContentFromString(aptContentWithAgentRestartRequiredFalse);
+    CHECK_FALSE(aptContent->AgentRestartRequired);
+}
+
+TEST_CASE("APT Parser AgentRestartRequired(adu-agent package name) Test")
+{
+    std::unique_ptr<AptContent> aptContent =
+        AptParser::ParseAptContentFromString(aptContentWithAgentRestartRequiredUsingNameAduAgent);
+    CHECK(aptContent->AgentRestartRequired);
+}
+
+TEST_CASE("APT Parser AgentRestartRequired(du-agent package name) Test")
+{
+    std::unique_ptr<AptContent> aptContent =
+        AptParser::ParseAptContentFromString(aptContentWithAgentRestartRequiredUsingNameDuAgent);
+    CHECK(aptContent->AgentRestartRequired);
 }

--- a/src/content_handlers/apt_handler/tests/sample_apt_manifest.json
+++ b/src/content_handlers/apt_handler/tests/sample_apt_manifest.json
@@ -1,0 +1,11 @@
+{
+    "name": "du-agent-update",
+    "version": "0.7.0",
+    "packages": [
+        {
+            "name": "deviceupdate-agent",
+            "version": "0.7.0~public~preview"
+        }
+    ],
+    "agentRestartRequired": true
+}


### PR DESCRIPTION
This changes fix **Bug 32158196**: DU Agent doesn't restart after self-update completed.

This is a regression caused by package name changed from "adu-agent" to "deviceupdate-agent".

Currently, the agent automatically restarts during 'apply' if one of the APT package names starts with "adu-agent". This logic is no longer valid. 

### Changes
- Add 'agentRestartRequired' property to APT Manifest
- Update APT manifest parser to support the new property
- Add more APT update handler unit tests



