### PR TITLE
Change LoadBufferWithFileContents to use FILE APIs.

### DIFF
--- a/src/libaducpal/inc/aducpal/unistd.h
+++ b/src/libaducpal/inc/aducpal/unistd.h
@@ -27,7 +27,6 @@ extern "C"
     uid_t ADUCPAL_getuid();
     int ADUCPAL_isatty(int fd);
     int ADUCPAL_open(const char* path, int oflag);
-    ssize_t ADUCPAL_read(int fildes, void* buf, size_t nbyte);
     int ADUCPAL_rmdir(const char* path);
     int ADUCPAL_setegid(gid_t gid);
     int ADUCPAL_seteuid(uid_t uid);
@@ -56,7 +55,6 @@ extern "C"
 #    define ADUCPAL_getuid() getuid()
 #    define ADUCPAL_isatty(fd) isatty(fd)
 #    define ADUCPAL_open(path, oflag) open(path, oflag)
-#    define ADUCPAL_read(fildes, buf, nbyte) read(fildes, buf, nbyte)
 #    define ADUCPAL_rmdir(path) rmdir(path)
 #    define ADUCPAL_setegid(gid) setegid(gid)
 #    define ADUCPAL_seteuid(uid) seteuid(uid)

--- a/src/libaducpal/inc/aducpal/unistd.h
+++ b/src/libaducpal/inc/aducpal/unistd.h
@@ -37,7 +37,6 @@ extern "C"
     long ADUCPAL_syscall(long number);
     void ADUCPAL_sync();
     int ADUCPAL_unlink(const char* path);
-    ssize_t ADUCPAL_write(int fildes, const void* buf, size_t nbyte);
 
 #    ifdef __cplusplus
 }
@@ -66,7 +65,6 @@ extern "C"
 #    define ADUCPAL_syscall(number) syscall(number)
 #    define ADUCPAL_sync() sync()
 #    define ADUCPAL_unlink(path) unlink(path)
-#    define ADUCPAL_write(fildes, buf, nbyte) write(fildes, buf, nbyte)
 
 #endif // #ifdef ADUCPAL_USE_PAL
 

--- a/src/libaducpal/src/unistd.c
+++ b/src/libaducpal/src/unistd.c
@@ -81,11 +81,7 @@ int ADUCPAL_open(const char* path, int oflag)
 
 ssize_t ADUCPAL_read(int fildes, void* buf, size_t nbyte)
 {
-    UNREFERENCED_PARAMETER(fildes);
-    UNREFERENCED_PARAMETER(buf);
-    UNREFERENCED_PARAMETER(nbyte);
-    __debugbreak();
-    return -1;
+    return _read(fildes, buf, (unsigned int)nbyte);
 }
 
 int ADUCPAL_rmdir(const char* path)
@@ -155,14 +151,4 @@ int ADUCPAL_unlink(const char* path)
     // Perhaps h = CreateFile(file, ... FILE_FLAG_DELETE_ON_CLOSE); CloseHandle(h); ?
 
     return _unlink(path);
-}
-
-ssize_t ADUCPAL_write(int fildes, const void* buf, size_t nbyte)
-{
-    UNREFERENCED_PARAMETER(fildes);
-    UNREFERENCED_PARAMETER(buf);
-    UNREFERENCED_PARAMETER(nbyte);
-
-    __debugbreak();
-    return -1;
 }

--- a/src/libaducpal/src/unistd.c
+++ b/src/libaducpal/src/unistd.c
@@ -79,11 +79,6 @@ int ADUCPAL_open(const char* path, int oflag)
     return fd;
 }
 
-ssize_t ADUCPAL_read(int fildes, void* buf, size_t nbyte)
-{
-    return _read(fildes, buf, (unsigned int)nbyte);
-}
-
 int ADUCPAL_rmdir(const char* path)
 {
     return _rmdir(path);


### PR DESCRIPTION
Changing LoadBufferWithFileContents to use fopen, fgets, fclose rather than open, read, close?  The latter is a bit quirky on Windows.