### PR TITLE
Bug 42608779: ADUC_Logging_Init assumes parent paths exist

### DIFF
--- a/src/logging/zlog/CMakeLists.txt
+++ b/src/logging/zlog/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories (${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/inc
 
 find_package (Threads REQUIRED)
 
-target_link_libraries (${PROJECT_NAME} PRIVATE Threads::Threads)
+target_link_libraries (${PROJECT_NAME} PRIVATE Threads::Threads aduc::system_utils)
 
 # _DEAFULT_SOURCE - Needed so DT_REG is defined in dirent.h
 #                   see man page for readdir

--- a/src/logging/zlog/src/init.c
+++ b/src/logging/zlog/src/init.c
@@ -6,6 +6,7 @@
  * Licensed under the MIT License.
  */
 #include "aduc/logging.h"
+#include "aduc/system_utils.h"
 #include <stdio.h> // printf
 #include <sys/stat.h> // mkdir
 
@@ -67,7 +68,11 @@ void ADUC_Logging_Init(ADUC_LOG_SEVERITY logLevel, const char* filePrefix)
 
     // zlog_init doesn't create the log path, so attempt to create it here.
     // If it can't be created, zlogging will send output to console.
-    (void)mkdir(ADUC_LOG_FOLDER, S_IRWXU);
+    int dir_result = ADUC_SystemUtils_MkDirRecursive(ADUC_LOG_FOLDER, -1 /*userId*/, -1 /*groupId*/, S_IRWXU);
+    if (dir_result != 0)
+    {
+        printf("WARNING: Cannot create a folder for logging file. ('%s')", ADUC_LOG_FOLDER);
+    }
 
     if (zlog_init(
             ADUC_LOG_FOLDER,


### PR DESCRIPTION
Use the recursive mkdir helper