### PR TITLE
Bug 30744239 RemoveInstalledCriteria does not remove all matched entries

### DIFF
--- a/src/content_handlers/apt_handler/src/apt_handler.cpp
+++ b/src/content_handlers/apt_handler/src/apt_handler.cpp
@@ -400,7 +400,6 @@ const JSON_Status safe_json_serialize_to_file_pretty(const JSON_Value* value, co
 
 /**
  * @brief Persist specified installedCriteria in a file and mark its state as 'installed'.
- * NOTE: For private preview, only the last installedCriteria is persisted.
  * 
  * @param installedCriteriaFilePath A full path to installed criteria data file.
  * @param installedCriteria An installed criteria string.
@@ -455,6 +454,16 @@ AptHandlerImpl::PersistInstalledCriteria(const char* installedCriteriaFilePath, 
 /**
  * @brief Remove specified installedCriteria from installcriteria data file.
  *
+ * Note: it will remove duplicate installedCriteria entries.<br/>
+ * For example, only the baz array element would remain after a call with "bar" installedCriteria:<br/>
+ * \code
+ * [
+ *   {"installedCriteria": "bar", "state": "installed", "timestamp": "<time 1>"},
+ *   {"installedCriteria": "bar", "state": "installed", "timestamp": "<time 2>"},
+ *   {"installedCriteria": "baz", "state": "installed", "timestamp": "<time 3>"},
+ * ]
+ * \endcode
+ *
  * @param installedCriteriaFilePath A full path to installed criteria data file.
  * @param installedCriteria An installed criteria string.
  *
@@ -496,7 +505,12 @@ AptHandlerImpl::RemoveInstalledCriteria(const char* installedCriteriaFilePath, c
                         // Failed to remove.
                         success = false;
                     }
-                    break;
+
+                    if (!success)
+                    {
+                        break;
+                    }
+                    // otherwise, keep going to remove duplicates
                 }
             }
         }

--- a/src/content_handlers/apt_handler/tests/apt_handler_ut.cpp
+++ b/src/content_handlers/apt_handler/tests/apt_handler_ut.cpp
@@ -22,6 +22,15 @@ struct JSONValueDeleter
     }
 };
 
+class InstalledCriteriaPersistence
+{
+public:
+    ~InstalledCriteriaPersistence()
+    {
+        remove(ADUC_INSTALLEDCRITERIA_FILE_PATH);
+    }
+};
+
 using AutoFreeJsonValue_t = std::unique_ptr<JSON_Value, JSONValueDeleter>;
 
 const char* aptTestJSONStringInstallLibCurlAndAptDoc =
@@ -120,7 +129,7 @@ TEST_CASE("APT handler prepare success")
     REQUIRE(std::remove(testFile.c_str()) == 0);
 }
 
-TEST_CASE("APT handler download missing package test",  "[!hide][functional_test]")
+TEST_CASE("APT handler download missing package test", "[!hide][functional_test]")
 {
     const std::string& workFolder = "/tmp";
     const std::string& fileName = "test.json";
@@ -139,7 +148,7 @@ TEST_CASE("APT handler download missing package test",  "[!hide][functional_test
     REQUIRE(std::remove(testFile.c_str()) == 0);
 }
 
-TEST_CASE("APT Handler bad version number test",  "[!hide][functional_test]")
+TEST_CASE("APT Handler bad version number test", "[!hide][functional_test]")
 {
     const std::string& workFolder = "/tmp";
     const std::string& fileName = "test.json";
@@ -243,6 +252,7 @@ TEST_CASE("APT Handler update apt-doc tests", "[!hide][functional_test]")
 
 TEST_CASE("APT_Handler_IsInstalled_test")
 {
+    InstalledCriteriaPersistence persistence; // remove installed criteria file on destruction.
     AptHandlerImpl::RemoveAllInstalledCriteria();
     // Persist foo
     const char* installedCriteria_foo = "contoso-iot-edge-6.1.0.19";
@@ -283,6 +293,7 @@ TEST_CASE("APT_Handler_IsInstalled_test")
 
 TEST_CASE("APT_Handler_RemoveIsInstalledTwice_test")
 {
+    InstalledCriteriaPersistence persistence; // remove installed criteria file on destruction.
     AptHandlerImpl::RemoveAllInstalledCriteria();
 
     // Ensure foo doesn't exist.
@@ -305,4 +316,87 @@ TEST_CASE("APT_Handler_RemoveIsInstalledTwice_test")
     // Regression test: 2nd remove should succeeded, with no infinite loop.
     removed = AptHandlerImpl::RemoveInstalledCriteria(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_foo);
     CHECK(removed);
+}
+
+TEST_CASE("APT_Handler_RemoveInstalledCriteriaShouldRemoveDuplicates")
+{
+    InstalledCriteriaPersistence persistence; // remove installed criteria file on destruction.
+    AptHandlerImpl::RemoveAllInstalledCriteria();
+
+    const char* installedCriteria_contoso = "contoso-iot-edge-6.1.0.19";
+
+    ADUC_Result isInstalled =
+        AptHandlerImpl::GetIsInstalled(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_contoso);
+    CHECK(isInstalled.ResultCode != ADUC_IsInstalledResult_Installed);
+
+    // Persist
+    bool persisted =
+        AptHandlerImpl::PersistInstalledCriteria(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_contoso);
+    CHECK(persisted);
+
+    // Should be installed
+    isInstalled = AptHandlerImpl::GetIsInstalled(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_contoso);
+    CHECK(isInstalled.ResultCode == ADUC_IsInstalledResult_Installed);
+
+    // Persist duplicate
+    persisted = AptHandlerImpl::PersistInstalledCriteria(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_contoso);
+    CHECK(persisted);
+
+    // Should still be installed
+    isInstalled = AptHandlerImpl::GetIsInstalled(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_contoso);
+    CHECK(isInstalled.ResultCode == ADUC_IsInstalledResult_Installed);
+
+    // Single remove call should remove all matching
+    bool removed =
+        AptHandlerImpl::RemoveInstalledCriteria(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_contoso);
+    CHECK(removed);
+
+    // Should NOT be installed
+    isInstalled = AptHandlerImpl::GetIsInstalled(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_contoso);
+    CHECK(isInstalled.ResultCode == ADUC_IsInstalledResult_NotInstalled);
+}
+
+TEST_CASE("APT_Handler_RemoveInstalledCriteriaShouldRemoveDuplicatesAndSkipNonMatching")
+{
+    const char* installedCriteria_foo = "contoso-iot-edge-6.1.0.19";
+    const char* installedCriteria_bar = "bar.1.0.1";
+
+    InstalledCriteriaPersistence persistence; // remove installed criteria file on destruction.
+    AptHandlerImpl::RemoveAllInstalledCriteria();
+
+    // Persist foo
+    bool persisted = AptHandlerImpl::PersistInstalledCriteria(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_foo);
+    CHECK(persisted);
+
+    ADUC_Result isInstalled = AptHandlerImpl::GetIsInstalled(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_foo);
+    CHECK(isInstalled.ResultCode == ADUC_IsInstalledResult_Installed);
+
+    // Persist dup foo
+    persisted = AptHandlerImpl::PersistInstalledCriteria(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_foo);
+    CHECK(persisted);
+
+    isInstalled = AptHandlerImpl::GetIsInstalled(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_foo);
+    CHECK(isInstalled.ResultCode == ADUC_IsInstalledResult_Installed);
+
+    // Persist bar
+    isInstalled = AptHandlerImpl::GetIsInstalled(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_bar);
+    CHECK(isInstalled.ResultCode != ADUC_IsInstalledResult_Installed);
+
+    persisted = AptHandlerImpl::PersistInstalledCriteria(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_bar);
+    CHECK(persisted);
+
+    isInstalled = AptHandlerImpl::GetIsInstalled(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_bar);
+    CHECK(isInstalled.ResultCode == ADUC_IsInstalledResult_Installed);
+
+    // Single remove foo and duplicates
+    bool removed = AptHandlerImpl::RemoveInstalledCriteria(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_foo);
+    CHECK(removed);
+
+    // foo should NOT be installed
+    isInstalled = AptHandlerImpl::GetIsInstalled(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_foo);
+    CHECK(isInstalled.ResultCode == ADUC_IsInstalledResult_NotInstalled);
+
+    // but bar should be installed
+    isInstalled = AptHandlerImpl::GetIsInstalled(ADUC_INSTALLEDCRITERIA_FILE_PATH, installedCriteria_bar);
+    CHECK(isInstalled.ResultCode == ADUC_IsInstalledResult_Installed);
 }


### PR DESCRIPTION
Allow RemoveInstalledCriteria to remove duplicates.

Add tests for removing all dups and not removing non-matching.
Add InstalledCriteriaPersistence RAII class and used it to remove ADUC_INSTALLEDCRITERIA_FILE_PATH on destruction to improve test isolation for tests that use PersistInstalledCriteria().

Update docs for RemoveInstalledCriteria with example json.  

screenshot of doxygen:
![image](https://user-images.githubusercontent.com/84477130/119635455-8fe21780-bdc8-11eb-9a88-25c638a95f49.png)

