### PR TITLE
Added generic error handlers to the linux_adu_core_impl

### DIFF
--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
@@ -186,6 +186,20 @@ ADUC_Result LinuxPlatformLayer::Download(const char* workflowId, const char* upd
 
         extendedResultCode = MAKE_ADUC_DELIVERY_OPTIMIZATION_EXTENDEDRESULTCODE(doErrorCode);
     }
+    catch (const std::exception& e)
+    {
+        Log_Error("DP download failed with an unhandled std exception: %s", e.what());
+
+        resultCode = ADUC_DownloadResult_Failure;
+        extendedResultCode = ADUC_ERC_NOTRECOVERABLE;
+    }
+    catch (...)
+    {
+        Log_Error("DO download failed due to an unknown exception");
+
+        resultCode = ADUC_DownloadResult_Failure;
+        extendedResultCode = ADUC_ERC_NOTRECOVERABLE;
+    }
 
     // If we downloaded successfully, validate the file hash.
     if (resultCode == ADUC_DownloadResult_Success)


### PR DESCRIPTION
Added two generic error handlers to the linux_adu_core_impl download step.

Pertains to bug:

https://microsoft.visualstudio.com/OS/_workitems/edit/28240915 