### PR TITLE
Revert clang-format.sh and disable from precommit git hook

### DIFF
--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -30,27 +30,11 @@ if [ -z "$GITROOT" ]; then
     $ret 1
 fi
 
-issue_with_file=false
 pushd "$GITROOT" > /dev/null || $ret
 # diff-filter=d will exclude deleted files.
-# --cached for only the staged files
 IFS=$'\n'
-for FILE in $(git diff --diff-filter=d --relative --name-only --cached HEAD -- "*.[CcHh]" "*.[CcHh][Pp][Pp]"); do
-    # Use --dry-run and --Werror to have clang-format return non-zero error return if it
-    # had to reformat a file.
-    # Need to use git cat-file blob so that it gets staged file in case it got formatted in working set, which would
-    # allow it to bypass pre-commit hook even if staged file is not formatted correctly.
-    if ! git cat-file blob :"$FILE" 2>&1 | clang-format --dry-run --Werror --verbose --style=file; then
-        issue_with_file=true
-        clang-format --verbose --style=file -i "$FILE"
-    fi
+for FILE in $(git diff --diff-filter=d --relative --name-only HEAD -- "*.[CcHh]" "*.[CcHh][Pp][Pp]"); do
+    clang-format -verbose -style=file -i "$FILE"
 done
 IFS=' '
 popd > /dev/null || $ret
-
-if [[ $issue_with_file == "true" ]]; then
-    echo 'Error: Some staged C/C++ files had issues reformatted. Fix issues and/or git add the reformatted changes.'
-    $ret 1
-fi
-
-$ret 0

--- a/scripts/githooks/pre-commit.sh
+++ b/scripts/githooks/pre-commit.sh
@@ -30,9 +30,10 @@ if ! "$GITROOT/scripts/sh-format.sh" -v; then
     $ret 1
 fi
 
-if ! "$GITROOT/scripts/clang-format.sh"; then
-    $ret 1
-fi
+# Disable for now due to arg compat across clangformat versions
+# if ! "$GITROOT/scripts/clang-format.sh"; then
+#     $ret 1
+# fi
 
 # Unfortunately, cmake-format cannot take in piped file contents, so
 # not using it for pre-commit hook currently.


### PR DESCRIPTION
Revert clang-format.sh due to issues with dry-run of staged content on some versions and disable in precommit githook for now due to incompatible sets of cmd-line argument across versions.