### PR TITLE
[0.8.x] adu-shell: remove hardcoded paths, use ADUSHELL_FILE_PATH instead.

### DIFF
--- a/src/adu-shell/CMakeLists.txt
+++ b/src/adu-shell/CMakeLists.txt
@@ -34,7 +34,12 @@ string (
 set (source_files ${agent_c_files})
 
 # Support all microsoft/* update types by default.
-set (source_files ${agent_c_files} ${agent_apt_c_files} ${agent_swupdate_c_files} ${agent_script_c_files})
+set (
+    source_files
+    ${agent_c_files}
+    ${agent_apt_c_files}
+    ${agent_swupdate_c_files}
+    ${agent_script_c_files})
 
 set (adushell_def ADUSHELL_SWUPDATE="yes" ADUSHELL_APT="yes" ADUSHELL_SCRIPT="yes")
 
@@ -48,6 +53,7 @@ set_target_properties (${target_name} PROPERTIES COMPILE_DEFINITIONS _DEFAULT_SO
 
 target_compile_definitions (
     ${target_name}
+    PUBLIC ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}"
     PRIVATE ADUC_VERSION="${ADUC_VERSION}"
             ADUC_PLATFORM_LAYER="${ADUC_PLATFORM_LAYER}"
             ADUC_CONF_FILE_PATH="${ADUC_CONF_FILE_PATH}"

--- a/src/adu-shell/inc/adushell_const.hpp
+++ b/src/adu-shell/inc/adushell_const.hpp
@@ -13,7 +13,7 @@ namespace Shell
 {
 namespace Const
 {
-const char* adu_shell = "/usr/lib/adu/adu-shell";
+const char* adu_shell = ADUSHELL_FILE_PATH;
 
 const char* update_type_opt = "--update-type";
 const char* update_type_microsoft_apt = "microsoft/apt";

--- a/src/content_handlers/CMakeLists.txt
+++ b/src/content_handlers/CMakeLists.txt
@@ -38,6 +38,8 @@ add_subdirectory (swupdate_handler)
 #   add_subdirectory (my_handler)
 #
 
+target_compile_definitions (${PROJECT_NAME} PUBLIC ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}")
+
 if (${ADUC_PLATFORM_LAYER} STREQUAL "simulator")
     target_compile_definitions (${PROJECT_NAME} PUBLIC ADUC_SIMULATOR_MODE=1)
 endif ()

--- a/src/content_handlers/apt_handler/CMakeLists.txt
+++ b/src/content_handlers/apt_handler/CMakeLists.txt
@@ -29,13 +29,12 @@ get_filename_component (
     "/")
 
 target_compile_definitions (
-    ${target_name} PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="${ADUC_INSTALLEDCRITERIA_FILE_PATH}")
+    ${target_name} PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="${ADUC_INSTALLEDCRITERIA_FILE_PATH}"
+                           ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}")
 
 target_link_libraries (
     ${target_name}
-    PUBLIC
-            aduc::content_handlers
-            aduc::workflow_data_utils
+    PUBLIC aduc::content_handlers aduc::workflow_data_utils
     PRIVATE aduc::c_utils
             aduc::extension_manager
             aduc::exception_utils

--- a/src/content_handlers/script_handler/CMakeLists.txt
+++ b/src/content_handlers/script_handler/CMakeLists.txt
@@ -31,7 +31,8 @@ target_link_libraries (
             aduc::system_utils
             aduc::workflow_data_utils
             aduc::workflow_utils
-            -zdefs
-            )
+            -zdefs)
+
+target_compile_definitions (${target_name} PUBLIC ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}")
 
 install (TARGETS ${target_name} LIBRARY DESTINATION ${ADUC_EXTENSIONS_INSTALL_FOLDER})

--- a/src/content_handlers/swupdate_handler/CMakeLists.txt
+++ b/src/content_handlers/swupdate_handler/CMakeLists.txt
@@ -28,10 +28,11 @@ target_link_libraries (
             aduc::system_utils
             aduc::workflow_data_utils
             aduc::workflow_utils
-            -zdefs
-            )
+            -zdefs)
 
-target_compile_definitions (${target_name} PRIVATE ADUC_VERSION_FILE="${ADUC_VERSION_FILE}"
-                                                   ADUC_LOG_FOLDER="${ADUC_LOG_FOLDER}")
+target_compile_definitions (
+    ${target_name}
+    PRIVATE ADUC_VERSION_FILE="${ADUC_VERSION_FILE}" ADUC_LOG_FOLDER="${ADUC_LOG_FOLDER}"
+            ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}")
 
 install (TARGETS ${target_name} LIBRARY DESTINATION ${ADUC_EXTENSIONS_INSTALL_FOLDER})

--- a/src/platform_layers/linux_platform_layer/CMakeLists.txt
+++ b/src/platform_layers/linux_platform_layer/CMakeLists.txt
@@ -63,7 +63,8 @@ target_compile_definitions (
             ADUC_FILE_USER="${ADUC_FILE_USER}"
             ADUC_DEVICEINFO_MODEL="${ADUC_DEVICEINFO_MODEL}"
             ADUC_VERSION_FILE="${ADUC_VERSION_FILE}"
-            ADUC_BUILD_UNIT_TESTS="${ADUC_BUILD_UNIT_TESTS}")
+            ADUC_BUILD_UNIT_TESTS="${ADUC_BUILD_UNIT_TESTS}"
+            ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}")
 
 if (ADUC_BUILD_UNIT_TESTS)
     add_subdirectory (tests)

--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_exports.cpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_exports.cpp
@@ -75,7 +75,7 @@ int ADUC_RebootSystem()
 
     std::string output;
     std::vector<std::string> args{ "--update-type", "common", "--update-action", "reboot" };
-    const int exitStatus = ADUC_LaunchChildProcess("/usr/lib/adu/adu-shell", args, output);
+    const int exitStatus = ADUC_LaunchChildProcess(ADUSHELL_FILE_PATH, args, output);
 
     if (exitStatus != 0)
     {


### PR DESCRIPTION
The macro ADUSHELL_FILE_PATH is already properly setup and provided by the build system.
Although hardcoded paths were still in source files.

Since the user might customise its value, use such the ADUSHELL_FILE_PATH instead of hardcoded
values all along the project.