### PR TITLE
Bug 32367663: Relax special chars restrictions on DeviceInfo

### DIFF
--- a/src/agent/device_info_interface/src/device_info_interface.c
+++ b/src/agent/device_info_interface/src/device_info_interface.c
@@ -100,12 +100,6 @@ static void ApplyDeviceInfoPropertyConstraints(char* value)
             *curr = '\0';
             break;
         }
-
-        if (!(isalnum(*curr) || *curr == '.' || *curr == '-'))
-        {
-            // Replace unsupported characters with '-'
-            *curr = '-';
-        }
         ++curr;
     }
 }

--- a/src/agent/device_info_interface/src/device_info_interface.c
+++ b/src/agent/device_info_interface/src/device_info_interface.c
@@ -81,9 +81,8 @@ void DeviceInfoInterfaceData_Free()
 /**
  * @brief Ensure that a DeviceInfo property meets certain constraints.
  *
- * For private preview, Manufacturer and Model have the following limitations:
+ * For public preview, Manufacturer and Model have the following limitations:
  * 1. 1-64 characters in length.
- * 2. alphanumeric, dot and dash only.
  * However, to be safe, apply these constraints to all properties.
  *
  * @param value String value to apply constraints to.


### PR DESCRIPTION
Aligning with this change ADU-M's fix: Bug 32192452: Relax compat info DeviceManufacturer and DeviceModel restrictions

~~**Pending:** Leo is still waiting to hear back from IoT team on the length restrictions here:~~
~~Restrictions on device Manufacturer and model? · Issue #153 · Azure/iot-plugandplay-models (github.com)~~
Confirmed: The length limit remains 64

