### PR TITLE
1.4x perf speedup by using python 3.11 in e2e test pipelines

### DIFF
--- a/azurepipelines/e2e_test/e2etest.yaml
+++ b/azurepipelines/e2e_test/e2etest.yaml
@@ -188,9 +188,9 @@ stages:
                   workingDirectory: $(E2E_WORKING_DIR)/
 
                 - task: UsePythonVersion@0
-                  displayName: Using Python version 3.10
+                  displayName: Using Python version 3.11
                   inputs:
-                      versionSpec: 3.10
+                      versionSpec: 3.11
 
                 - script: |
                       python3 -m pip install -r scenarios/testingtoolkit/requirements.txt
@@ -307,9 +307,9 @@ stages:
                   workingDirectory: $(E2E_WORKING_DIR)
 
                 - task: UsePythonVersion@0
-                  displayName: Set the python version to Python 3.10
+                  displayName: Set the python version to Python 3.11
                   inputs:
-                      versionSpec: 3.10
+                      versionSpec: 3.11
 
                 - script: |
                       python -m pip install -r scenarios/testingtoolkit/requirements.txt


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.11.html#faster-cpython

Last 2 runs using python 3.10:
9812 secs
16346 secs
avg => 13079

Last 2 runs using python 3.11:
8649 secs
10280 secs
avg => 9464.5

13079 / 9464.5  => 1.4x speedup.

