### PR TITLE
Removed log message for retrieving connection information from AIS 

### DIFF
--- a/src/agent/src/main.c
+++ b/src/agent/src/main.c
@@ -1030,8 +1030,6 @@ bool GetConnectionInfoFromIdentityService(ADUC_ConnectionInfo* info)
     }
     memset(info, 0, sizeof(*info));
 
-    Log_Info("Requesting connection string from the Edge Identity Service");
-
     time_t expirySecsSinceEpoch = time(NULL) + EIS_TOKEN_EXPIRY_TIME_IN_SECONDS;
 
     EISUtilityResult eisProvisionResult =


### PR DESCRIPTION
Removed the logging prompt from the GetConnectionInfoFromEIS() function because it can cause confusion when called by other sections than  main.c. The caller should be the one to inform the user not the function being called.

Related bug: https://microsoft.visualstudio.com/OS/_queries/edit/41718105/?triage=true