### PR TITLE
Update cached workfolder when processing replacement workflow

### DIFF
--- a/src/adu_workflow/src/agent_workflow.c
+++ b/src/adu_workflow/src/agent_workflow.c
@@ -492,6 +492,8 @@ void ADUC_Workflow_HandlePropertyUpdate(
                     goto done;
                 }
 
+                Log_Debug("Retry %s is applicable", newRetryToken);
+
                 // Sets both cancellation type to Retry and updates the current retry token
                 workflow_update_retry_deployment(currentWorkflowData->WorkflowHandle, newRetryToken);
 
@@ -521,6 +523,7 @@ void ADUC_Workflow_HandlePropertyUpdate(
                     // workflow handle of the new deployment into the current workflow data, so that we can handle the update action.
                     bool deferredReplacement =
                         workflow_update_replacement_deployment(currentWorkflowData->WorkflowHandle, nextWorkflow);
+
                     if (deferredReplacement)
                     {
                         Log_Info(
@@ -535,6 +538,8 @@ void ADUC_Workflow_HandlePropertyUpdate(
                         ADUC_Workflow_HandleUpdateAction(currentWorkflowData);
                         goto done;
                     }
+
+                    Log_Debug("deferral not needed. Processing '%s' now", workflow_peek_id(nextWorkflow));
 
                     workflow_transfer_data(
                         currentWorkflowData->WorkflowHandle /* wfTarget */, nextWorkflow /* wfSource */);
@@ -959,6 +964,7 @@ void ADUC_Workflow_WorkCompletionCallback(const void* workCompletionToken, ADUC_
                     // Reset workflow state to process deployment and transfer
                     // the deferred workflow to current.
                     workflow_update_for_replacement(workflowData->WorkflowHandle);
+
                 }
                 else
                 {


### PR DESCRIPTION
workflow_transfer_data was not updating the workfolder so processing of replacement workflow (deferred or not) was using the previous workflow's workfolder that was cached in the property cache.  Fix is to set the workfolder with new workflow data upon transfer (which happens right before processing the replacement workflow).