### PR TITLE
GetConnectionInfoFromConnectionString crashes on failure.

### DIFF
--- a/src/agent/src/main.c
+++ b/src/agent/src/main.c
@@ -970,6 +970,10 @@ ADUC_ConnType GetConnTypeFromConnectionString(const char* connectionString)
 bool GetConnectionInfoFromConnectionString(ADUC_ConnectionInfo* info, const char* connectionString)
 {
     bool succeeded = false;
+
+    ADUC_ConfigInfo config;
+    memset(&config, 0, sizeof(config));
+
     if (info == NULL)
     {
         goto done;
@@ -999,8 +1003,6 @@ bool GetConnectionInfoFromConnectionString(ADUC_ConnectionInfo* info, const char
     info->authType = ADUC_AuthType_SASToken;
 
     // Optional: The certificate string is needed for Edge Gateway connection.
-    ADUC_ConfigInfo config;
-    memset(&config, 0, sizeof(config));
     if (ADUC_ConfigInfo_Init(&config, ADUC_CONF_FILE_PATH) && config.edgegatewayCertPath != NULL)
     {
         if (!LoadBufferWithFileContents(config.edgegatewayCertPath, certificateString, ARRAY_SIZE(certificateString)))


### PR DESCRIPTION
If any of these goto done is called, ConfigInfo_Unit will call Uninit on an uninitialized ConfigInfo!  

```C
bool GetConnectionInfoFromConnectionString(ADUC_ConnectionInfo* info, const char* connectionString)
{
    bool succeeded = false;
    if (info == NULL)
    {
        goto done;
    }
    if (connectionString == NULL)
    {
        goto done;
    }

    memset(info, 0, sizeof(*info));

    char certificateString[8192];

    if (mallocAndStrcpy_s(&info->connectionString, connectionString) != 0)
    {
        goto done;
    }

    info->connType = GetConnTypeFromConnectionString(info->connectionString);

    if (info->connType == ADUC_ConnType_NotSet)
    {
        Log_Error("Connection string is invalid");
        goto done;
    }

    info->authType = ADUC_AuthType_SASToken;

    // Optional: The certificate string is needed for Edge Gateway connection.
    ADUC_ConfigInfo config;
    memset(&config, 0, sizeof(config));
```