### PR TITLE
Fixed DO group permissions to allow for writing the connection string

### DIFF
--- a/packages/debian/postinst
+++ b/packages/debian/postinst
@@ -152,6 +152,17 @@ case "$1" in
             systemctl restart "$ms_doclient_lite_service"
         fi
 
+        # Note: We must add the 'adu' user to the 'do' group so that we can set the connection_string for
+        # the nested edge scenario. 
+        echo "Add the 'adu' user to the 'do' group"
+        if getent passwd 'adu' > /dev/null; then
+            usermod -aG 'do' 'adu'
+
+            # Restart deliveryoptimization-agent service to ensure that the new 'do' user's permissions take effect.
+            echo "Restart $ms_doclient_lite_service"
+            systemctl restart "$ms_doclient_lite_service"
+        fi
+
         # Do not restart the current adu-agent because we want the update workflow
         # to complete, and reports the agent's state to ADU Management service.
         echo "============================================================"

--- a/packages/debian/postinst
+++ b/packages/debian/postinst
@@ -143,22 +143,13 @@ case "$1" in
         # which is one of the dependencies declared in adu-agent control file.
         # We are assuming that both DO user and group currently exist at this point.
         # Add 'do' user to 'adu' group to allow DO to write to ADU download sandbox.
-        echo "Add the 'do' user to the 'adu' group."
+        echo "Add the 'do' user to the 'adu' group and 'adu' to the 'do' group"
         if getent passwd 'do' > /dev/null; then
             usermod -aG 'adu' 'do'
-
-            # Restart deliveryoptimization-agent service to ensure that the new 'do' user's groups take effect.
-            echo "Restart $ms_doclient_lite_service"
-            systemctl restart "$ms_doclient_lite_service"
-        fi
-
-        # Note: We must add the 'adu' user to the 'do' group so that we can set the connection_string for
-        # the nested edge scenario. 
-        echo "Add the 'adu' user to the 'do' group"
-        if getent passwd 'adu' > /dev/null; then
+            # Note: We must add the 'adu' user to the 'do' group so that we can set the connection_string for DO
             usermod -aG 'do' 'adu'
 
-            # Restart deliveryoptimization-agent service to ensure that the new 'do' user's permissions take effect.
+            # Restart deliveryoptimization-agent service to ensure that the new 'do' user's groups take effect.
             echo "Restart $ms_doclient_lite_service"
             systemctl restart "$ms_doclient_lite_service"
         fi


### PR DESCRIPTION
Added the code in our postisnt script to add adu to the do group so we have permissions to write the connection_string to DO in order to fix an issue with the Nested Edge scenario. 