### PR TITLE
Moved all unit tests running CATCH2_CONFIG_RUNNER to output to cerr instead of cout so the catch2 test runner isn't confused

### DIFF
--- a/src/utils/config_utils/tests/main.cpp
+++ b/src/utils/config_utils/tests/main.cpp
@@ -20,18 +20,18 @@ int main(int argc, char* argv[])
 
     // Global setup
     result = umock_c_init([](UMOCK_C_ERROR_CODE error_code) -> void {
-        std::cout << "*** umock_c failed, err=" << error_code << std::endl;
+        std::cerr << "*** umock_c failed, err=" << error_code << std::endl;
     });
     if (result != 0)
     {
-        std::cout << "umock_c_init_failed, err=" << result << std::endl;
+        std::cerr << "umock_c_init_failed, err=" << result << std::endl;
         return result;
     }
 
     result = Catch::Session().run(argc, argv);
     if (result != 0)
     {
-        std::cout << "Catch session failed, err=" << result << std::endl;
+        std::cerr << "Catch session failed, err=" << result << std::endl;
     }
 
     // Global cleanup.

--- a/src/utils/eis_utils/tests/main.cpp
+++ b/src/utils/eis_utils/tests/main.cpp
@@ -20,18 +20,18 @@ int main(int argc, char* argv[])
 
     // Global setup
     result = umock_c_init([](UMOCK_C_ERROR_CODE error_code) -> void {
-        std::cout << "*** umock_c failed, err=" << error_code << std::endl;
+        std::cerr << "*** umock_c failed, err=" << error_code << std::endl;
     });
     if (result != 0)
     {
-        std::cout << "umock_c_init_failed, err=" << result << std::endl;
+        std::cerr << "umock_c_init_failed, err=" << result << std::endl;
         return result;
     }
 
     result = Catch::Session().run(argc, argv);
     if (result != 0)
     {
-        std::cout << "Catch session failed, err=" << result << std::endl;
+        std::cerr << "Catch session failed, err=" << result << std::endl;
     }
 
     // Global cleanup.


### PR DESCRIPTION
- Moved cout to cerr so the catch2 test runner doesn't attempt to create more filters/bugs from the std::cout output


Bug for PR: https://microsoft.visualstudio.com/OS/_queries/edit/42919115/?triage=true