### PR TITLE
One line fix on how-to-build-agent-code.md

### DIFF
--- a/docs/agent-reference/how-to-build-agent-code.md
+++ b/docs/agent-reference/how-to-build-agent-code.md
@@ -49,7 +49,7 @@ To install all dependencies run:
 To install only the dependencies necessary for the agent:
 
 ```shell
-./scripts/install-deps.sh --install-aduc-deps --install-packages
+./scripts/install-deps.sh --install-aduc-deps --install-packages --install-do
 ```
 
 `install-deps.sh` also provides several options for installing individual


### PR DESCRIPTION
Currently, the agent cannot build without having DO as a dependency. To avoid failures, I think we should make the modification on the documentation