### PR TITLE
Fix memory leak in ADUC

### DIFF
--- a/src/agent/adu_core_interface/src/adu_core_json.c
+++ b/src/agent/adu_core_interface/src/adu_core_json.c
@@ -524,7 +524,9 @@ JSON_Value* ADUC_JSON_GetUpdateManifestRoot(const JSON_Value* updateActionJson)
         return false;
     }
 
-    return json_parse_string(manifestString);
+    JSON_Value* updateManifestRoot = json_parse_string(manifestString);
+    free(manifestString);
+    return updateManifestRoot;
 }
 
 /**


### PR DESCRIPTION
ADUC_JSON_GetStringField() requires the
caller to call free() on the allocated string.