### PR TITLE
Changed version from 0.6.0-public-preview to 0.7.0-rc1-public-preview

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set_cache_with_env_or_default (
 
 set_cache_with_env_or_default (
     ADUC_VERSION_PRERELEASE
-    "rc4-public-preview"
+    "rc1-public-preview"
     STRING
     "The pre-release part of the semantic version")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set_cache_with_env_or_default (
 
 set_cache_with_env_or_default (
     ADUC_VERSION_MINOR
-    "6"
+    "7"
     STRING
     "The minor part of the semantic version")
 
@@ -53,7 +53,7 @@ set_cache_with_env_or_default (
 
 set_cache_with_env_or_default (
     ADUC_VERSION_PRERELEASE
-    "public-preview"
+    "rc4-public-preview"
     STRING
     "The pre-release part of the semantic version")
 

--- a/azurepipelines/adu-debian-arm32-build.yml
+++ b/azurepipelines/adu-debian-arm32-build.yml
@@ -1,8 +1,8 @@
 variables:
   version.major: 0
-  version.minor: 6
+  version.minor: 7
   version.patch: 0
-  version.pre-release: "public-preview"
+  version.pre-release: "rc4-public-preview"
   version.build: $[format('{0:yyyyMMdd}-{0:HHmmss}', pipeline.startTime)]
 
   # Environment variables for all client builds:

--- a/azurepipelines/adu-debian-arm32-build.yml
+++ b/azurepipelines/adu-debian-arm32-build.yml
@@ -2,7 +2,7 @@ variables:
   version.major: 0
   version.minor: 7
   version.patch: 0
-  version.pre-release: "rc4-public-preview"
+  version.pre-release: "rc1-public-preview"
   version.build: $[format('{0:yyyyMMdd}-{0:HHmmss}', pipeline.startTime)]
 
   # Environment variables for all client builds:

--- a/azurepipelines/adu-ubuntu-amd64-build.yml
+++ b/azurepipelines/adu-ubuntu-amd64-build.yml
@@ -2,7 +2,7 @@ variables:
   version.major: 0
   version.minor: 7
   version.patch: 0
-  version.pre-release: "rc4-public-preview"
+  version.pre-release: "rc1-public-preview"
   version.build: $[format('{0:yyyyMMdd}-{0:HHmmss}', pipeline.startTime)]
 
   # TODO(shiyipeng): Bug 30317524: [ADU E2E Testing] Azure Artifacts no longer free - publishing to test feed fails

--- a/azurepipelines/adu-ubuntu-amd64-build.yml
+++ b/azurepipelines/adu-ubuntu-amd64-build.yml
@@ -1,8 +1,8 @@
 variables:
   version.major: 0
-  version.minor: 6
+  version.minor: 7
   version.patch: 0
-  version.pre-release: "public-preview"
+  version.pre-release: "rc4-public-preview"
   version.build: $[format('{0:yyyyMMdd}-{0:HHmmss}', pipeline.startTime)]
 
   # TODO(shiyipeng): Bug 30317524: [ADU E2E Testing] Azure Artifacts no longer free - publishing to test feed fails

--- a/azurepipelines/adu-ubuntu-arm64-build.yml
+++ b/azurepipelines/adu-ubuntu-arm64-build.yml
@@ -2,7 +2,7 @@ variables:
   version.major: 0
   version.minor: 7
   version.patch: 0
-  version.pre-release: "rc4-public-preview"
+  version.pre-release: "rc1-public-preview"
     version.build: $[format('{0:yyyyMMdd}-{0:HHmmss}', pipeline.startTime)]
     # Environment variables for all client builds:
     ADUC_VERSION_MAJOR: $(version.major)

--- a/azurepipelines/adu-ubuntu-arm64-build.yml
+++ b/azurepipelines/adu-ubuntu-arm64-build.yml
@@ -1,8 +1,8 @@
 variables:
-    version.major: 0
-    version.minor: 6
-    version.patch: 0
-    version.pre-release: "public-preview"
+  version.major: 0
+  version.minor: 7
+  version.patch: 0
+  version.pre-release: "rc4-public-preview"
     version.build: $[format('{0:yyyyMMdd}-{0:HHmmss}', pipeline.startTime)]
     # Environment variables for all client builds:
     ADUC_VERSION_MAJOR: $(version.major)


### PR DESCRIPTION
changed major, minor, patch, and pre-release versions.

Please ignore the "rc4" in the branch name. It is actually rc1. PR name reflects that.