### PR TITLE
Disable component changed detection

### DIFF
--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.hpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.hpp
@@ -290,7 +290,12 @@ private:
      */
     static void DoWorkCallback(ADUC_Token token, ADUC_WorkflowDataToken workflowData) noexcept
     {
+#if ENABLE_COMPONENT_CHANGED_DETECTION
         DetectAndHandleComponentsAvailabilityChangedEvent(token, workflowData);
+#else
+        UNREFERENCED_PARAMETER(token);
+        UNREFERENCED_PARAMETER(workflowData);
+#endif
     }
 
     //


### PR DESCRIPTION
Disabling the component changed detection feature.
We're working on the better design that will be available in the next release.