### PR TITLE
Merge 'develop' into 'main'

### DIFF
--- a/src/agent/adu_core_interface/src/adu_core_interface.c
+++ b/src/agent/adu_core_interface/src/adu_core_interface.c
@@ -120,11 +120,12 @@ void ADUC_WorkflowData_Uninit(ADUC_WorkflowData* workflowData)
 /**
  * @brief Reports the client json via PnP so it ends up in the reported section of the twin.
  *
+ * @param messageType The message type.
  * @param json_value The json value to be reported.
  * @param workflowData The workflow data.
  * @return _Bool true if call succeeded.
  */
-static _Bool ReportClientJsonProperty(const char* json_value, ADUC_WorkflowData* workflowData)
+static _Bool ReportClientJsonProperty(ADUC_D2C_Message_Type messageType, const char* json_value, ADUC_WorkflowData* workflowData)
 {
     _Bool success = false;
 
@@ -144,7 +145,7 @@ static _Bool ReportClientJsonProperty(const char* json_value, ADUC_WorkflowData*
     }
 
     if (!ADUC_D2C_Message_SendAsync(
-            ADUC_D2C_Message_Type_Device_Update_Result,
+            messageType,
             &g_iotHubClientHandleForADUComponent,
             STRING_c_str(jsonToSend),
             NULL /* responseCallback */,
@@ -226,7 +227,7 @@ _Bool ReportStartupMsg(ADUC_WorkflowData* workflowData)
         goto done;
     }
 
-    ReportClientJsonProperty(jsonString, workflowData);
+    ReportClientJsonProperty(ADUC_D2C_Message_Type_Device_Properties, jsonString, workflowData);
 
     success = true;
 done:
@@ -816,7 +817,7 @@ _Bool AzureDeviceUpdateCoreInterface_ReportStateAndResultAsync(
         goto done;
     }
 
-    if (!ReportClientJsonProperty(jsonString, workflowData))
+    if (!ReportClientJsonProperty(ADUC_D2C_Message_Type_Device_Update_Result, jsonString, workflowData))
     {
         goto done;
     }

--- a/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
+++ b/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
@@ -315,14 +315,21 @@ ADUC_Result SWUpdateHandlerImpl::Apply(const tagADUC_WorkflowData* workflowData)
     // Cancel requested?
     if (workflow_is_cancel_requested(workflowData->WorkflowHandle))
     {
+        Log_Info("Workflow cancel requested. Calling Cancel() now...");
         result = this->Cancel(workflowData);
         goto done;
     }
 
     if (workflow_get_operation_cancel_requested(workflowData->WorkflowHandle))
     {
+        Log_Info("Workflow operation cancel requested. Calling CancelApply() now...");
         CancelApply(ADUC_LOG_FOLDER);
     }
+
+    result = {
+        .ResultCode = ADUC_Result_Success,
+        .ExtendedResultCode = 0
+    };
 
 done:
     workflow_free_string(workFolder);
@@ -512,6 +519,7 @@ ADUC_Result SWUpdateHandlerImpl::Backup(const tagADUC_WorkflowData* workflowData
  */
 ADUC_Result SWUpdateHandlerImpl::Restore(const tagADUC_WorkflowData* workflowData)
 {
+    Log_Info("Restore begin.");
     UNREFERENCED_PARAMETER(workflowData);
     ADUC_Result result = { ADUC_Result_Restore_Success };
     ADUC_Result cancel_result = CancelApply(ADUC_LOG_FOLDER);
@@ -520,5 +528,6 @@ ADUC_Result SWUpdateHandlerImpl::Restore(const tagADUC_WorkflowData* workflowDat
         result = { .ResultCode = ADUC_Result_Failure,
                    .ExtendedResultCode = ADUC_ERC_UPPERLEVEL_WORKFLOW_FAILED_RESTORE_FAILED };
     }
+    Log_Info("Restore end.");
     return result;
 }

--- a/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
+++ b/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
@@ -418,14 +418,24 @@ ADUC_Result SWUpdateHandlerImpl::Apply(const tagADUC_WorkflowData* workflowData)
     if (workflow_get_operation_cancel_requested(workflowData->WorkflowHandle))
     {
         Cancel(workflowData);
+        goto done;
     }
+
+    result = {
+        .ResultCode = ADUC_Result_Success,
+        .ExtendedResultCode = 0
+    };
 
 done:
     workflow_free_string(workFolder);
 
     // Always require a reboot after successful apply
-    result = { ADUC_Result_Apply_RequiredImmediateReboot };
-
+    if (IsAducResultCodeSuccess(result.ResultCode))
+    {
+        workflow_request_immediate_reboot(workflowData->WorkflowHandle);
+        result = { ADUC_Result_Apply_RequiredImmediateReboot };
+    }
+    
     return result;
 }
 

--- a/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
@@ -948,6 +948,7 @@ static ADUC_Result StepsHandler_Install(const tagADUC_WorkflowData* workflowData
             }
             catch (...)
             {
+                Log_Error("The handler throws an exception inside Install().");
                 result = { .ResultCode = ADUC_Result_Failure,
                            .ExtendedResultCode = ADUC_ERC_STEPS_HANDLER_INSTALL_UNKNOWN_EXCEPTION_INSTALL_CHILD_STEP };
                 goto done;
@@ -1002,9 +1003,11 @@ static ADUC_Result StepsHandler_Install(const tagADUC_WorkflowData* workflowData
             try
             {
                 result = contentHandler->Apply(&stepWorkflow);
+                Log_Debug("Step's apply() return r:0x%x rc:0x%x", result.ResultCode, result.ExtendedResultCode);
             }
             catch (...)
             {
+                Log_Error("The handler throws an exception inside Apply().");
                 result = { .ResultCode = ADUC_Result_Failure,
                            .ExtendedResultCode = ADUC_ERC_STEPS_HANDLER_INSTALL_UNKNOWN_EXCEPTION_APPLY_CHILD_STEP };
                 goto done;
@@ -1018,6 +1021,7 @@ static ADUC_Result StepsHandler_Install(const tagADUC_WorkflowData* workflowData
                 // when apply fails, invoke restore action
                 try
                 {
+                    Log_Info("Failed to install or apply. Try to restore now...");
                     // Try to restore from the apply failure, but it shouldn't impact the result code.
                     // To know the restore result on each step, the corresponding Update Handler will need to
                     // implement proper logging and send it up through Diagnostics service.

--- a/src/utils/d2c_messaging/inc/aduc/d2c_messaging.h
+++ b/src/utils/d2c_messaging/inc/aduc/d2c_messaging.h
@@ -27,6 +27,7 @@ typedef enum _tagADUC_D2C_Message_Type
     ADUC_D2C_Message_Type_Device_Information,       /**< deviceInformation interface reported property */
     ADUC_D2C_Message_Type_Diagnostics,              /**< diagnostics interface reported property */
     ADUC_D2C_Message_Type_Diagnostics_ACK,          /**< diagnostics interface ACK */
+    ADUC_D2C_Message_Type_Device_Properties,        /**< deviceUpdate interface reported property */
     ADUC_D2C_Message_Type_Max
 } ADUC_D2C_Message_Type;
 

--- a/src/utils/d2c_messaging/src/d2c_messaging.c
+++ b/src/utils/d2c_messaging/src/d2c_messaging.c
@@ -526,12 +526,12 @@ bool ADUC_D2C_Message_SendAsync(
     {
         if (s_pendingMessageStore[type].completedCallback != NULL)
         {
-            Log_Debug("Replacing existing pending message. (t:%d)", type);
+            Log_Debug("Replacing existing pending message. (t:%d, s:%s)", type, s_pendingMessageStore[type].content);
             OnMessageProcessingCompleted(&s_pendingMessageStore[type], ADUC_D2C_Message_Status_Replaced);
         }
     }
 
-    Log_Debug("Queueing message (t:%d, c:0x%x", type, message);
+    Log_Debug("Queueing message (t:%d, c:0x%x, m:%s)", type, message, message);
     memset(&s_pendingMessageStore[type], 0, sizeof(s_pendingMessageStore[0]));
     s_pendingMessageStore[type].cloudServiceHandle = cloudServiceHandle;
     s_pendingMessageStore[type].originalContent = message;


### PR DESCRIPTION
Fix issue in reboot/restart flow and race condition in D2C messaging util (#242)

* Fix an issue for image-based update scenario where the device doesn't reboot after the new image is installed.
* Add ADUC_D2C_Message_Type_Device_Properties to avoid a race condition.
