### PR TITLE
[0.8.x] compilation: add option for hardening flags, defaults to ON.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ option (ADUC_BUILD_DOCUMENTATION "Build documentation files" OFF)
 option (ADUC_BUILD_PACKAGES "Build the ADU Agent packages" OFF)
 option (ADUC_INSTALL_DAEMON "Install the ADU Agent as a daemon" ON)
 option (ADUC_REGISTER_DAEMON "Register the ADU Agent daemon with the system" ON)
+option (ADUC_HARDENING "Add hardening flags to compilation" ON)
 
 ### End CMake Options
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,11 +5,13 @@ if (ADUC_WARNINGS_AS_ERRORS)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 endif ()
 
-set (COMPILER_HARDENING_FLAGS
-     "-fPIE -D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wformat -Werror=format-security")
-set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -z relro -z now")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILER_HARDENING_FLAGS}")
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMPILER_HARDENING_FLAGS} -Wall")
+if (ADUC_HARDENING)
+    set (COMPILER_HARDENING_FLAGS
+         "-fPIE -D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wformat -Werror=format-security")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -fPIE -fPIC -z relro -z now")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILER_HARDENING_FLAGS}")
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMPILER_HARDENING_FLAGS} -Wall")
+endif ()
 
 add_definitions (-DADUC_LOG_FOLDER="${ADUC_LOG_FOLDER}")
 add_definitions (-DADUC_DOWNLOADS_FOLDER="${ADUC_DOWNLOADS_FOLDER}")


### PR DESCRIPTION
When compiling for an embedded system, such as OpenWRT,
the hardening settings are global to the whole system.

In such case one needs to disable the specific flags that are currently
forced in the current build of this application, in order to avoid conflicts.

The new switch is ON by default, therefore this path is retro-compatible.

Since this patch, though, one can set the option to OFF in the OpenWRT/Yocto recipe
in order to let the hardening settings common to the whole system to be applied.