### PR TITLE
fix readdir EOVERFLOW for qemu arm32 on 64bit host

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,11 @@ if (ADUC_WARNINGS_AS_ERRORS)
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
 endif ()
 
+# Avoids readdir returning errno 75 EOVERFLOW when running
+# 32-bit ARM docker/qemu on top of 64-bit host
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FILE_OFFSET_BITS=64")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_FILE_OFFSET_BITS=64")
+
 set (COMPILER_HARDENING_FLAGS
      "-fPIE -D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wformat -Werror=format-security")
 set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -z relro -z now")


### PR DESCRIPTION
If inode does not fit into 32-bit offset, then getdirents in glic will return errno 75 EOVERFLOW
It only repros on 32-bit arm running in qemu/docker on top of 64-bit host os.
Compiling with -D_FILE_OFFSET_BITS=64 seems to fix the issue.