### PR TITLE
Set default DO ref to main

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -72,7 +72,7 @@ install_githooks=false
 
 du_test_data_dir_path="/tmp/adu/"
 # DO Deps
-default_do_ref=develop
+default_do_ref=v1.0.1
 install_do=false
 do_ref=$default_do_ref
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -72,7 +72,7 @@ install_githooks=false
 
 du_test_data_dir_path="/tmp/adu/"
 # DO Deps
-default_do_ref=main
+default_do_ref=develop
 install_do=false
 do_ref=$default_do_ref
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -72,7 +72,7 @@ install_githooks=false
 
 du_test_data_dir_path="/tmp/adu/"
 # DO Deps
-default_do_ref=v1.0.0
+default_do_ref=main
 install_do=false
 do_ref=$default_do_ref
 


### PR DESCRIPTION
To better align DU and DO development, and to resolve 
CMake Error in sdk-cpp/CMakeLists.txt:
  Imported target "Boost::filesystem" includes non-existent path

    "/include"

  in its INTERFACE_INCLUDE_DIRECTORIES.  
