### PR TITLE
[0.8.x] swupdate: fix execution logic in apply action.

### DIFF
--- a/src/content_handlers/swupdate_handler/src/swupdate_handler.cpp
+++ b/src/content_handlers/swupdate_handler/src/swupdate_handler.cpp
@@ -200,9 +200,9 @@ ADUC_Result SWUpdateHandlerImpl::Install(const tagADUC_WorkflowData* workflowDat
         args.emplace_back(data.str().c_str());
 
         args.emplace_back(adushconst::target_log_folder_opt);
-        
+
         // Note: this implementation of SWUpdate Handler is relying on ADUC_LOG_FOLDER value from build pipeline.
-        // For GA, we should make this configurable in du-config.json. 
+        // For GA, we should make this configurable in du-config.json.
         args.emplace_back(ADUC_LOG_FOLDER);
 
         std::string output;
@@ -250,9 +250,9 @@ ADUC_Result SWUpdateHandlerImpl::Apply(const tagADUC_WorkflowData* workflowData)
                                    adushconst::update_action_apply };
 
     args.emplace_back(adushconst::target_log_folder_opt);
-    
+
     // Note: this implementation of SWUpdate Handler is relying on ADUC_LOG_FOLDER value from build pipeline.
-    // For GA, we should make this configurable in du-config.json. 
+    // For GA, we should make this configurable in du-config.json.
     args.emplace_back(ADUC_LOG_FOLDER);
 
     std::string output;
@@ -270,15 +270,17 @@ ADUC_Result SWUpdateHandlerImpl::Apply(const tagADUC_WorkflowData* workflowData)
     if (workflow_get_operation_cancel_requested(workflowData->WorkflowHandle))
     {
         // Note: this implementation of SWUpdate Handler is relying on ADUC_LOG_FOLDER value from build pipeline.
-        // For GA, we should make this configurable in du-config.json. 
-        CancelApply(ADUC_LOG_FOLDER);
+        // For GA, we should make this configurable in du-config.json.
+        result = CancelApply(ADUC_LOG_FOLDER); // Otherwise returning ADUC_Result_Success ot ADUC_Result_InProgress
+        goto done;
     }
+
+    Log_Info("Apply succeeded");
+    // Always require a reboot after successful apply
+    result = { ADUC_Result_Apply_RequiredImmediateReboot };
 
 done:
     workflow_free_string(workFolder);
-
-    // Always require a reboot after successful apply
-    result = { ADUC_Result_Apply_RequiredImmediateReboot };
 
     return result;
 }


### PR DESCRIPTION
Previously the value ADUC_Result_Apply_RequiredImmediateReboot was *always* set,
even in case of error.

This means that:

1) In case of bad exit code, the flow was:

   if (exitCode != 0)
   {
       ...
       result = { ADUC_Result_Failure, exitCode };
       goto done;

    done:
       result = { ADUC_Result_Apply_RequiredImmediateReboot };
       return result;

The issue here is that the first error result assignement is *overwritten* by the second seuccess_reboot defautl result.

2) In case of canceled request:

    // Cancel requested?
    if (workflow_get_operation_cancel_requested(workflowData->WorkflowHandle))
    {
        CancelApply(ADUC_LOG_FOLDER); // Other options for result could be ADUC_Result_Success or ADUC_Result_InProgress
        goto done;

    done:
       result = { ADUC_Result_Apply_RequiredImmediateReboot };
       goto done;

    The issue here is that:
    a - A reboot is requested (successful result) even if the operation was canceled.
    b - The CancelApply result is never returned to the workflow.
    c - DOUBT: I have assumed that returning the CancelApply result to the workflow is the inital expected behavior in the design,
        but it might actually even be that it should be returned to the workflow ADUC_Result_Success or ADUC_Result_InProgress and the
        result of the Cancel operation be unused. In such case the cancel might be handled by the workflow instead.