### PR TITLE
No alloc FileEntity from workflow_get_update_file

### DIFF
--- a/src/adu_workflow/src/agent_workflow.c
+++ b/src/adu_workflow/src/agent_workflow.c
@@ -964,7 +964,6 @@ void ADUC_Workflow_WorkCompletionCallback(const void* workCompletionToken, ADUC_
                     // Reset workflow state to process deployment and transfer
                     // the deferred workflow to current.
                     workflow_update_for_replacement(workflowData->WorkflowHandle);
-
                 }
                 else
                 {
@@ -1169,14 +1168,21 @@ static void CallDownloadHandlerOnUpdateWorkflowCompleted(const ADUC_WorkflowHand
     for (size_t i = 0; i < payloadCount; ++i)
     {
         ADUC_Result result = {};
-        ADUC_FileEntity* fileEntity = NULL;
-        if (!workflow_get_update_file(workflowHandle, i, &fileEntity) || IsNullOrEmpty(fileEntity->DownloadHandlerId))
+        ADUC_FileEntity fileEntity;
+        memset(&fileEntity, 0, sizeof(fileEntity));
+        if (!workflow_get_update_file(workflowHandle, i, &fileEntity))
         {
             continue;
         }
 
+        if (IsNullOrEmpty(fileEntity.DownloadHandlerId))
+        {
+            ADUC_FileEntity_Uninit(&fileEntity);
+            continue;
+        }
+
         // NOTE: do not free the handle as it is owned by the DownloadHandlerFactory.
-        DownloadHandlerHandle* handle = ADUC_DownloadHandlerFactory_LoadDownloadHandler(fileEntity->DownloadHandlerId);
+        DownloadHandlerHandle* handle = ADUC_DownloadHandlerFactory_LoadDownloadHandler(fileEntity.DownloadHandlerId);
         if (handle == NULL)
         {
             Log_Error("Failed to load download handler.");
@@ -1194,6 +1200,8 @@ static void CallDownloadHandlerOnUpdateWorkflowCompleted(const ADUC_WorkflowHand
                 workflow_set_success_erc(workflowHandle, result.ExtendedResultCode);
             }
         }
+
+        ADUC_FileEntity_Uninit(&fileEntity);
     }
 }
 

--- a/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/utils/CMakeLists.txt
+++ b/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/utils/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries (
     PRIVATE aduc::c_utils
             aduc::extension_manager
             aduc::logging
+            aduc::parser_utils
             aduc::shared_lib
             aduc::source_update_cache
             aduc::workflow_utils)

--- a/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/utils/tests/CMakeLists.txt
+++ b/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/utils/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries (
     ${PROJECT_NAME}
     PRIVATE aduc::adu_types
             aduc::microsoft_delta_download_handler_utils
+            aduc::parser_utils
             aduc::workflow_utils
             Catch2::Catch2)
 

--- a/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/utils/tests/microsoft_delta_download_handler_utils_ut.cpp
+++ b/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/utils/tests/microsoft_delta_download_handler_utils_ut.cpp
@@ -11,6 +11,7 @@
 using Catch::Matchers::Equals;
 
 #include "aduc/microsoft_delta_download_handler_utils.h"
+#include <aduc/parser_utils.h>
 #include <aduc/result.h> // ADUC_Result_*
 #include <aduc/types/adu_core.h> // ADUC_Result_*
 #include <aduc/types/update_content.h> // ADUC_RelatedFile, ADUC_FileEntity
@@ -22,63 +23,61 @@ using Catch::Matchers::Equals;
 #define TEST_PAYLOAD_FILE_ID "ac47d3bab772454283ae95f0bbb1a1de"
 #define TEST_DELTA_FILE_ID "312d0351155037c4900d76473d371c35"
 
-const std::string updateManifest{
-    R"( {                                                                         )"
-    R"(     "compatibility": [                                                    )"
-    R"(         {                                                                 )"
-    R"(             "deviceManufacturer": "contoso",                              )"
-    R"(             "deviceModel": "toaster"                                      )"
-    R"(         }                                                                 )"
-    R"(     ],                                                                    )"
-    R"(     "createdDateTime": "2022-03-12T12:22:37.2627901Z",                    )"
-    R"(     "files": {                                                            )"
-    R"(         "PAYLOAD_FILE_ID": {                                              )"
-    R"(             "fileName": "target_update.swu",                              )"
-    R"(             "hashes": {                                                   )"
-    R"(                 "sha256": "PAYLOAD_HASH"                                  )"
-    R"(             },                                                            )"
-    R"(             "sizeInBytes": 98765,                                         )"
-    R"(             "properties": {                                               )"
-    R"(             },                                                            )"
-    R"(             "downloadHandler": {                                          )"
-    R"(                 "id": "microsoft/delta:1"                                 )"
-    R"(             },                                                            )"
-    R"(             "relatedFiles": {                                             )"
-    R"(                 "DELTA_FILE_ID": {                                        )"
-    R"(                     "fileName": "DELTA_UPDATE_FILE_NAME",                 )"
-    R"(                     "sizeInBytes": 1234,                                  )"
-    R"(                     "hashes": {                                           )"
-    R"(                         "sha256": "DELTA_UPDATE_HASH"                     )"
-    R"(                     },                                                    )"
-    R"(                     "properties": {                                       )"
-    R"(                         "microsoft.sourceFileHash": "SOURCE_UPDATE_HASH", )"
-    R"(                         "microsoft.sourceFileHashAlgorithm": "sha256"     )"
-    R"(                     }                                                     )"
-    R"(                 }                                                         )"
-    R"(             }                                                             )"
-    R"(         }                                                                 )"
-    R"(     },                                                                    )"
-    R"(     "instructions": {                                                     )"
-    R"(         "steps": [                                                        )"
-    R"(             {                                                             )"
-    R"(                 "files": [                                                )"
-    R"(                     "f222b9ffefaaac577"                                   )"
-    R"(                 ],                                                        )"
-    R"(                 "handler": "microsoft/swupdate:1",                        )"
-    R"(                 "handlerProperties": {                                    )"
-    R"(                     "installedCriteria": "toaster_firmware-0.1"           )"
-    R"(                 }                                                         )"
-    R"(             }                                                             )"
-    R"(         ]                                                                 )"
-    R"(     },                                                                    )"
-    R"(     "manifestVersion": "5",                                               )"
-    R"(     "updateId": {                                                         )"
-    R"(         "name": "toaster_firmware",                                       )"
-    R"(         "provider": "contoso",                                            )"
-    R"(         "version": "0.1"                                                  )"
-    R"(     }                                                                     )"
-    R"( }                                                                         )"
-};
+const std::string updateManifest{ R"( {                                                                         )"
+                                  R"(     "compatibility": [                                                    )"
+                                  R"(         {                                                                 )"
+                                  R"(             "deviceManufacturer": "contoso",                              )"
+                                  R"(             "deviceModel": "toaster"                                      )"
+                                  R"(         }                                                                 )"
+                                  R"(     ],                                                                    )"
+                                  R"(     "createdDateTime": "2022-03-12T12:22:37.2627901Z",                    )"
+                                  R"(     "files": {                                                            )"
+                                  R"(         "PAYLOAD_FILE_ID": {                                              )"
+                                  R"(             "fileName": "target_update.swu",                              )"
+                                  R"(             "hashes": {                                                   )"
+                                  R"(                 "sha256": "PAYLOAD_HASH"                                  )"
+                                  R"(             },                                                            )"
+                                  R"(             "sizeInBytes": 98765,                                         )"
+                                  R"(             "properties": {                                               )"
+                                  R"(             },                                                            )"
+                                  R"(             "downloadHandler": {                                          )"
+                                  R"(                 "id": "microsoft/delta:1"                                 )"
+                                  R"(             },                                                            )"
+                                  R"(             "relatedFiles": {                                             )"
+                                  R"(                 "DELTA_FILE_ID": {                                        )"
+                                  R"(                     "fileName": "DELTA_UPDATE_FILE_NAME",                 )"
+                                  R"(                     "sizeInBytes": 1234,                                  )"
+                                  R"(                     "hashes": {                                           )"
+                                  R"(                         "sha256": "DELTA_UPDATE_HASH"                     )"
+                                  R"(                     },                                                    )"
+                                  R"(                     "properties": {                                       )"
+                                  R"(                         "microsoft.sourceFileHash": "SOURCE_UPDATE_HASH", )"
+                                  R"(                         "microsoft.sourceFileHashAlgorithm": "sha256"     )"
+                                  R"(                     }                                                     )"
+                                  R"(                 }                                                         )"
+                                  R"(             }                                                             )"
+                                  R"(         }                                                                 )"
+                                  R"(     },                                                                    )"
+                                  R"(     "instructions": {                                                     )"
+                                  R"(         "steps": [                                                        )"
+                                  R"(             {                                                             )"
+                                  R"(                 "files": [                                                )"
+                                  R"(                     "f222b9ffefaaac577"                                   )"
+                                  R"(                 ],                                                        )"
+                                  R"(                 "handler": "microsoft/swupdate:1",                        )"
+                                  R"(                 "handlerProperties": {                                    )"
+                                  R"(                     "installedCriteria": "toaster_firmware-0.1"           )"
+                                  R"(                 }                                                         )"
+                                  R"(             }                                                             )"
+                                  R"(         ]                                                                 )"
+                                  R"(     },                                                                    )"
+                                  R"(     "manifestVersion": "5",                                               )"
+                                  R"(     "updateId": {                                                         )"
+                                  R"(         "name": "toaster_firmware",                                       )"
+                                  R"(         "provider": "contoso",                                            )"
+                                  R"(         "version": "0.1"                                                  )"
+                                  R"(     }                                                                     )"
+                                  R"( }                                                                         )" };
 
 const std::string desiredTemplate{
     R"( {                                                                                 )"
@@ -136,16 +135,17 @@ TEST_CASE("MicrosoftDeltaDownloadHandlerUtils_ProcessRelatedFile Cache Miss")
     result = workflow_init(desired.c_str(), false, &handle);
     REQUIRE(IsAducResultCodeSuccess(result.ResultCode));
 
-    ADUC_FileEntity* fileEntity = nullptr;
+    ADUC_FileEntity fileEntity;
+    memset(&fileEntity, 0, sizeof(fileEntity));
     REQUIRE(workflow_get_update_file(handle, 0, &fileEntity));
 
     //
     // Act
     //
     result = MicrosoftDeltaDownloadHandlerUtils_ProcessRelatedFile(
-        handle, &fileEntity->RelatedFiles[0], "/foo/", "/bar/", MockProcessDeltaUpdateFn, MockDownloadDeltaUpdateFn);
+        handle, &fileEntity.RelatedFiles[0], "/foo/", "/bar/", MockProcessDeltaUpdateFn, MockDownloadDeltaUpdateFn);
 
     CHECK(result.ResultCode == ADUC_Result_Success_Cache_Miss);
 
-    workflow_free_file_entity(fileEntity);
+    ADUC_FileEntity_Uninit(&fileEntity);
 }

--- a/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/source_update_cache/CMakeLists.txt
+++ b/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/source_update_cache/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries (
     ${target_name}
     PUBLIC aduc::adu_types aduc::c_utils
     PRIVATE aduc::file_utils
+            aduc::parser_utils
             aduc::path_utils
             aduc::permission_utils
             aduc::system_utils

--- a/src/extensions/step_handlers/apt_handler/CMakeLists.txt
+++ b/src/extensions/step_handlers/apt_handler/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries (
             aduc::contract_utils
             aduc::extension_manager
             aduc::installed_criteria_utils
+            aduc::parser_utils
             aduc::process_utils
             aduc::workflow_data_utils
             aduc::workflow_utils

--- a/src/extensions/step_handlers/apt_handler/tests/CMakeLists.txt
+++ b/src/extensions/step_handlers/apt_handler/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries (
             aduc::exception_utils
             aduc::extension_manager
             aduc::installed_criteria_utils
+            aduc::parser_utils
             aduc::process_utils
             aduc::string_utils
             aduc::system_utils

--- a/src/extensions/step_handlers/script_handler/CMakeLists.txt
+++ b/src/extensions/step_handlers/script_handler/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries (
             aduc::extension_utils
             aduc::extension_manager
             aduc::logging
+            aduc::parser_utils
             aduc::process_utils
             aduc::string_utils
             aduc::system_utils

--- a/src/extensions/step_handlers/script_handler/src/script_handler.cpp
+++ b/src/extensions/step_handlers/script_handler/src/script_handler.cpp
@@ -8,6 +8,7 @@
 #include "aduc/script_handler.hpp"
 #include "aduc/extension_manager.hpp"
 #include "aduc/logging.h"
+#include "aduc/parser_utils.h" // ADUC_FileEntity_Uninit
 #include "aduc/process_utils.hpp" // ADUC_LaunchChildProcess
 #include "aduc/string_c_utils.h" // IsNullOrEmpty
 #include "aduc/string_utils.hpp" // ADUC::StringUtils::Split
@@ -105,7 +106,8 @@ static ADUC_Result Script_Handler_DownloadPrimaryScriptFile(ADUC_WorkflowHandle 
     ADUC_Result result = { ADUC_Result_Failure };
     const char* workflowId = nullptr;
     char* workFolder = nullptr;
-    ADUC_FileEntity* entity = nullptr;
+    ADUC_FileEntity entity;
+    memset(&entity, 0, sizeof(entity));
     int fileCount = workflow_get_update_files_count(handle);
     int createResult = 0;
 
@@ -148,17 +150,15 @@ static ADUC_Result Script_Handler_DownloadPrimaryScriptFile(ADUC_WorkflowHandle 
             .retryTimeout = DO_RETRY_TIMEOUT_DEFAULT,
         };
 
-        result = ExtensionManager::Download(entity, handle, &downloadOptions, nullptr);
+        result = ExtensionManager::Download(&entity, handle, &downloadOptions, nullptr);
     }
     catch (...)
     {
         result.ExtendedResultCode = ADUC_ERC_SCRIPT_HANDLER_DOWNLOAD_PRIMARY_FILE_FAILURE_UNKNOWNEXCEPTION;
     }
 
-    workflow_free_file_entity(entity);
-    entity = nullptr;
-
 done:
+    ADUC_FileEntity_Uninit(&entity);
     workflow_free_string(workFolder);
     return result;
 }
@@ -187,7 +187,8 @@ ADUC_Result ScriptHandlerImpl::Download(const tagADUC_WorkflowData* workflowData
     char* installedCriteria = nullptr;
     const char* workflowId = workflow_peek_id(workflowHandle);
     char* workFolder = workflow_get_workfolder(workflowData->WorkflowHandle);
-    ADUC_FileEntity* entity = nullptr;
+    ADUC_FileEntity fileEntity;
+    memset(&fileEntity, 0, sizeof(fileEntity));
     int fileCount = workflow_get_update_files_count(workflowHandle);
     ADUC_Result result = Script_Handler_DownloadPrimaryScriptFile(workflowHandle);
 
@@ -212,7 +213,7 @@ ADUC_Result ScriptHandlerImpl::Download(const tagADUC_WorkflowData* workflowData
     {
         Log_Info("Downloading file #%d", i);
 
-        if (!workflow_get_update_file(workflowHandle, i, &entity))
+        if (!workflow_get_update_file(workflowHandle, i, &fileEntity))
         {
             result = { .ResultCode = ADUC_Result_Failure,
                        .ExtendedResultCode = ADUC_ERC_SCRIPT_HANDLER_DOWNLOAD_FAILURE_GET_PAYLOAD_FILE_ENTITY };
@@ -225,16 +226,14 @@ ADUC_Result ScriptHandlerImpl::Download(const tagADUC_WorkflowData* workflowData
                 .retryTimeout = DO_RETRY_TIMEOUT_DEFAULT,
             };
 
-            result = ExtensionManager::Download(entity, workflowHandle, &downloadOptions, nullptr);
+            result = ExtensionManager::Download(&fileEntity, workflowHandle, &downloadOptions, nullptr);
+            ADUC_FileEntity_Uninit(&fileEntity);
         }
         catch (...)
         {
             result = { .ResultCode = ADUC_Result_Failure,
                        .ExtendedResultCode = ADUC_ERC_SCRIPT_HANDLER_DOWNLOAD_PAYLOAD_FILE_FAILURE_UNKNOWNEXCEPTION };
         }
-
-        workflow_free_file_entity(entity);
-        entity = nullptr;
 
         if (IsAducResultCodeFailure(result.ResultCode))
         {
@@ -248,7 +247,7 @@ ADUC_Result ScriptHandlerImpl::Download(const tagADUC_WorkflowData* workflowData
 
 done:
     workflow_free_string(workFolder);
-    workflow_free_file_entity(entity);
+    ADUC_FileEntity_Uninit(&fileEntity);
     workflow_free_string(installedCriteria);
     Log_Info("Script_Handler download task end.");
     return result;

--- a/src/extensions/step_handlers/simulator_handler/CMakeLists.txt
+++ b/src/extensions/step_handlers/simulator_handler/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries (
     PRIVATE aduc::agent_workflow
             aduc::contract_utils
             aduc::logging
+            aduc::parser_utils
             aduc::workflow_utils
             Parson::parson)
 

--- a/src/extensions/step_handlers/simulator_handler/tests/CMakeLists.txt
+++ b/src/extensions/step_handlers/simulator_handler/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries (
             aduc::exception_utils
             aduc::extension_utils
             aduc::logging
+            aduc::parser_utils
             aduc::process_utils
             aduc::string_utils
             aduc::system_utils

--- a/src/extensions/step_handlers/swupdate_handler/CMakeLists.txt
+++ b/src/extensions/step_handlers/swupdate_handler/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries (
             aduc::contract_utils
             aduc::extension_manager
             aduc::logging
+            aduc::parser_utils
             aduc::process_utils
             aduc::string_utils
             aduc::system_utils

--- a/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
+++ b/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
@@ -20,6 +20,7 @@
 #include "aduc/adu_core_exports.h"
 #include "aduc/extension_manager.hpp"
 #include "aduc/logging.h"
+#include "aduc/parser_utils.h" // ADUC_FileEntity_Uninit
 #include "aduc/process_utils.hpp"
 #include "aduc/string_c_utils.h"
 #include "aduc/string_utils.hpp"
@@ -124,7 +125,8 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
 {
     std::stringstream updateFilename;
     ADUC_Result result = { ADUC_Result_Failure };
-    ADUC_FileEntity* entity = nullptr;
+    ADUC_FileEntity fileEntity;
+    memset(&fileEntity, 0, sizeof(fileEntity));
     ADUC_WorkflowHandle workflowHandle = workflowData->WorkflowHandle;
     char* workFolder = workflow_get_workfolder(workflowHandle);
     int fileCount = 0;
@@ -164,25 +166,25 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
         goto done;
     }
 
-    if (!workflow_get_update_file(workflowHandle, 0, &entity))
+    if (!workflow_get_update_file(workflowHandle, 0, &fileEntity))
     {
         result.ExtendedResultCode = ADUC_ERC_SWUPDATE_HANDLER_DOWNLOAD_BAD_FILE_ENTITY;
         goto done;
     }
 
-    updateFilename << workFolder << "/" << entity->TargetFilename;
+    updateFilename << workFolder << "/" << fileEntity.TargetFilename;
 
     {
         ExtensionManager_Download_Options downloadOptions = {
             .retryTimeout = DO_RETRY_TIMEOUT_DEFAULT,
         };
 
-        result = ExtensionManager::Download(entity, workflowHandle, &downloadOptions, nullptr);
+        result = ExtensionManager::Download(&fileEntity, workflowHandle, &downloadOptions, nullptr);
     }
 
 done:
     workflow_free_string(workFolder);
-    workflow_free_file_entity(entity);
+    ADUC_FileEntity_Uninit(&fileEntity);
     free(updateName);
 
     return result;
@@ -197,7 +199,8 @@ done:
 ADUC_Result SWUpdateHandlerImpl::Install(const tagADUC_WorkflowData* workflowData)
 {
     ADUC_Result result = { ADUC_Result_Failure };
-    ADUC_FileEntity* entity = nullptr;
+    ADUC_FileEntity fileEntity;
+    memset(&fileEntity, 0, sizeof(fileEntity));
     ADUC_WorkflowHandle workflowHandle = workflowData->WorkflowHandle;
     char* workFolder = workflow_get_workfolder(workflowHandle);
 
@@ -219,7 +222,7 @@ ADUC_Result SWUpdateHandlerImpl::Install(const tagADUC_WorkflowData* workflowDat
         goto done;
     }
 
-    if (!workflow_get_update_file(workflowHandle, 0, &entity))
+    if (!workflow_get_update_file(workflowHandle, 0, &fileEntity))
     {
         result.ExtendedResultCode = ADUC_ERC_SWUPDATE_HANDLER_INSTALL_FAILURE_BAD_FILE_ENTITY;
         goto done;
@@ -240,7 +243,7 @@ ADUC_Result SWUpdateHandlerImpl::Install(const tagADUC_WorkflowData* workflowDat
                                        adushconst::update_action_install };
 
         std::stringstream data;
-        data << workFolder << "/" << entity->TargetFilename;
+        data << workFolder << "/" << fileEntity.TargetFilename;
         args.emplace_back(adushconst::target_data_opt);
         args.emplace_back(data.str().c_str());
 
@@ -264,7 +267,7 @@ ADUC_Result SWUpdateHandlerImpl::Install(const tagADUC_WorkflowData* workflowDat
 
 done:
     workflow_free_string(workFolder);
-    workflow_free_file_entity(entity);
+    ADUC_FileEntity_Uninit(&fileEntity);
     return result;
 }
 

--- a/src/extensions/step_handlers/swupdate_handler_v2/CMakeLists.txt
+++ b/src/extensions/step_handlers/swupdate_handler_v2/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries (
             aduc::exception_utils
             aduc::extension_manager
             aduc::logging
+            aduc::parser_utils
             aduc::process_utils
             aduc::string_utils
             aduc::system_utils

--- a/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
+++ b/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
@@ -15,6 +15,7 @@
 #include "aduc/adu_core_exports.h"
 #include "aduc/extension_manager.hpp"
 #include "aduc/logging.h"
+#include "aduc/parser_utils.h" // ADUC_FileEntity_Uninit
 #include "aduc/process_utils.hpp"
 #include "aduc/string_c_utils.h"
 #include "aduc/string_utils.hpp"
@@ -68,7 +69,8 @@ static ADUC_Result SWUpdate_Handler_DownloadScriptFile(ADUC_WorkflowHandle handl
 {
     ADUC_Result result = { ADUC_Result_Failure };
     char* workFolder = nullptr;
-    ADUC_FileEntity* entity = nullptr;
+    ADUC_FileEntity entity;
+    memset(&entity, 0, sizeof(entity));
     int fileCount = workflow_get_update_files_count(handle);
     int createResult = 0;
     // Download the main script file.
@@ -105,17 +107,15 @@ static ADUC_Result SWUpdate_Handler_DownloadScriptFile(ADUC_WorkflowHandle handl
 
     try
     {
-        result = ExtensionManager::Download(entity, handle, &Default_ExtensionManager_Download_Options, nullptr);
+        result = ExtensionManager::Download(&entity, handle, &Default_ExtensionManager_Download_Options, nullptr);
     }
     catch (...)
     {
         result.ExtendedResultCode = ADUC_ERC_SWUPDATE_HANDLER_DOWNLOAD_PRIMARY_FILE_FAILURE_UNKNOWNEXCEPTION;
     }
 
-    workflow_free_file_entity(entity);
-    entity = nullptr;
-
 done:
+    ADUC_FileEntity_Uninit(&entity);
     workflow_free_string(workFolder);
     return result;
 }
@@ -296,7 +296,8 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
     ADUC_WorkflowHandle workflowHandle = workflowData->WorkflowHandle;
     char* installedCriteria = nullptr;
     char* workFolder = workflow_get_workfolder(workflowData->WorkflowHandle);
-    ADUC_FileEntity* entity = nullptr;
+    ADUC_FileEntity fileEntity;
+    memset(&fileEntity, 0, sizeof(fileEntity));
     int fileCount = workflow_get_update_files_count(workflowHandle);
     ADUC_Result result = SWUpdate_Handler_DownloadScriptFile(workflowHandle);
 
@@ -321,7 +322,7 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
     {
         Log_Info("Downloading file #%d", i);
 
-        if (!workflow_get_update_file(workflowHandle, i, &entity))
+        if (!workflow_get_update_file(workflowHandle, i, &fileEntity))
         {
             result = { .ResultCode = ADUC_Result_Failure,
                        .ExtendedResultCode = ADUC_ERC_SWUPDATE_HANDLER_DOWNLOAD_FAILURE_GET_PAYLOAD_FILE_ENTITY };
@@ -331,7 +332,7 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
         try
         {
             result = ExtensionManager::Download(
-                entity, workflowHandle, &Default_ExtensionManager_Download_Options, nullptr);
+                &fileEntity, workflowHandle, &Default_ExtensionManager_Download_Options, nullptr);
         }
         catch (...)
         {
@@ -339,9 +340,6 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
                        .ExtendedResultCode =
                            ADUC_ERC_SWUPDATE_HANDLER_DOWNLOAD_PAYLOAD_FILE_FAILURE_UNKNOWNEXCEPTION };
         }
-
-        workflow_free_file_entity(entity);
-        entity = nullptr;
 
         if (IsAducResultCodeFailure(result.ResultCode))
         {
@@ -355,7 +353,7 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
 
 done:
     workflow_free_string(workFolder);
-    workflow_free_file_entity(entity);
+    ADUC_FileEntity_Uninit(&fileEntity);
     workflow_free_string(installedCriteria);
     Log_Info("SWUpdate_Handler download task end.");
     return result;
@@ -421,10 +419,7 @@ ADUC_Result SWUpdateHandlerImpl::Apply(const tagADUC_WorkflowData* workflowData)
         goto done;
     }
 
-    result = {
-        .ResultCode = ADUC_Result_Success,
-        .ExtendedResultCode = 0
-    };
+    result = { .ResultCode = ADUC_Result_Success, .ExtendedResultCode = 0 };
 
 done:
     workflow_free_string(workFolder);

--- a/src/extensions/step_handlers/swupdate_handler_v2/tests/CMakeLists.txt
+++ b/src/extensions/step_handlers/swupdate_handler_v2/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries (
             aduc::c_utils
             aduc::exception_utils
             aduc::extension_manager
+            aduc::parser_utils
             aduc::process_utils
             aduc::string_utils
             aduc::system_utils

--- a/src/extensions/update_manifest_handlers/steps_handler/CMakeLists.txt
+++ b/src/extensions/update_manifest_handlers/steps_handler/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries (
             aduc::extension_manager
             aduc::extension_utils
             aduc::logging
+            aduc::parser_utils
             aduc::process_utils
             aduc::string_utils
             aduc::system_utils

--- a/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
@@ -12,18 +12,17 @@
 #include "aduc/extension_manager.hpp"
 #include "aduc/extension_manager_download_options.h"
 #include "aduc/logging.h"
+#include "aduc/parser_utils.h" // ADUC_FileEntity_Uninit
 #include "aduc/string_c_utils.h" // IsNullOrEmpty
 #include "aduc/string_utils.hpp"
 #include "aduc/system_utils.h"
 #include "aduc/workflow_utils.h"
 
-#include "parson.h"
-
-#include <sstream>
-#include <string>
-
 #include <azure_c_shared_utility/crt_abstractions.h> // mallocAndStrcpy
 #include <azure_c_shared_utility/strings.h> // STRING_*
+#include <parson.h>
+#include <sstream>
+#include <string>
 
 // Note: this requires ${CMAKE_DL_LIBS}
 #include <dlfcn.h>
@@ -100,8 +99,9 @@ ADUC_Result PrepareStepsWorkflowDataObject(ADUC_WorkflowHandle handle)
         for (unsigned int i = 0; i < stepCount; i++)
         {
             STRING_HANDLE childId = nullptr;
-            ADUC_FileEntity* entity = nullptr;
             childHandle = nullptr;
+            ADUC_FileEntity entity;
+            memset(&entity, 0, sizeof(entity));
 
             if (workflow_is_inline_step(handle, i))
             {
@@ -140,7 +140,7 @@ ADUC_Result PrepareStepsWorkflowDataObject(ADUC_WorkflowHandle handle)
                     "Downloading a detached Update manifest file for level#%d step#%d (file id:%s).",
                     workflowLevel,
                     i,
-                    entity->FileId);
+                    entity.FileId);
 
                 try
                 {
@@ -148,7 +148,7 @@ ADUC_Result PrepareStepsWorkflowDataObject(ADUC_WorkflowHandle handle)
                         .retryTimeout = DO_RETRY_TIMEOUT_DEFAULT,
                     };
 
-                    result = ExtensionManager::Download(entity, handle, &downloadOptions, nullptr);
+                    result = ExtensionManager::Download(&entity, handle, &downloadOptions, nullptr);
                 }
                 catch (...)
                 {
@@ -156,15 +156,12 @@ ADUC_Result PrepareStepsWorkflowDataObject(ADUC_WorkflowHandle handle)
                         "Exception occurred while downloading a detached Update Manifest file for level#%d step#%d (file id:%s).",
                         workflowLevel,
                         i,
-                        entity->FileId);
+                        entity.FileId);
                     result.ExtendedResultCode = ADUC_ERC_STEPS_HANDLER_DOWNLOAD_FAILURE_UNKNOWNEXCEPTION;
                 }
 
                 std::stringstream childManifestFile;
-                childManifestFile << workFolder << "/" << entity->TargetFilename;
-
-                workflow_free_file_entity(entity);
-                entity = nullptr;
+                childManifestFile << workFolder << "/" << entity.TargetFilename;
 
                 // For 'microsoft/steps:1' implementation, abort download task as soon as an error occurs.
                 if (IsAducResultCodeFailure(result.ResultCode))
@@ -260,13 +257,14 @@ ADUC_Result PrepareStepsWorkflowDataObject(ADUC_WorkflowHandle handle)
     result = { ADUC_Result_Success };
 
 done:
+    workflow_free_string(workFolder);
+    ADUC_FileEntity_Uninit(entity);
+
     if (IsAducResultCodeFailure(result.ResultCode))
     {
         workflow_free(childHandle);
     }
 
-    workflow_free_string(workFolder);
-    workflow_free_file_entity(entity);
     return result;
 }
 

--- a/src/utils/workflow_utils/inc/aduc/workflow_utils.h
+++ b/src/utils/workflow_utils/inc/aduc/workflow_utils.h
@@ -278,19 +278,12 @@ size_t workflow_get_bundle_updates_count(ADUC_WorkflowHandle handle);
 /**
  * @brief Gets a bundle update file at specified index.
  *
- * @param handle A workflow data object handle.
- * @param index An index of the file to get.
- * @param entity An output file entity object. Caller must free the object with workflow_free_file_entity().
+ * @param[in] handle A workflow data object handle.
+ * @param[in] index An index of the file to get.
+ * @param[out] entity An output file entity object.
  * @return true on success.
  */
-bool workflow_get_bundle_updates_file(ADUC_WorkflowHandle handle, size_t index, ADUC_FileEntity** entity);
-
-/**
- * @brief Free specified file entity object.
- *
- * @param entity A pointer to file entity object to be freed.
- */
-void workflow_free_file_entity(ADUC_FileEntity* entity);
+bool workflow_get_bundle_updates_file(ADUC_WorkflowHandle handle, size_t index, ADUC_FileEntity* entity);
 
 /**
  * @brief Get an Update Manifest property (string) without copying the value.
@@ -721,13 +714,12 @@ workflow_peek_update_manifest_handler_properties_string(ADUC_WorkflowHandle hand
 /**
  * @brief Gets a reference step update manifest file at specified index.
  *
- * @param handle A workflow data object handle.
- * @param stepIndex A step index.
- * @param entity An output reference step update manifest file entity object.
- *               Caller must free the object with workflow_free_file_entity().
- * @return Returns true if succeeded.
+ * @param[in] handle A workflow data object handle.
+ * @param[in] stepIndex A step index.
+ * @param[out] entity An output reference step update manifest file entity object.
+ * @return Returns true on success.
  */
-bool workflow_get_step_detached_manifest_file(ADUC_WorkflowHandle handle, size_t stepIndex, ADUC_FileEntity** entity);
+bool workflow_get_step_detached_manifest_file(ADUC_WorkflowHandle handle, size_t stepIndex, ADUC_FileEntity* entity);
 
 /**
  * @brief Gets a serialized json string of the specified workflow's Update Manifest.

--- a/src/utils/workflow_utils/inc/aduc/workflow_utils.h
+++ b/src/utils/workflow_utils/inc/aduc/workflow_utils.h
@@ -233,20 +233,20 @@ size_t workflow_get_update_files_count(ADUC_WorkflowHandle handle);
  *
  * @param handle A workflow data object handle.
  * @param index An index of the file to get.
- * @param entity An output file entity object. Caller must free the object with workflow_free_file_entity().
- * @return true If succeeded.
+ * @param entity An output file entity object. Caller must uninitialize it via ADUC_FileEntity_Uninit when done.
+ * @return true on success.
  */
-bool workflow_get_update_file(ADUC_WorkflowHandle handle, size_t index, ADUC_FileEntity** entity);
+bool workflow_get_update_file(ADUC_WorkflowHandle handle, size_t index, ADUC_FileEntity* entity);
 
 /**
  * @brief Gets the update file entity by name.
  *
- * @param handle A workflow data object handle.
- * @param fileName File name.
-* @param entity An output file entity object. Caller must free the object with workflow_free_file_entity().
- * @return true If succeeded.
+ * @param[in] handle A workflow data object handle.
+ * @param[in] fileName File name.
+ * @param[out] entity An output file entity object. Caller must uninitialize it via ADUC_FileEntity_Uninit().
+ * @return true on success.
  */
-bool workflow_get_update_file_by_name(ADUC_WorkflowHandle handle, const char* fileName, ADUC_FileEntity** entity);
+bool workflow_get_update_file_by_name(ADUC_WorkflowHandle handle, const char* fileName, ADUC_FileEntity* entity);
 
 /**
  * @brief Gets the inode associated with the update file entity at the specified index.
@@ -281,7 +281,7 @@ size_t workflow_get_bundle_updates_count(ADUC_WorkflowHandle handle);
  * @param handle A workflow data object handle.
  * @param index An index of the file to get.
  * @param entity An output file entity object. Caller must free the object with workflow_free_file_entity().
- * @return true If succeeded.
+ * @return true on success.
  */
 bool workflow_get_bundle_updates_file(ADUC_WorkflowHandle handle, size_t index, ADUC_FileEntity** entity);
 
@@ -438,7 +438,7 @@ ADUC_WorkflowHandle workflow_get_child(ADUC_WorkflowHandle handle, int index);
  * @param index An index indicate the location the @p childHandle will be inserted at.
  *              To insert at the end of the list, pass '-1'.
  * @param childHandle A child workflow object handle.
- * @return true If succeeded.
+ * @return true on success.
  */
 bool workflow_insert_child(ADUC_WorkflowHandle handle, int index, ADUC_WorkflowHandle childHandle);
 

--- a/src/utils/workflow_utils/tests/workflow_utils_ut.cpp
+++ b/src/utils/workflow_utils/tests/workflow_utils_ut.cpp
@@ -82,20 +82,18 @@ TEST_CASE("Initialization test")
     auto filecount = workflow_get_update_files_count(handle);
     REQUIRE(filecount == 2);
 
-    ADUC_FileEntity* file0 = nullptr;
+    ADUC_FileEntity file0;
+    memset(&file0, 0, sizeof(file0));
     bool success = workflow_get_update_file(handle, 0, &file0);
     REQUIRE(success);
-    REQUIRE(file0 != nullptr);
-    CHECK_THAT(file0->FileId, Equals("f483750ebb885d32c"));
-    CHECK(file0->HashCount == 1);
+    CHECK_THAT(file0.FileId, Equals("f483750ebb885d32c"));
+    CHECK(file0.HashCount == 1);
     CHECK_THAT(
-        file0->DownloadUri,
+        file0.DownloadUri,
         Equals(
             "http://duinstance2.b.nlu.dl.adu.microsoft.com/westus2/duinstance2/e5cc19d5e9174c93ada35cc315f1fb1d/apt-manifest-tree-1.0.json"));
 
-    ADUC_FileEntity_Uninit(file0);
-    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-no-malloc, hicpp-no-malloc)
-    free(file0);
+    ADUC_FileEntity_Uninit(&file0);
 
     char* updateId = workflow_get_expected_update_id_string(handle);
     CHECK_THAT(updateId, Equals("{\"provider\":\"Contoso\",\"name\":\"Virtual-Vacuum\",\"version\":\"20.0\"}"));
@@ -132,8 +130,7 @@ TEST_CASE("Get Compatibility")
     CHECK(result.ResultCode != 0);
     CHECK(result.ExtendedResultCode == 0);
 
-    const char* expectedValue =
-        R"([{"deviceManufacturer":"contoso","deviceModel":"virtual-vacuum-v1"}])";
+    const char* expectedValue = R"([{"deviceManufacturer":"contoso","deviceModel":"virtual-vacuum-v1"}])";
 
     char* compats = workflow_get_compatibility(handle);
     CHECK_THAT(compats, Equals(expectedValue));
@@ -183,20 +180,18 @@ TEST_CASE("Child workflow uses fileUrls from parent")
     workflow_insert_child(bundle, 0, leaf0);
 
     // Check that leaf 0 file has the right download uri.
-    ADUC_FileEntity* file0 = nullptr;
+    ADUC_FileEntity file0;
+    memset(&file0, 0, sizeof(file0));
     bool success = workflow_get_update_file(leaf0, 0, &file0);
     REQUIRE(success);
-    REQUIRE(file0 != nullptr);
-    CHECK_THAT(file0->FileId, Equals("f13b5435aab7c18da"));
-    CHECK(file0->HashCount == 1);
+    CHECK_THAT(file0.FileId, Equals("f13b5435aab7c18da"));
+    CHECK(file0.HashCount == 1);
     CHECK_THAT(
-        file0->DownloadUri,
+        file0.DownloadUri,
         Equals(
             "http://duinstance2.b.nlu.dl.adu.microsoft.com/westus2/duinstance2/c02058a476a242d7bc0e3c576c180051/contoso-motor-installscript.sh"));
 
-    ADUC_FileEntity_Uninit(file0);
-    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-no-malloc, hicpp-no-malloc)
-    free(file0);
+    ADUC_FileEntity_Uninit(&file0);
 
     workflow_free(bundle);
 }
@@ -213,22 +208,19 @@ TEST_CASE("Get update file by name")
     REQUIRE(filecount == 2);
 
     // Check that leaf 0 file has the right download uri.
-    ADUC_FileEntity* file0 = nullptr;
+    ADUC_FileEntity file0;
+    memset(&file0, 0, sizeof(file0));
     bool success =
         workflow_get_update_file_by_name(bundle, "contoso.contoso-virtual-motors.1.1.updatemanifest.json", &file0);
     CHECK(success);
-    CHECK(file0 != nullptr);
-    CHECK_THAT(file0->FileId, Equals("f222b9ffefaaac577"));
-    CHECK(file0->HashCount == 1);
+    CHECK_THAT(file0.FileId, Equals("f222b9ffefaaac577"));
+    CHECK(file0.HashCount == 1);
     CHECK_THAT(
-        file0->DownloadUri,
+        file0.DownloadUri,
         Equals(
             "http://duinstance2.b.nlu.dl.adu.microsoft.com/westus2/duinstance2/31c38c3340a84e38ae8d30ce340f4a49/contoso.contoso-virtual-motors.1.1.updatemanifest.json"));
 
-    ADUC_FileEntity_Uninit(file0);
-    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-no-malloc, hicpp-no-malloc)
-    free(file0);
-
+    ADUC_FileEntity_Uninit(&file0);
     workflow_free(bundle);
 }
 
@@ -244,22 +236,19 @@ TEST_CASE("Get update file by name - mixed case")
     REQUIRE(filecount == 2);
 
     // Check that leaf 0 file has the right download uri.
-    ADUC_FileEntity* file0 = nullptr;
+    ADUC_FileEntity file0;
+    memset(&file0, 0, sizeof(file0));
     bool success =
         workflow_get_update_file_by_name(bundle, "contoso.Contoso-virtual-motors.1.1.updatemanifest.json", &file0);
     CHECK(success);
-    CHECK(file0 != nullptr);
-    CHECK_THAT(file0->FileId, Equals("f222b9ffefaaac577"));
-    CHECK(file0->HashCount == 1);
+    CHECK_THAT(file0.FileId, Equals("f222b9ffefaaac577"));
+    CHECK(file0.HashCount == 1);
     CHECK_THAT(
-        file0->DownloadUri,
+        file0.DownloadUri,
         Equals(
             "http://duinstance2.b.nlu.dl.adu.microsoft.com/westus2/duinstance2/31c38c3340a84e38ae8d30ce340f4a49/contoso.contoso-virtual-motors.1.1.updatemanifest.json"));
 
-    ADUC_FileEntity_Uninit(file0);
-    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-no-malloc, hicpp-no-malloc)
-    free(file0);
-
+    ADUC_FileEntity_Uninit(&file0);
     workflow_free(bundle);
 }
 


### PR DESCRIPTION
workflow_get_update_file and workflow_get_update_file_by_name unnecessarily allocate the FileEntity for the out param. Fixed to just pass in address of stack variable instead to avoid fragmenting the heap.