### PR TITLE
SHARED -> MODULE to avoid linking to extensions

### DIFF
--- a/src/extensions/component_enumerators/examples/contoso_component_enumerator/CMakeLists.txt
+++ b/src/extensions/component_enumerators/examples/contoso_component_enumerator/CMakeLists.txt
@@ -4,7 +4,7 @@ include (agentRules)
 
 compileasc99 ()
 
-add_library (${PROJECT_NAME} SHARED contoso_component_enumerator.cpp)
+add_library (${PROJECT_NAME} MODULE contoso_component_enumerator.cpp)
 
 find_package (Parson REQUIRED)
 

--- a/src/extensions/content_downloaders/curl_downloader/CMakeLists.txt
+++ b/src/extensions/content_downloaders/curl_downloader/CMakeLists.txt
@@ -4,7 +4,7 @@ include (agentRules)
 
 compileasc99 ()
 
-add_library (${PROJECT_NAME} SHARED)
+add_library (${PROJECT_NAME} MODULE)
 add_library (aduc::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_sources (

--- a/src/extensions/content_downloaders/deliveryoptimization_downloader/CMakeLists.txt
+++ b/src/extensions/content_downloaders/deliveryoptimization_downloader/CMakeLists.txt
@@ -6,7 +6,7 @@ compileasc99 ()
 
 find_package (deliveryoptimization_sdk CONFIG REQUIRED)
 
-add_library (${PROJECT_NAME} SHARED)
+add_library (${PROJECT_NAME} MODULE)
 add_library (aduc::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_sources (

--- a/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/plugin/CMakeLists.txt
+++ b/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/plugin/CMakeLists.txt
@@ -3,7 +3,7 @@ set (target_name microsoft_delta_download_handler)
 include (agentRules)
 compileasc99 ()
 
-add_library (${target_name} MODULE "")
+add_library (${target_name} MODULE)
 
 target_include_directories (${target_name} PUBLIC inc ${ADUC_EXPORT_INCLUDES})
 

--- a/src/extensions/step_handlers/apt_handler/CMakeLists.txt
+++ b/src/extensions/step_handlers/apt_handler/CMakeLists.txt
@@ -2,12 +2,8 @@ cmake_minimum_required (VERSION 3.5)
 
 set (target_name microsoft_apt_1)
 
-set (SOURCE_ALL src/apt_handler.cpp src/apt_parser.cpp)
-
-#
-# Create a SHARED library.
-#
-add_library (${target_name} SHARED ${SOURCE_ALL})
+add_library (${target_name} MODULE)
+target_sources (${target_name} PRIVATE src/apt_handler.cpp src/apt_parser.cpp)
 
 add_library (aduc::${target_name} ALIAS ${target_name})
 

--- a/src/extensions/step_handlers/simulator_handler/CMakeLists.txt
+++ b/src/extensions/step_handlers/simulator_handler/CMakeLists.txt
@@ -2,12 +2,8 @@ cmake_minimum_required (VERSION 3.5)
 
 set (target_name microsoft_simulator_1)
 
-set (SOURCE_ALL src/simulator_handler.cpp)
-
-#
-# Create a shared library.
-#
-add_library (${target_name} SHARED ${SOURCE_ALL})
+add_library (${target_name} MODULE)
+target_sources (${target_name} PRIVATE src/simulator_handler.cpp)
 
 add_library (aduc::${target_name} ALIAS ${target_name})
 

--- a/src/extensions/step_handlers/swupdate_handler_v2/CMakeLists.txt
+++ b/src/extensions/step_handlers/swupdate_handler_v2/CMakeLists.txt
@@ -9,7 +9,7 @@ set (
     "${ADUC_CONF_FOLDER}/${SWUPDATE_HANDLER_CONF_FILE}"
     CACHE STRING "Path to the SWUpdate handler configuration file.")
 
-add_library (${target_name} SHARED "")
+add_library (${target_name} MODULE)
 
 add_library (aduc::${target_name} ALIAS ${target_name})
 

--- a/src/extensions/update_manifest_handlers/steps_handler/CMakeLists.txt
+++ b/src/extensions/update_manifest_handlers/steps_handler/CMakeLists.txt
@@ -10,7 +10,7 @@ set (target_name microsoft_steps_1)
 find_package (Parson REQUIRED)
 find_package (IotHubClient REQUIRED)
 
-add_library (${target_name} SHARED)
+add_library (${target_name} MODULE)
 add_library (aduc::${target_name} ALIAS ${target_name})
 
 target_sources (${target_name} PRIVATE src/steps_handler.cpp src/handler_create.cpp)


### PR DESCRIPTION
as per [CMake add_library doc](https://cmake.org/cmake/help/latest/command/add_library.html#command:add_library):
`SHARED libraries are linked dynamically and loaded at runtime. MODULE libraries are plugins that are not linked into other targets but may be loaded dynamically at runtime using dlopen-like functionality`

The intention of extensions is to be plugins, not to allow other targets to directly link with them.  This only affects non-windows platforms.