### PR TITLE
Create how-to-install-deb-pkg-on-rpi.md

### DIFF
--- a/docs/agent-reference/how-to-install-deb-pkg-on-rpi.md
+++ b/docs/agent-reference/how-to-install-deb-pkg-on-rpi.md
@@ -2,27 +2,27 @@
 
 ## Raspberry Pi 3
 
-### For ubuntu server 20.04 (64-bit)
+### Ubuntu server 20.04 (64-bit)
 
-1. From RPi Imager, choose `Other general-purpose OS -> Ubuntu Server 20.04.5 LTS (64-bit)`
-2. [setup packages.microsoft.com apt.d repository](https://learn.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#ubuntu).
-3. `sudo apt install deviceupdate-agent`
+- From RPi Imager, choose `Other general-purpose OS -> Ubuntu Server 20.04.5 LTS (64-bit)`
+- [setup packages.microsoft.com apt.d repository](https://learn.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#ubuntu).
+- `sudo apt install deviceupdate-agent`
 
-### For Debian 10 armhf on rpi3
+### Debian 10 armhf on rpi3
 
-1. From RPi Imager, choose `Raspberry Pi OS" - > Raspberry Pi OS Lite (Legacy)`
-2. Follow step 1 of [add apt.d for packages.microsoft.com for Debian 10 buster](https://learn.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#debian).
-3. Step 2 fails with "could not find a distribution template for Raspbian/buster". Instead do:
+- From RPi Imager, choose `Raspberry Pi OS" - > Raspberry Pi OS Lite (Legacy)`
+- Follow step 1 of [add apt.d for packages.microsoft.com for Debian 10 buster](https://learn.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#debian).
+- Step 2 fails with "could not find a distribution template for Raspbian/buster". Instead do:
     
     `echo "deb https://packages.microsoft.com/debian/10/prod buster main" > /etc/apt/sources.list.d/microsoft-prod.list`
     
-5. `sudo apt update`
-6. `sudo apt install deviceupdate-agent`
+- `sudo apt update`
+- `sudo apt install deviceupdate-agent`
 
 ## Raspberry Pi 4
 
 ### Ubuntu 20.04 aarch64
 
-1. From RPi Imager, choose `Other general-purpose OS -> Ubuntu Server 20.04.5 LTS (64-bit)`
-2. [setup packages.microsoft.com apt.d repository](https://learn.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#ubuntu).
-3. `sudo apt install deviceupdate-agent`
+- From RPi Imager, choose `Other general-purpose OS -> Ubuntu Server 20.04.5 LTS (64-bit)`
+- [setup packages.microsoft.com apt.d repository](https://learn.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#ubuntu).
+- `sudo apt install deviceupdate-agent`

--- a/docs/agent-reference/how-to-install-deb-pkg-on-rpi.md
+++ b/docs/agent-reference/how-to-install-deb-pkg-on-rpi.md
@@ -1,0 +1,28 @@
+# Install from Debian packages hosted on packages.microsoft.com
+
+## Raspberry Pi 3
+
+### For ubuntu server 20.04 (64-bit)
+
+1. From RPi Imager, choose `Other general-purpose OS -> Ubuntu Server 20.04.5 LTS (64-bit)`
+2. [setup packages.microsoft.com apt.d repository](https://learn.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#ubuntu).
+3. `sudo apt install deviceupdate-agent`
+
+### For Debian 10 armhf on rpi3
+
+1. From RPi Imager, choose `Raspberry Pi OS" - > Raspberry Pi OS Lite (Legacy)`
+2. Follow step 1 of [add apt.d for packages.microsoft.com for Debian 10 buster](https://learn.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#debian).
+3. Step 2 fails with "could not find a distribution template for Raspbian/buster". Instead do:
+    
+    `echo "deb https://packages.microsoft.com/debian/10/prod buster main" > /etc/apt/sources.list.d/microsoft-prod.list`
+    
+5. `sudo apt update`
+6. `sudo apt install deviceupdate-agent`
+
+## Raspberry Pi 4
+
+### Ubuntu 20.04 aarch64
+
+1. From RPi Imager, choose `Other general-purpose OS -> Ubuntu Server 20.04.5 LTS (64-bit)`
+2. [setup packages.microsoft.com apt.d repository](https://learn.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#ubuntu).
+3. `sudo apt install deviceupdate-agent`


### PR DESCRIPTION
- Add rpi3 steps for ubuntu 20.04+aarch64 and Debian10+armhf
- Add rpi4 steps for Ubuntu 20.04+aarch64

Addresses github issue: #344 