### PR TITLE
Fix memleak ADUC_ParseUpdateType

### DIFF
--- a/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
+++ b/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
@@ -327,10 +327,7 @@ ADUC_Result SWUpdateHandlerImpl::Apply(const tagADUC_WorkflowData* workflowData)
         CancelApply(ADUC_LOG_FOLDER);
     }
 
-    result = {
-        .ResultCode = ADUC_Result_Success,
-        .ExtendedResultCode = 0
-    };
+    result = { .ResultCode = ADUC_Result_Success, .ExtendedResultCode = 0 };
 
 done:
     workflow_free_string(workFolder);

--- a/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
+++ b/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
@@ -183,6 +183,7 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
 done:
     workflow_free_string(workFolder);
     workflow_free_file_entity(entity);
+    free(updateName);
 
     return result;
 }

--- a/src/utils/c_utils/tests/c_utils_ut.cpp
+++ b/src/utils/c_utils/tests/c_utils_ut.cpp
@@ -223,6 +223,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(!ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 
     SECTION("Missing Update Name")
@@ -231,6 +232,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(!ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 
     SECTION("Missing Version Number")
@@ -239,6 +241,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(!ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 
     SECTION("Missing Delimiter")
@@ -247,6 +250,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(!ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 
     SECTION("Negative Number")
@@ -255,6 +259,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(!ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 
     SECTION("Ransome Negative Number")
@@ -263,6 +268,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(!ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 
     SECTION("Zero")
@@ -273,6 +279,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         CHECK(ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
         CHECK_THAT(updateTypeName, Equals("microsoft/apt"));
         CHECK(updateTypeVersion == 0);
+        free(updateTypeName);
     }
 
     SECTION("Positive Number")
@@ -283,6 +290,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         CHECK(ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
         CHECK_THAT(updateTypeName, Equals("microsoft/apt"));
         CHECK(updateTypeVersion == 1);
+        free(updateTypeName);
     }
 
     SECTION("Positive Large Number")
@@ -293,6 +301,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         CHECK(ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
         CHECK_THAT(updateTypeName, Equals("microsoft/apt"));
         CHECK(updateTypeVersion == 4294967294);
+        free(updateTypeName);
     }
 
     SECTION("Positive UINT MAX")
@@ -301,6 +310,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 
     SECTION("Positive Larger Than UINT MAX")
@@ -309,6 +319,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(!ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 
     SECTION("Positive ULONG MAX")
@@ -317,6 +328,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(!ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 
     SECTION("Version contains space")
@@ -325,6 +337,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(!ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 
     SECTION("Decimal version")
@@ -333,6 +346,7 @@ TEST_CASE("ADUC_ParseUpdateType and atoui")
         char* updateTypeName = nullptr;
         unsigned int updateTypeVersion;
         CHECK(!ADUC_ParseUpdateType(updateType, &updateTypeName, &updateTypeVersion));
+        free(updateTypeName);
     }
 }
 


### PR DESCRIPTION
## Change Summary

- Free malloc'ed updateName out param from ADUC_ParseUpdateType in swupdate_handler.cpp
- Do the same in c_utils unit tests that call ADUC_ParseUpdateType

## Valgrind cmdline to verify:
```sh
/opt/valgrind.3.19.0/bin/valgrind --leak-check=full ./out/bin/c_utils_unit_tests
```

## Valgrind after:
```
==833634==
==833634== HEAP SUMMARY:
==833634==     in use at exit: 0 bytes in 0 blocks
==833634==   total heap usage: 4,153 allocs, 4,153 frees, 508,776 bytes allocated
==833634==
==833634== All heap blocks were freed -- no leaks are possible
==833634==
==833634== For lists of detected and suppressed errors, rerun with: -s
==833634== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

## Valgrind before
```
==831838==
==831838== HEAP SUMMARY:
==831838==     in use at exit: 56 bytes in 4 blocks
==831838==   total heap usage: 4,153 allocs, 4,149 frees, 508,776 bytes allocated
==831838==
==831838== 14 bytes in 1 blocks are definitely lost in loss record 1 of 4
==831838==    at 0x483C855: malloc (vg_replace_malloc.c:381)
==831838==    by 0x1F8E54: ADUC_ParseUpdateType (string_c_utils.c:335)
==831838==    by 0x1E833E: ____C_A_T_C_H____T_E_S_T____18() (c_utils_ut.cpp:273)
==831838==    by 0x12F569: Catch::TestInvokerAsFunction::invoke() const (catch.hpp:14036)
==831838==    by 0x12EB60: Catch::TestCase::invoke() const (catch.hpp:13929)
==831838==    by 0x128FA5: Catch::RunContext::invokeActiveTestCase() (catch.hpp:12791)
==831838==    by 0x128CD8: Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (catch.hpp:12764)
==831838==    by 0x1276FE: Catch::RunContext::runTest(Catch::TestCase const&) (catch.hpp:12525)
==831838==    by 0x12A91D: Catch::(anonymous namespace)::TestGroup::execute() (catch.hpp:13119)
==831838==    by 0x12BD30: Catch::Session::runInternal() (catch.hpp:13325)
==831838==    by 0x12BA26: Catch::Session::run() (catch.hpp:13281)
==831838==    by 0x169BD6: int Catch::Session::run<char>(int, char const* const*) (catch.hpp:13003)
==831838==
==831838== 14 bytes in 1 blocks are definitely lost in loss record 2 of 4
==831838==    at 0x483C855: malloc (vg_replace_malloc.c:381)
==831838==    by 0x1F8E54: ADUC_ParseUpdateType (string_c_utils.c:335)
==831838==    by 0x1E87C5: ____C_A_T_C_H____T_E_S_T____18() (c_utils_ut.cpp:283)
==831838==    by 0x12F569: Catch::TestInvokerAsFunction::invoke() const (catch.hpp:14036)
==831838==    by 0x12EB60: Catch::TestCase::invoke() const (catch.hpp:13929)
==831838==    by 0x128FA5: Catch::RunContext::invokeActiveTestCase() (catch.hpp:12791)
==831838==    by 0x128CD8: Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (catch.hpp:12764)
==831838==    by 0x1276FE: Catch::RunContext::runTest(Catch::TestCase const&) (catch.hpp:12525)
==831838==    by 0x12A91D: Catch::(anonymous namespace)::TestGroup::execute() (catch.hpp:13119)
==831838==    by 0x12BD30: Catch::Session::runInternal() (catch.hpp:13325)
==831838==    by 0x12BA26: Catch::Session::run() (catch.hpp:13281)
==831838==    by 0x169BD6: int Catch::Session::run<char>(int, char const* const*) (catch.hpp:13003)
==831838==
==831838== 14 bytes in 1 blocks are definitely lost in loss record 3 of 4
==831838==    at 0x483C855: malloc (vg_replace_malloc.c:381)
==831838==    by 0x1F8E54: ADUC_ParseUpdateType (string_c_utils.c:335)
==831838==    by 0x1E8C4C: ____C_A_T_C_H____T_E_S_T____18() (c_utils_ut.cpp:293)
==831838==    by 0x12F569: Catch::TestInvokerAsFunction::invoke() const (catch.hpp:14036)
==831838==    by 0x12EB60: Catch::TestCase::invoke() const (catch.hpp:13929)
==831838==    by 0x128FA5: Catch::RunContext::invokeActiveTestCase() (catch.hpp:12791)
==831838==    by 0x128CD8: Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (catch.hpp:12764)
==831838==    by 0x1276FE: Catch::RunContext::runTest(Catch::TestCase const&) (catch.hpp:12525)
==831838==    by 0x12A91D: Catch::(anonymous namespace)::TestGroup::execute() (catch.hpp:13119)
==831838==    by 0x12BD30: Catch::Session::runInternal() (catch.hpp:13325)
==831838==    by 0x12BA26: Catch::Session::run() (catch.hpp:13281)
==831838==    by 0x169BD6: int Catch::Session::run<char>(int, char const* const*) (catch.hpp:13003)
==831838==
==831838== 14 bytes in 1 blocks are definitely lost in loss record 4 of 4
==831838==    at 0x483C855: malloc (vg_replace_malloc.c:381)
==831838==    by 0x1F8E54: ADUC_ParseUpdateType (string_c_utils.c:335)
==831838==    by 0x1E90D5: ____C_A_T_C_H____T_E_S_T____18() (c_utils_ut.cpp:303)
==831838==    by 0x12F569: Catch::TestInvokerAsFunction::invoke() const (catch.hpp:14036)
==831838==    by 0x12EB60: Catch::TestCase::invoke() const (catch.hpp:13929)
==831838==    by 0x128FA5: Catch::RunContext::invokeActiveTestCase() (catch.hpp:12791)
==831838==    by 0x128CD8: Catch::RunContext::runCurrentTest(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (catch.hpp:12764)
==831838==    by 0x1276FE: Catch::RunContext::runTest(Catch::TestCase const&) (catch.hpp:12525)
==831838==    by 0x12A91D: Catch::(anonymous namespace)::TestGroup::execute() (catch.hpp:13119)
==831838==    by 0x12BD30: Catch::Session::runInternal() (catch.hpp:13325)
==831838==    by 0x12BA26: Catch::Session::run() (catch.hpp:13281)
==831838==    by 0x169BD6: int Catch::Session::run<char>(int, char const* const*) (catch.hpp:13003)
==831838==
==831838== LEAK SUMMARY:
==831838==    definitely lost: 56 bytes in 4 blocks
==831838==    indirectly lost: 0 bytes in 0 blocks
==831838==      possibly lost: 0 bytes in 0 blocks
==831838==    still reachable: 0 bytes in 0 blocks
==831838==         suppressed: 0 bytes in 0 blocks
==831838==
==831838== For lists of detected and suppressed errors, rerun with: -s
==831838== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)

```
