### PR TITLE
fix zlog file handle leak

### DIFF
--- a/src/agent/src/main.c
+++ b/src/agent/src/main.c
@@ -1185,7 +1185,6 @@ int main(int argc, char** argv)
     // high-privileged tasks, such as, registering agent's extension(s).
     if (!RunAsDesiredUser())
     {
-        ret = 1;
         goto done;
     }
 


### PR DESCRIPTION
Ran valgrind with file descriptor traching:
sudo -u adu $VALGRIND_BIN --track-fds=all /usr/bin/AducIotAgent -l0 -e

Before the fix it leaks the agent zlog init'ed from agent/main.c
After the fix, valgrind shows that it does not leak it.