### PR TITLE
Added input params checks to ConnectionStringUtils_IsNestedEdge to prevent test failures

### DIFF
--- a/src/utils/c_utils/src/connection_string_utils.c
+++ b/src/utils/c_utils/src/connection_string_utils.c
@@ -48,6 +48,11 @@ bool ConnectionStringUtils_DoesKeyExist(const char* connectionString, const char
 {
     bool keyExists = false;
 
+    if (connectionString == NULL || key == NULL)
+    {
+        return false;
+    }
+
     MAP_HANDLE map = connectionstringparser_parse_from_char(connectionString);
     if (map == NULL)
     {

--- a/src/utils/c_utils/src/connection_string_utils.c
+++ b/src/utils/c_utils/src/connection_string_utils.c
@@ -48,7 +48,7 @@ bool ConnectionStringUtils_DoesKeyExist(const char* connectionString, const char
 {
     bool keyExists = false;
 
-    if (connectionString == NULL || key == NULL)
+    if ( IsNullOrEmpty(connectionString)|| IsNullOrEmpty(key))
     {
         return false;
     }


### PR DESCRIPTION
- Added an input param check for ConnectionStringUtils_IsNestedEdge to prevent unit test error messages
- Bug for PR: https://microsoft.visualstudio.com/OS/_queries/edit/42934385/?triage=true