### PR TITLE
Bug 32212559: Deployment stuck at ‘in progress’: bug in startup code path

### DIFF
--- a/src/agent/adu_core_interface/inc/aduc/adu_core_export_helpers.h
+++ b/src/agent/adu_core_interface/inc/aduc/adu_core_export_helpers.h
@@ -17,6 +17,14 @@
 EXTERN_C_BEGIN
 
 /**
+ * @brief Generate a unique identifier.
+ *
+ * @param buffer Where to store identifier.
+ * @param buffer_cch Number of characters in @p buffer.
+ */
+void GenerateUniqueId(char* buffer, size_t buffer_cch);
+
+/**
  * @brief Frees each FileEntity's members and the ADUC_FileEntity array
  * @param filecount the total number of files held within files
  * @param files a pointer to an array of ADUC_FileEntity objects

--- a/src/agent/adu_core_interface/inc/aduc/adu_core_export_helpers.h
+++ b/src/agent/adu_core_interface/inc/aduc/adu_core_export_helpers.h
@@ -17,14 +17,6 @@
 EXTERN_C_BEGIN
 
 /**
- * @brief Generate a unique identifier.
- *
- * @param buffer Where to store identifier.
- * @param buffer_cch Number of characters in @p buffer.
- */
-void GenerateUniqueId(char* buffer, size_t buffer_cch);
-
-/**
  * @brief Frees each FileEntity's members and the ADUC_FileEntity array
  * @param filecount the total number of files held within files
  * @param files a pointer to an array of ADUC_FileEntity objects

--- a/src/agent/adu_core_interface/src/adu_core_export_helpers.c
+++ b/src/agent/adu_core_interface/src/adu_core_export_helpers.c
@@ -25,7 +25,7 @@
  * @param buffer Where to store identifier.
  * @param buffer_cch Number of characters in @p buffer.
  */
-static void GenerateUniqueId(char* buffer, size_t buffer_cch)
+void GenerateUniqueId(char* buffer, size_t buffer_cch)
 {
     const time_t timer = time(NULL);
     const struct tm* ptm = gmtime(&timer);

--- a/src/agent/adu_core_interface/src/adu_core_export_helpers.c
+++ b/src/agent/adu_core_interface/src/adu_core_export_helpers.c
@@ -8,7 +8,6 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
-#include <time.h>
 
 #include <parson.h>
 
@@ -18,19 +17,6 @@
 #include <aduc/string_c_utils.h>
 #include <sys/wait.h> // for waitpid
 #include <unistd.h>
-
-/**
- * @brief Generate a unique identifier.
- *
- * @param buffer Where to store identifier.
- * @param buffer_cch Number of characters in @p buffer.
- */
-void GenerateUniqueId(char* buffer, size_t buffer_cch)
-{
-    const time_t timer = time(NULL);
-    const struct tm* ptm = gmtime(&timer);
-    (void)strftime(buffer, buffer_cch, "%y%m%d%H%M%S", ptm);
-}
 
 void ADUC_MethodCall_Idle(ADUC_WorkflowData* workflowData);
 

--- a/src/agent/adu_core_interface/src/adu_core_export_helpers.c
+++ b/src/agent/adu_core_interface/src/adu_core_export_helpers.c
@@ -762,7 +762,7 @@ void ADUC_MethodCall_Idle(ADUC_WorkflowData* workflowData)
         workflowData->WorkFolder = NULL;
 
         Log_Info("UpdateAction: Idle. Ending workflow with WorkflowId: %s", workflowData->WorkflowId);
-        memset(workflowData->WorkFolder, 0, sizeof(*(workflowData->WorkFolder)));
+        workflowData->WorkflowId[0] = 0;
     }
 
     else

--- a/src/agent/adu_core_interface/src/adu_core_export_helpers.c
+++ b/src/agent/adu_core_interface/src/adu_core_export_helpers.c
@@ -774,12 +774,11 @@ void ADUC_MethodCall_Idle(ADUC_WorkflowData* workflowData)
 
         free(workflowData->WorkFolder);
         workflowData->WorkFolder = NULL;
+
+        Log_Info("UpdateAction: Idle. Ending workflow with WorkflowId: %s", workflowData->WorkflowId);
+        memset(workflowData->WorkFolder, 0, sizeof(*(workflowData->WorkFolder)));
     }
 
-    if (workflowData->WorkflowId != NULL)
-    {
-        Log_Info("UpdateAction: Idle. WorkflowId: %s", workflowData->WorkflowId);
-    }
     else
     {
         Log_Info("UpdateAction: Idle. WorkflowId is not generated yet.");

--- a/src/agent/adu_core_interface/src/adu_core_export_helpers.c
+++ b/src/agent/adu_core_interface/src/adu_core_export_helpers.c
@@ -776,7 +776,14 @@ void ADUC_MethodCall_Idle(ADUC_WorkflowData* workflowData)
         workflowData->WorkFolder = NULL;
     }
 
-    Log_Info("UpdateAction: Idle. WorkflowId: %s", workflowData->WorkflowId);
+    if (workflowData->WorkflowId != NULL)
+    {
+        Log_Info("UpdateAction: Idle. WorkflowId: %s", workflowData->WorkflowId);
+    }
+    else
+    {
+        Log_Info("UpdateAction: Idle. WorkflowId is not generated yet.");
+    }
 
     // Can reach Idle state from ApplyStarted as there isn't an ApplySucceeded state.
     if (workflowData->LastReportedState != ADUCITF_State_Idle

--- a/src/agent/adu_core_interface/src/adu_core_export_helpers.c
+++ b/src/agent/adu_core_interface/src/adu_core_export_helpers.c
@@ -776,9 +776,6 @@ void ADUC_MethodCall_Idle(ADUC_WorkflowData* workflowData)
         workflowData->WorkFolder = NULL;
     }
 
-    // Each time we get to idle, generate a new workflow id.
-    GenerateUniqueId(workflowData->WorkflowId, sizeof(workflowData->WorkflowId) / sizeof(workflowData->WorkflowId[0]));
-
     Log_Info("UpdateAction: Idle. WorkflowId: %s", workflowData->WorkflowId);
 
     // Can reach Idle state from ApplyStarted as there isn't an ApplySucceeded state.

--- a/src/agent/adu_core_interface/src/agent_workflow.c
+++ b/src/agent/adu_core_interface/src/agent_workflow.c
@@ -446,6 +446,19 @@ void ADUC_Workflow_HandleStartupWorkflowData(ADUC_WorkflowData* workflowData)
     else
     {
         Log_Info("The installed criteria is not met. The current update was not installed on the device.");
+
+        if (workflowData->CurrentAction == ADUCITF_UpdateAction_Download)
+        {
+            Log_Info("There's a pending 'download' action request. Continue downloading the update.");
+
+            // There's a pending download requrest.
+            // We need to make sure we don't change our state to 'idle'.
+            workflowData->StartupIdleCallSent = true;
+
+            // Continue processing 'download' action.
+            ADUC_Workflow_HandleUpdateAction(workflowData);
+            goto done;
+        }
     }
 
     ADUC_SetUpdateStateWithResult(workflowData, ADUCITF_State_Idle, result);

--- a/src/agent/adu_core_interface/src/agent_workflow.c
+++ b/src/agent/adu_core_interface/src/agent_workflow.c
@@ -90,6 +90,7 @@
 
 #include "agent_workflow_utils.h"
 
+
 static void DownloadProgressCallback(
     const char* workflowId,
     const char* fileId,
@@ -449,13 +450,16 @@ void ADUC_Workflow_HandleStartupWorkflowData(ADUC_WorkflowData* workflowData)
 
         if (workflowData->CurrentAction == ADUCITF_UpdateAction_Download)
         {
-            Log_Info("There's a pending 'download' action request. Continue downloading the update.");
+            Log_Info("There's a pending 'download' action request. Resume downloading the update.");
 
-            // There's a pending download requrest.
+            // There's a pending download request.
             // We need to make sure we don't change our state to 'idle'.
             workflowData->StartupIdleCallSent = true;
 
-            // Continue processing 'download' action.
+            // We need to generate a new workflowId for this scenario then resume processing 'download' action.
+            GenerateUniqueId(workflowData->WorkflowId, sizeof(workflowData->WorkflowId) / sizeof(workflowData->WorkflowId[0]));
+            Log_Info("Resuming workflow with WorkflowId %s", workflowData->WorkflowId);
+            
             ADUC_Workflow_HandleUpdateAction(workflowData);
             goto done;
         }

--- a/src/agent/adu_core_interface/src/agent_workflow.c
+++ b/src/agent/adu_core_interface/src/agent_workflow.c
@@ -699,8 +699,7 @@ void ADUC_Workflow_HandleUpdateAction(ADUC_WorkflowData* workflowData)
     if (entry->Action == ADUCITF_UpdateAction_Download)
     {
         // Generate workflowId when we start downloading.
-        GenerateUniqueId(
-            workflowData->WorkflowId, sizeof(workflowData->WorkflowId) / sizeof(workflowData->WorkflowId[0]));
+        GenerateUniqueId(workflowData->WorkflowId, ARRAY_SIZE(workflowData->WorkflowId));
         Log_Info("Start the workflow - downloading, with WorkflowId %s", workflowData->WorkflowId);
 
         result = ADUC_MethodCall_Prepare(workflowData);

--- a/src/agent/adu_core_interface/src/agent_workflow.c
+++ b/src/agent/adu_core_interface/src/agent_workflow.c
@@ -81,6 +81,7 @@
 #include <stdlib.h>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h> // PRIu64
+#include <time.h>
 
 #include "aduc/adu_core_export_helpers.h"
 #include "aduc/adu_core_interface.h"
@@ -89,6 +90,19 @@
 #include "aduc/result.h"
 
 #include "agent_workflow_utils.h"
+
+/**
+ * @brief Generate a unique identifier.
+ *
+ * @param buffer Where to store identifier.
+ * @param buffer_cch Number of characters in @p buffer.
+ */
+void GenerateUniqueId(char* buffer, size_t buffer_cch)
+{
+    const time_t timer = time(NULL);
+    const struct tm* ptm = gmtime(&timer);
+    (void)strftime(buffer, buffer_cch, "%y%m%d%H%M%S", ptm);
+}
 
 static void DownloadProgressCallback(
     const char* workflowId,

--- a/src/agent/adu_core_interface/tests/adu_core_export_helpers_ut.cpp
+++ b/src/agent/adu_core_interface/tests/adu_core_export_helpers_ut.cpp
@@ -290,11 +290,6 @@ TEST_CASE_METHOD(TestCaseFixture, "MethodCall workflow: Valid")
 
     ADUC_WorkflowData workflowData{};
 
-    const std::string workflowId{ "unit_test" };
-    constexpr size_t workflowIdSize = ARRAY_SIZE(workflowData.WorkflowId);
-    strncpy(workflowData.WorkflowId, workflowId.c_str(), workflowIdSize);
-    workflowData.WorkflowId[workflowIdSize - 1] = '\0';
-
     workflowData.LastReportedState = ADUCITF_State_Idle;
     workflowData.DownloadProgressCallback = DownloadProgressCallback;
 
@@ -333,6 +328,11 @@ TEST_CASE_METHOD(TestCaseFixture, "MethodCall workflow: Valid")
     methodCallData.MethodSpecificData.DownloadInfo = &downloadInfo;
 
     workflowData.CurrentAction = ADUCITF_UpdateAction_Download;
+
+    const std::string workflowId{ "unit_test" };
+    constexpr size_t workflowIdSize = ARRAY_SIZE(workflowData.WorkflowId);
+    strncpy(workflowData.WorkflowId, workflowId.c_str(), workflowIdSize);
+    workflowData.WorkflowId[workflowIdSize - 1] = '\0';
 
     result = ADUC_MethodCall_Download(&methodCallData);
 

--- a/src/agent/adu_core_interface/tests/adu_core_interface_ut.cpp
+++ b/src/agent/adu_core_interface/tests/adu_core_interface_ut.cpp
@@ -157,7 +157,6 @@ TEST_CASE_METHOD(TestCaseFixture, "AzureDeviceUpdateCoreInterface_Connected")
 
     AzureDeviceUpdateCoreInterface_Connected(&workflowData);
 
-    CHECK(workflowData.WorkflowId[0] != '\0');
     CHECK(workflowData.LastReportedState == ADUCITF_State_Idle);
     CHECK(workflowData.StartupIdleCallSent);
     CHECK(!workflowData.OperationInProgress);


### PR DESCRIPTION
When the previous action is Download, and then the device lost connection, when it gets connected and starts up again - it is stuck at `at progress` because the agent reports `idle` in this case, while it should resume the Download workflow.

Add the logic to resume Download workflow as Nox suggested. 

Validation to ensure that this won’t regress anything is needed.