### PR TITLE
Fix regression in reboot and restart logics

### DIFF
--- a/src/adu_workflow/src/agent_workflow.c
+++ b/src/adu_workflow/src/agent_workflow.c
@@ -1254,8 +1254,8 @@ done:
 
 void ADUC_Workflow_MethodCall_Install_Complete(ADUC_MethodCall_Data* methodCallData, ADUC_Result result)
 {
-    if (result.ResultCode == ADUC_Result_Install_RequiredImmediateReboot
-        || result.ResultCode == ADUC_Result_Install_RequiredReboot)
+    if (workflow_is_immediate_reboot_requested(methodCallData->WorkflowData->WorkflowHandle) ||
+        workflow_is_reboot_requested(methodCallData->WorkflowData->WorkflowHandle))
     {
         // If 'install' indicated a reboot required result from apply, go ahead and reboot.
         Log_Info("Install indicated success with RebootRequired - rebooting system now");
@@ -1275,8 +1275,8 @@ void ADUC_Workflow_MethodCall_Install_Complete(ADUC_MethodCall_Data* methodCallD
         }
     }
     else if (
-        result.ResultCode == ADUC_Result_Install_RequiredImmediateAgentRestart
-        || result.ResultCode == ADUC_Result_Install_RequiredAgentRestart)
+        workflow_is_immediate_agent_restart_requested(methodCallData->WorkflowData->WorkflowHandle) ||
+        workflow_is_agent_restart_requested(methodCallData->WorkflowData->WorkflowHandle))
     {
         // If 'install' indicated a restart is required, go ahead and restart the agent.
         Log_Info("Install indicated success with AgentRestartRequired - restarting the agent now");
@@ -1333,8 +1333,8 @@ done:
 
 void ADUC_Workflow_MethodCall_Apply_Complete(ADUC_MethodCall_Data* methodCallData, ADUC_Result result)
 {
-    if (result.ResultCode == ADUC_Result_Apply_RequiredReboot
-        || result.ResultCode == ADUC_Result_Apply_RequiredImmediateReboot)
+    if (workflow_is_immediate_reboot_requested(methodCallData->WorkflowData->WorkflowHandle) ||
+        workflow_is_reboot_requested(methodCallData->WorkflowData->WorkflowHandle))
     {
         // If apply indicated a reboot required result from apply, go ahead and reboot.
         Log_Info("Apply indicated success with RebootRequired - rebooting system now");
@@ -1354,8 +1354,8 @@ void ADUC_Workflow_MethodCall_Apply_Complete(ADUC_MethodCall_Data* methodCallDat
         }
     }
     else if (
-        result.ResultCode == ADUC_Result_Apply_RequiredAgentRestart
-        || result.ResultCode == ADUC_Result_Apply_RequiredImmediateAgentRestart)
+        workflow_is_immediate_agent_restart_requested(methodCallData->WorkflowData->WorkflowHandle) ||
+        workflow_is_agent_restart_requested(methodCallData->WorkflowData->WorkflowHandle))
     {
         // If apply indicated a restart is required, go ahead and restart the agent.
         Log_Info("Apply indicated success with AgentRestartRequired - restarting the agent now");

--- a/src/agent/adu_core_interface/tests/workflow_reboot_ut.cpp
+++ b/src/agent/adu_core_interface/tests/workflow_reboot_ut.cpp
@@ -218,6 +218,23 @@ public:
         UNREFERENCED_PARAMETER(workflowData);
 
         ADUC_Result result = { s_install_result_code, 0 };
+
+        switch (result.ResultCode)
+        {
+            case ADUC_Result_Install_RequiredImmediateAgentRestart:
+                workflow_request_immediate_agent_restart(workflowData->WorkflowHandle);
+                break;
+            case ADUC_Result_Install_RequiredAgentRestart:
+                workflow_request_agent_restart(workflowData->WorkflowHandle);
+                break;
+            case ADUC_Result_Install_RequiredImmediateReboot:
+                workflow_request_immediate_reboot(workflowData->WorkflowHandle);
+                break;
+            case ADUC_Result_Install_RequiredReboot:
+                workflow_request_reboot(workflowData->WorkflowHandle);
+                break;
+        }
+
         return result;
     }
 
@@ -225,6 +242,23 @@ public:
         UNREFERENCED_PARAMETER(workflowData);
 
         ADUC_Result result = { s_apply_result_code, 0 };
+
+        switch (result.ResultCode)
+        {
+            case ADUC_Result_Apply_RequiredImmediateAgentRestart:
+                workflow_request_immediate_agent_restart(workflowData->WorkflowHandle);
+                break;
+            case ADUC_Result_Apply_RequiredAgentRestart:
+                workflow_request_agent_restart(workflowData->WorkflowHandle);
+                break;
+            case ADUC_Result_Apply_RequiredImmediateReboot:
+                workflow_request_immediate_reboot(workflowData->WorkflowHandle);
+                break;
+            case ADUC_Result_Apply_RequiredReboot:
+                workflow_request_reboot(workflowData->WorkflowHandle);
+                break;
+        }
+
         return result;
     }
 

--- a/src/content_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/content_handlers/steps_handler/src/steps_handler.cpp
@@ -553,6 +553,7 @@ static ADUC_Result StepsHandler_Download(const tagADUC_WorkflowData* workflowDat
                 result.ResultCode = ADUC_Result_Install_Skipped_UpdateAlreadyInstalled;
                 result.ExtendedResultCode = 0;
                 workflow_set_result(stepHandle, result);
+                workflow_set_result_details(handle, workflow_peek_result_details(stepHandle));
                 // The current instance is already up-to-date, continue checking the next instance.
                 goto instanceDone;
             }
@@ -839,6 +840,7 @@ static ADUC_Result StepsHandler_Install(const tagADUC_WorkflowData* workflowData
                 result.ResultCode = ADUC_Result_Install_Skipped_UpdateAlreadyInstalled;
                 result.ExtendedResultCode = 0;
                 workflow_set_result(stepHandle, result);
+                workflow_set_result_details(handle, workflow_peek_result_details(stepHandle));
                 // Skipping 'backup', 'install' and 'apply'.
                 goto instanceDone;
             }


### PR DESCRIPTION
With the new Steps Handler design, Content Handles are responsible for requesting system reboot or agent restart using                 **workflow_request_immediate_agent_restart**, **workflow_request_agent_restart**, **workflow_request_immediate_reboot**, **workflow_request_reboot** APIs.
The state machine must check those requests and perform reboot or restart accordingly.

Changes:
- Update state machine logics
- Fix related unit tests
