### PR TITLE
Task 34732610: (agent build) Pipeline Migration to 1ES

### DIFF
--- a/azurepipelines/adu-debian-arm32-build.yml
+++ b/azurepipelines/adu-debian-arm32-build.yml
@@ -27,7 +27,8 @@ resources:
 trigger:
   branches:
     include:
-      - main
+      # Currently Debian ARM 32 is not being supported.
+      # - main
       # - release/*
   paths:
     exclude:
@@ -41,10 +42,10 @@ trigger:
 pr:
   branches:
     include:
-      - main
+      # Currently Debian ARM 32 is not being supported.
+      # - main
       # - release/*
       # - feature/*
-      # TODO(shiyipeng): Task 27290511: Debian arm32 64 pipeline - improve build time
       #- dev/*
   paths:
     exclude:
@@ -61,7 +62,6 @@ pr:
 jobs:
   - job: BuildAduAgent
     displayName: "Build ADU Agent"
-    # Task 27290511: Debian arm pipeline - improve build time
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 360
     pool: aduc_1es_client_pool
@@ -98,7 +98,7 @@ jobs:
         displayName: "Run docker container"
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --build-unit-tests --platform-layer simulator --content-handlers microsoft/swupdate --log-lib zlog --out-dir out-arm32
+          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --build-unit-tests --platform-layer simulator --content-handlers microsoft/swupdate --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm32
         displayName: "Build Client and Unit Tests (simulator-swupdate-Debug)"
 
         # note, --out-dir param in the dependencies script adds a src/agent to the final location of AducIotAgent
@@ -132,7 +132,7 @@ jobs:
         condition: and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --provision-with-iotedge --build-unit-tests --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --out-dir out-arm32
+          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --provision-with-iotedge --build-unit-tes --static-analysis clang-tidy,cppcheck --out-dir out-arm32
         displayName: "Build Client and Unit Tests (linux-apt-Debug)"
 
       - bash: |
@@ -155,7 +155,7 @@ jobs:
           publishRunAttachments: false # Attachments are not supported for CTest
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --type MinSizeRel --provision-with-iotedge --build-unit-tests --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --build-packages --out-dir out-arm32
+          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --type MinSizeRel --provision-with-iotedge --build-unit-tests --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --build-packages --static-analysis clang-tidy,cppcheck --out-dir out-arm32
         displayName: "Build Client, Unit Tests and Packages (linux-apt-MinSizeRel)"
 
       - bash: |
@@ -178,7 +178,7 @@ jobs:
           publishRunAttachments: false # Attachments are not supported for CTest
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --platform-layer linux --content-handlers microsoft/swupdate --log-lib zlog --out-dir out-arm32
+          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --platform-layer linux --content-handlers microsoft/swupdate --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm32
         displayName: "Build Client (linux-swupdate-Debug)"
 
       - task: PublishPipelineArtifact@0

--- a/azurepipelines/adu-debian-arm32-build.yml
+++ b/azurepipelines/adu-debian-arm32-build.yml
@@ -27,7 +27,8 @@ resources:
 trigger:
   branches:
     include:
-      # Currently Debian ARM 32 is not being supported.
+      # TODO: Deliverable 32125353: [GA] Support OS Debian 10 with DU extensible agent
+      # Pause Debian 9 ARM 32 build for now.
       # - main
       # - release/*
   paths:
@@ -42,7 +43,8 @@ trigger:
 pr:
   branches:
     include:
-      # Currently Debian ARM 32 is not being supported.
+      # TODO: Deliverable 32125353: [GA] Support OS Debian 10 with DU extensible agent
+      # Pause Debian 9 ARM 32 build for now.
       # - main
       # - release/*
       # - feature/*
@@ -132,7 +134,7 @@ jobs:
         condition: and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --provision-with-iotedge --build-unit-tes --static-analysis clang-tidy,cppcheck --out-dir out-arm32
+          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --provision-with-iotedge --build-unit-tests --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm32
         displayName: "Build Client and Unit Tests (linux-apt-Debug)"
 
       - bash: |

--- a/azurepipelines/adu-debian-arm32-build.yml
+++ b/azurepipelines/adu-debian-arm32-build.yml
@@ -64,12 +64,19 @@ jobs:
     # Task 27290511: Debian arm pipeline - improve build time
     timeoutInMinutes: 360
     cancelTimeoutInMinutes: 360
-    pool: ADUC-Linux
+    pool: aduc_1es_client_pool
     steps:
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
         displayName: "Component Detection"
         inputs:
           sourceScanPath: src
+
+      - task: Docker@2
+        displayName: Login to ACR
+        inputs:
+          command: login
+          containerRegistry: aduccontainerregistry
+          repository: debian9-arm32
 
       - bash: |
           echo "Running whoami"
@@ -79,52 +86,16 @@ jobs:
         displayName: "Prebuild"
         condition: always()
 
-      - bash: |
-          cp /usr/bin/qemu-arm-static $(Build.SourcesDirectory)/docker/arm32/qemu-arm-static
-          sudo docker build --pull --rm -f "docker/arm32/Dockerfile" -t aduprivatepreview:latest "docker/arm32"
-        displayName: "Build docker image"
+      - task: Docker@2
+        displayName: Pull latest build image
+        inputs:
+          command: pull
+          containerRegistry: aduccontainerregistry
+          arguments: "aduccontainerregistry.azurecr.io/debian9-arm32:latest"
 
       - bash: |
-          sudo docker run -d -t --rm -v $(Build.SourcesDirectory):/iot-hub-device-update -v ~/.gitconfig:/etc/.gitconfig --name arm32container aduprivatepreview:latest bash
+          sudo docker run -d -t --rm -v $(Build.SourcesDirectory):/iot-hub-device-update -v ~/.gitconfig:/etc/.gitconfig --name arm32container aduccontainerregistry.azurecr.io/debian9-arm32:latest bash
         displayName: "Run docker container"
-
-      - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/install-deps.sh --install-aduc-deps --install-packages
-        displayName: "Install aduc dependencies in container"
-
-        # do_access_token is defined as a secret variable.
-        # This token gives our pipeline access to DO's private github repos.
-        # When DO code is public, we will no longer need to use this access token.
-        # Here we use git configuration to 'hijack' the regular github repo URLs
-        # and replace them with the authenticated URLs.
-        # See https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
-        # Before setting the various url insteadOf sections, we make sure the config is in a clean state.
-        # Any corrupted/invalid entries will prevent the clone from succeeding.
-        # The various git config commands will also fail to remove invalid entries,
-        # so we use sed instead.
-      - bash: |
-          sudo docker exec arm32container cp /etc/.gitconfig /iot-hub-device-update/.gitconfig
-          sudo docker exec arm32container sed -i -e '/^.*url.*https.*@github.com\/Microsoft.*$/d' -e '/^.*insteadOf.*https.*github.com\/Microsoft.*$/d' /iot-hub-device-update/.gitconfig
-          sudo docker exec arm32container cp -f /iot-hub-device-update/.gitconfig /etc/.gitconfig
-          sudo docker exec arm32container git config --global url."https://api:$DO_ACCESS_TOKEN@github.com/Microsoft/do-client.git".insteadOf "https://github.com/Microsoft/do-client.git"
-          sudo docker exec arm32container git config --global url."https://api:$DO_ACCESS_TOKEN@github.com/Microsoft/do-client".insteadOf "https://github.com/Microsoft/do-client"
-        displayName: "Configure git credentials for DO inside container"
-        env:
-          DO_ACCESS_TOKEN: $(do_access_token)
-
-      - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/install-deps.sh --install-do --install-do-deps-distro debian-9
-        displayName: "Install DO SDK from source in container"
-
-        # Cleanup the entries we added to clone private repos.
-        # The various git config commands will also fail to remove invalid entries,
-        # so we use sed instead.
-      - bash: |
-          sudo docker exec arm32container cp /etc/.gitconfig /iot-hub-device-update/.gitconfig
-          sudo docker exec arm32container sed -i -e '/^.*url.*https.*github.com\/Microsoft.*$/d' -e '/^.*insteadOf.*https.*github.com\/Microsoft.*$/d' /iot-hub-device-update/.gitconfig
-          sudo docker exec arm32container cp -f /iot-hub-device-update/.gitconfig /etc/.gitconfig
-        displayName: "Remove git credentials for DO in container"
-        condition: succeededOrFailed()
 
       - bash: |
           sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --build-unit-tests --platform-layer simulator --content-handlers microsoft/swupdate --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm32
@@ -223,6 +194,7 @@ jobs:
         # Ignore SC2209: Use var=$(command) to assign output (or quote to assign string).
         #   We use 'ret=return' or 'ret=exit' to support dot sourcing.
       - bash: |
+          sudo apt-get install -y shellcheck
           shellcheck -s bash -e SC2164 -e SC2209 $(find -name "*.sh")
           exit $?
         displayName: "Run ShellCheck"

--- a/azurepipelines/adu-debian-arm32-build.yml
+++ b/azurepipelines/adu-debian-arm32-build.yml
@@ -78,14 +78,6 @@ jobs:
           containerRegistry: aduccontainerregistry
           repository: debian9-arm32
 
-      - bash: |
-          echo "Running whoami"
-          whoami
-          echo "Listing running containers"
-          sudo docker ps -a
-        displayName: "Prebuild"
-        condition: always()
-
       - task: Docker@2
         displayName: Pull latest build image
         inputs:
@@ -94,11 +86,19 @@ jobs:
           arguments: "aduccontainerregistry.azurecr.io/debian9-arm32:latest"
 
       - bash: |
+          echo "Running whoami"
+          whoami
+          echo "Listing running containers"
+          sudo docker ps -a
+        displayName: "Prebuild"
+        condition: always()
+
+      - bash: |
           sudo docker run -d -t --rm -v $(Build.SourcesDirectory):/iot-hub-device-update -v ~/.gitconfig:/etc/.gitconfig --name arm32container aduccontainerregistry.azurecr.io/debian9-arm32:latest bash
         displayName: "Run docker container"
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --build-unit-tests --platform-layer simulator --content-handlers microsoft/swupdate --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm32
+          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --build-unit-tests --platform-layer simulator --content-handlers microsoft/swupdate --log-lib zlog --out-dir out-arm32
         displayName: "Build Client and Unit Tests (simulator-swupdate-Debug)"
 
         # note, --out-dir param in the dependencies script adds a src/agent to the final location of AducIotAgent
@@ -132,7 +132,7 @@ jobs:
         condition: and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --provision-with-iotedge --build-unit-tests --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm32
+          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --provision-with-iotedge --build-unit-tests --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --out-dir out-arm32
         displayName: "Build Client and Unit Tests (linux-apt-Debug)"
 
       - bash: |
@@ -155,7 +155,7 @@ jobs:
           publishRunAttachments: false # Attachments are not supported for CTest
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --type MinSizeRel --provision-with-iotedge --build-unit-tests --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --build-packages --static-analysis clang-tidy,cppcheck --out-dir out-arm32
+          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --type MinSizeRel --provision-with-iotedge --build-unit-tests --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --build-packages --out-dir out-arm32
         displayName: "Build Client, Unit Tests and Packages (linux-apt-MinSizeRel)"
 
       - bash: |
@@ -178,7 +178,7 @@ jobs:
           publishRunAttachments: false # Attachments are not supported for CTest
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --platform-layer linux --content-handlers microsoft/swupdate --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm32
+          sudo docker exec -w /iot-hub-device-update arm32container scripts/build.sh --clean --platform-layer linux --content-handlers microsoft/swupdate --log-lib zlog --out-dir out-arm32
         displayName: "Build Client (linux-swupdate-Debug)"
 
       - task: PublishPipelineArtifact@0

--- a/azurepipelines/adu-ubuntu-amd64-build.yml
+++ b/azurepipelines/adu-ubuntu-amd64-build.yml
@@ -70,7 +70,7 @@ jobs:
     displayName: "Build ADU Agent"
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 60
-    pool: ADUC-Linux
+    pool: aduc_1es_client_pool
     steps:
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
         displayName: "Component Detection"

--- a/azurepipelines/adu-ubuntu-arm64-build.yml
+++ b/azurepipelines/adu-ubuntu-arm64-build.yml
@@ -17,9 +17,9 @@ variables:
   # gcc-8 matches what is built with poky warrior.
   CC: gcc-8
   CXX: g++-8
-  
+
 name: $(version.major).$(version.minor).$(version.patch)-$(version.pre-release)+$(version.build)
-  
+
 resources:
 - repo: self
 
@@ -56,21 +56,21 @@ pr:
       - docker/*
       - scripts/*
       - licenses/*
-  
+
 jobs:
 - job: BuildAduAgent
   displayName: 'Build ADU Agent'
   timeoutInMinutes: 360
   cancelTimeoutInMinutes: 360
-  pool: ADUC-Linux
+  pool: aduc_1es_client_pool
   steps:
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
     inputs:
       sourceScanPath: src
-  
+
   # QEMU must be registered before this pipeline runs, but restarting the build VM will deregister QEMU,
-  # So, we just need to run QEMU before kicking off this pipeline. 
+  # So, we just need to run QEMU before kicking off this pipeline.
   # This is only an issue on the arm64 flavor since we aren't able to register QEMU as part of the docker
   # image for this architecture, which is not the case for arm32.
 
@@ -91,7 +91,7 @@ jobs:
     displayName: 'Build docker image'
 
   - bash: |
-          sudo docker run -d -t --rm -v $(Build.SourcesDirectory):/iot-hub-device-update -v ~/.gitconfig:/etc/.gitconfig --name arm64container adu-arm64-img:latest bash 
+          sudo docker run -d -t --rm -v $(Build.SourcesDirectory):/iot-hub-device-update -v ~/.gitconfig:/etc/.gitconfig --name arm64container adu-arm64-img:latest bash
     displayName: 'Run docker container'
 
   - bash: |
@@ -115,7 +115,7 @@ jobs:
           sudo docker exec arm64container git config --global url."https://api:$DO_ACCESS_TOKEN@github.com/Microsoft/do-client.git".insteadOf "https://github.com/Microsoft/do-client.git"
           sudo docker exec arm64container git config --global url."https://api:$DO_ACCESS_TOKEN@github.com/Microsoft/do-client".insteadOf "https://github.com/Microsoft/do-client"
     displayName: 'Configure git credentials for DO inside container'
-    env: 
+    env:
       DO_ACCESS_TOKEN: $(do_access_token)
 
   - bash: |
@@ -169,7 +169,7 @@ jobs:
   - bash: |
           sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --provision-with-iotedge --type MinSizeRel --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --build-packages --static-analysis clang-tidy,cppcheck --out-dir out-arm64
     displayName: 'Build Client, Unit Tests and Packages: linux-apt-MinSizeRel'
-    
+
   - bash: |
           cp out-arm64/*.deb $(Build.ArtifactStagingDirectory)
           cp out-arm64/src/agent/out-arm64/bin/AducIotAgent $(Build.ArtifactStagingDirectory)/AducIotAgent

--- a/azurepipelines/adu-ubuntu-arm64-build.yml
+++ b/azurepipelines/adu-ubuntu-arm64-build.yml
@@ -21,7 +21,7 @@ variables:
 name: $(version.major).$(version.minor).$(version.patch)-$(version.pre-release)+$(version.build)
 
 resources:
-- repo: self
+  - repo: self
 
 trigger:
   branches:
@@ -58,177 +58,141 @@ pr:
       - licenses/*
 
 jobs:
-- job: BuildAduAgent
-  displayName: 'Build ADU Agent'
-  timeoutInMinutes: 360
-  cancelTimeoutInMinutes: 360
-  pool: aduc_1es_client_pool
-  steps:
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: 'Component Detection'
-    inputs:
-      sourceScanPath: src
+  - job: BuildAduAgent
+    displayName: "Build ADU Agent"
+    timeoutInMinutes: 360
+    cancelTimeoutInMinutes: 360
+    pool: aduc_1es_client_pool
+    steps:
+      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+        displayName: "Component Detection"
+        inputs:
+          sourceScanPath: src
 
-  # QEMU must be registered before this pipeline runs, but restarting the build VM will deregister QEMU,
-  # So, we just need to run QEMU before kicking off this pipeline.
-  # This is only an issue on the arm64 flavor since we aren't able to register QEMU as part of the docker
-  # image for this architecture, which is not the case for arm32.
+      - task: Docker@2
+        displayName: Login to ACR
+        inputs:
+          command: login
+          containerRegistry: aduccontainerregistry
+          repository: ubuntu1804-arm64
 
-  - bash: |
+      - task: Docker@2
+        displayName: Pull latest build image
+        inputs:
+          command: pull
+          containerRegistry: aduccontainerregistry
+          arguments: "aduccontainerregistry.azurecr.io/ubuntu1804-arm64:latest"
+
+      - bash: |
           echo "Running whoami"
           whoami
-          echo "Register QEMU"
-          sudo docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
           echo "Listing running containers"
           sudo docker ps -a
-          echo "Listing current images"
-          sudo docker images
-    displayName: 'Prebuild'
-    condition: always()
+        displayName: "Prebuild"
+        condition: always()
 
-  - bash: |
-          sudo docker build --pull --rm -f "docker/arm64/Dockerfile" -t adu-arm64-img:latest "docker/arm64"
-    displayName: 'Build docker image'
+      - bash: |
+          sudo docker run -d -t --rm -v $(Build.SourcesDirectory):/iot-hub-device-update -v ~/.gitconfig:/etc/.gitconfig --name arm64container aduccontainerregistry.azurecr.io/ubuntu1804-arm64:latest bash
+        displayName: "Run docker container"
 
-  - bash: |
-          sudo docker run -d -t --rm -v $(Build.SourcesDirectory):/iot-hub-device-update -v ~/.gitconfig:/etc/.gitconfig --name arm64container adu-arm64-img:latest bash
-    displayName: 'Run docker container'
+      - bash: |
+          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --platform-layer simulator --content-handlers microsoft/swupdate --log-lib zlog --out-dir out-arm64
+        displayName: "Build Client and Unit Tests: simulator-swupdate-Debug"
 
-  - bash: |
-          sudo docker exec -w /iot-hub-device-update arm64container scripts/install-deps.sh --install-aduc-deps --install-packages
-    displayName: 'Install aduc dependencies in container'
-
-    # do_access_token is defined as a secret variable.
-    # This token gives our pipeline access to DO's private github repos.
-    # When DO code is public, we will no longer need to use this access token.
-    # Here we use git configuration to 'hijack' the regular github repo URLs
-    # and replace them with the authenticated URLs.
-    # See https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf
-    # Before setting the various url insteadOf sections, we make sure the config is in a clean state.
-    # Any corrupted/invalid entries will prevent the clone from succeeding.
-    # The various git config commands will also fail to remove invalid entries,
-    # so we use sed instead.
-  - bash: |
-          sudo docker exec arm64container cp /etc/.gitconfig /iot-hub-device-update/.gitconfig
-          sudo docker exec arm64container sed -i -e '/^.*url.*https.*@github.com\/Microsoft\/.*$/d' -e '/^.*insteadOf.*https.*github.com\/Microsoft\/.*$/d' /iot-hub-device-update/.gitconfig
-          sudo docker exec arm64container cp -f /iot-hub-device-update/.gitconfig /etc/.gitconfig
-          sudo docker exec arm64container git config --global url."https://api:$DO_ACCESS_TOKEN@github.com/Microsoft/do-client.git".insteadOf "https://github.com/Microsoft/do-client.git"
-          sudo docker exec arm64container git config --global url."https://api:$DO_ACCESS_TOKEN@github.com/Microsoft/do-client".insteadOf "https://github.com/Microsoft/do-client"
-    displayName: 'Configure git credentials for DO inside container'
-    env:
-      DO_ACCESS_TOKEN: $(do_access_token)
-
-  - bash: |
-          sudo docker exec -w /iot-hub-device-update arm64container scripts/install-deps.sh --install-do --install-do-deps-distro ubuntu-18.04
-    displayName: 'Install DO SDK from source in container'
-
-    # Cleanup the entries we added to clone private repos.
-    # The various git config commands will also fail to remove invalid entries,
-    # so we use sed instead.
-  - bash: |
-          sudo docker exec arm64container cp /etc/.gitconfig /iot-hub-device-update/.gitconfig
-          sudo docker exec arm64container sed -i -e '/^.*url.*https.*github.com\/Microsoft\/.*$/d' -e '/^.*insteadOf.*https.*github.com\/Microsoft\/.*$/d' /iot-hub-device-update/.gitconfig
-          sudo docker exec arm64container cp -f /iot-hub-device-update/.gitconfig /etc/.gitconfig
-    displayName: 'Remove git credentials for DO in container'
-    condition: succeededOrFailed()
-
-  - bash: |
-          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --platform-layer simulator --content-handlers microsoft/swupdate --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm64
-    displayName: 'Build Client and Unit Tests: simulator-swupdate-Debug'
-
-    # note, -o param in the dependencies script adds a src/agent to the final location of AducIotAgent
-  - bash: |
+        # note, -o param in the dependencies script adds a src/agent to the final location of AducIotAgent
+      - bash: |
           cp out-arm64/src/agent/out-arm64/bin/AducIotAgent $(Build.ArtifactStagingDirectory)/AducIotAgentSim-microsoft-swupdate
-    displayName: 'Stage build artifacts (simulator-swupdate-debug)'
-    condition: and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
+        displayName: "Stage build artifacts (simulator-swupdate-debug)"
+        condition: and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
 
-  - bash: |
+      - bash: |
           sudo docker exec -w /iot-hub-device-update/out-arm64 arm64container ctest -T test -V --output-on-failure
-    displayName: 'Run Unit Tests: simulator-swupdate-Debug'
+        displayName: "Run Unit Tests: simulator-swupdate-Debug"
 
-  - task: PublishTestResults@2
-    displayName: 'Publish Unit Test Results: simulator-swupdate-Debug'
-    condition: succeededOrFailed() # Run this task even if tests fail.
-    inputs:
-      testResultsFormat: cTest
-      testResultsFiles: 'Testing/**/*.xml'
-      searchFolder: out-arm64
-      failTaskOnFailedTests: true
-      publishRunAttachments: false # Attachments are not supported for CTest
+      - task: PublishTestResults@2
+        displayName: "Publish Unit Test Results: simulator-swupdate-Debug"
+        condition: succeededOrFailed() # Run this task even if tests fail.
+        inputs:
+          testResultsFormat: cTest
+          testResultsFiles: "Testing/**/*.xml"
+          searchFolder: out-arm64
+          failTaskOnFailedTests: true
+          publishRunAttachments: false # Attachments are not supported for CTest
 
-  - bash: |
+      - bash: |
           sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --provision-with-iotedge --platform-layer simulator --content-handlers microsoft/apt --log-lib zlog --out-dir out-arm64
-    displayName: 'Build Client: simulator-apt-Debug'
+        displayName: "Build Client: simulator-apt-Debug"
 
-    # note, -o param in the dependencies script adds a src/agent to the final location of AducIotAgent
-  - bash: |
+        # note, -o param in the dependencies script adds a src/agent to the final location of AducIotAgent
+      - bash: |
           cp out-arm64/src/agent/out-arm64/bin/AducIotAgent $(Build.ArtifactStagingDirectory)/AducIotAgentSim-microsoft-apt
-    displayName: 'Stage build artifacts (simulator-apt-debug)'
-    condition: and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
+        displayName: "Stage build artifacts (simulator-apt-debug)"
+        condition: and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
 
-  - bash: |
-          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --provision-with-iotedge --type MinSizeRel --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --build-packages --static-analysis clang-tidy,cppcheck --out-dir out-arm64
-    displayName: 'Build Client, Unit Tests and Packages: linux-apt-MinSizeRel'
+      - bash: |
+          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --provision-with-iotedge --type MinSizeRel --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --build-packages --out-dir out-arm64
+        displayName: "Build Client, Unit Tests and Packages: linux-apt-MinSizeRel"
 
-  - bash: |
+      - bash: |
           cp out-arm64/*.deb $(Build.ArtifactStagingDirectory)
           cp out-arm64/src/agent/out-arm64/bin/AducIotAgent $(Build.ArtifactStagingDirectory)/AducIotAgent
-    displayName: 'Stage build artifacts (Deb package, agent and docs)'
-    condition: and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
+        displayName: "Stage build artifacts (Deb package, agent and docs)"
+        condition: and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
 
-  - bash: |
+      - bash: |
           sudo docker exec -w /iot-hub-device-update/out-arm64 arm64container ctest -T test -V --output-on-failure
-    displayName: 'Run Unit Tests: linux-apt-MinSizeRel'
+        displayName: "Run Unit Tests: linux-apt-MinSizeRel"
 
-  - task: PublishTestResults@2
-    displayName: 'Publish Unit Test Results: linux-apt-MinSizeRel'
-    condition: succeededOrFailed() # Run this task even if tests fail.
-    inputs:
-      testResultsFormat: cTest
-      testResultsFiles: 'Testing/**/*.xml'
-      searchFolder: out-arm64
-      failTaskOnFailedTests: true
-      publishRunAttachments: false # Attachments are not supported for CTest
+      - task: PublishTestResults@2
+        displayName: "Publish Unit Test Results: linux-apt-MinSizeRel"
+        condition: succeededOrFailed() # Run this task even if tests fail.
+        inputs:
+          testResultsFormat: cTest
+          testResultsFiles: "Testing/**/*.xml"
+          searchFolder: out-arm64
+          failTaskOnFailedTests: true
+          publishRunAttachments: false # Attachments are not supported for CTest
 
-  - bash: |
-          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --platform-layer linux --content-handlers microsoft/swupdate --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm64
-    displayName: 'Build Client and Unit Tests: linux-swupdate-Debug'
+      - bash: |
+          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --platform-layer linux --content-handlers microsoft/swupdate --log-lib zlog --out-dir out-arm64
+        displayName: "Build Client and Unit Tests: linux-swupdate-Debug"
 
-  - bash: |
+      - bash: |
           sudo docker exec -w /iot-hub-device-update/out-arm64 arm64container ctest -T test -V --output-on-failure
-    displayName: 'Run Unit Tests: linux-swupdate-Debug'
+        displayName: "Run Unit Tests: linux-swupdate-Debug"
 
-  - task: PublishTestResults@2
-    displayName: 'Publish Unit Test Results: linux-swupdate-Debug'
-    condition: succeededOrFailed() # Run this task even if tests fail.
-    inputs:
-      testResultsFormat: cTest
-      testResultsFiles: 'Testing/**/*.xml'
-      searchFolder: out-arm64
-      failTaskOnFailedTests: true
-      publishRunAttachments: false # Attachments are not supported for CTest
+      - task: PublishTestResults@2
+        displayName: "Publish Unit Test Results: linux-swupdate-Debug"
+        condition: succeededOrFailed() # Run this task even if tests fail.
+        inputs:
+          testResultsFormat: cTest
+          testResultsFiles: "Testing/**/*.xml"
+          searchFolder: out-arm64
+          failTaskOnFailedTests: true
+          publishRunAttachments: false # Attachments are not supported for CTest
 
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish Pipeline Artifacts'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
-    inputs:
-      artifactName: 'adu-arm64-client'
-      targetPath: '$(Build.ArtifactStagingDirectory)'
+      - task: PublishPipelineArtifact@0
+        displayName: "Publish Pipeline Artifacts"
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
+        inputs:
+          artifactName: "adu-arm64-client"
+          targetPath: "$(Build.ArtifactStagingDirectory)"
 
-    # Ignore SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
-    #   We usually want to return an error code from a specific, previous command
-    #   even if popd, pushd, or cd fails.
-    # Ignore SC2209: Use var=$(command) to assign output (or quote to assign string).
-    #   We use 'ret=return' or 'ret=exit' to support dot sourcing.
-  - bash: |
+        # Ignore SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
+        #   We usually want to return an error code from a specific, previous command
+        #   even if popd, pushd, or cd fails.
+        # Ignore SC2209: Use var=$(command) to assign output (or quote to assign string).
+        #   We use 'ret=return' or 'ret=exit' to support dot sourcing.
+      - bash: |
+          sudo apt-get install -y shellcheck
           shellcheck -s bash -e SC2164 -e SC2209 $(find -name "*.sh")
           exit $?
-    displayName: ' Run ShellCheck'
+        displayName: " Run ShellCheck"
 
-    # Stop the running container at the end of the build job
-    # Remove output directory to prevent persisting across build jobs
-  - bash: |
-        sudo docker stop arm64container
-        sudo rm -rf out-arm64
-    displayName: 'Postbuild'
-    condition: always()
+        # Stop the running container at the end of the build job
+        # Remove output directory to prevent persisting across build jobs
+      - bash: |
+          sudo docker stop arm64container
+          sudo rm -rf out-arm64
+        displayName: "Postbuild"
+        condition: always()

--- a/azurepipelines/adu-ubuntu-arm64-build.yml
+++ b/azurepipelines/adu-ubuntu-arm64-build.yml
@@ -43,7 +43,6 @@ pr:
       - main
       # - release/*
       # - feature/*
-      # TODO(shiyipeng): Task 27290511: Debian arm32 64 pipeline - improve build time
       #- dev/*
   paths:
     exclude:
@@ -96,7 +95,7 @@ jobs:
         displayName: "Run docker container"
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --platform-layer simulator --content-handlers microsoft/swupdate --log-lib zlog --out-dir out-arm64
+          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --platform-layer simulator --content-handlers microsoft/swupdate --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm64
         displayName: "Build Client and Unit Tests: simulator-swupdate-Debug"
 
         # note, -o param in the dependencies script adds a src/agent to the final location of AducIotAgent
@@ -130,7 +129,7 @@ jobs:
         condition: and(ne(variables['Build.Reason'], 'IndividualCI'), ne(variables['Build.Reason'], 'PullRequest'))
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --provision-with-iotedge --type MinSizeRel --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --build-packages --out-dir out-arm64
+          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --provision-with-iotedge --type MinSizeRel --platform-layer linux --content-handlers microsoft/apt --log-lib zlog --build-packages --static-analysis clang-tidy,cppcheck --out-dir out-arm64
         displayName: "Build Client, Unit Tests and Packages: linux-apt-MinSizeRel"
 
       - bash: |
@@ -154,7 +153,7 @@ jobs:
           publishRunAttachments: false # Attachments are not supported for CTest
 
       - bash: |
-          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --platform-layer linux --content-handlers microsoft/swupdate --log-lib zlog --out-dir out-arm64
+          sudo docker exec -w /iot-hub-device-update arm64container scripts/build.sh --clean --build-unit-tests --platform-layer linux --content-handlers microsoft/swupdate --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir out-arm64
         displayName: "Build Client and Unit Tests: linux-swupdate-Debug"
 
       - bash: |


### PR DESCRIPTION
* Migrate from selfhost build to 1es hosted build
* Refactor the ARM builds. Start using Azcontainer to host a container with dependencies installed.
* Stop building debian 9 arm32 until request confirmed from PM.
* Will be merged to release080rc1 branch and later merge to main.