### PR TITLE
fix: cmake misses some POSITION_INDEPENDENT_CODE settings

### DIFF
--- a/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/source_update_cache/CMakeLists.txt
+++ b/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/source_update_cache/CMakeLists.txt
@@ -15,6 +15,11 @@ target_include_directories (${target_name} PUBLIC inc ${ADUC_EXPORT_INCLUDES})
 target_sources (${target_name} PRIVATE src/source_update_cache.c src/source_update_cache_utils.cpp
                                        src/source_update_cache_utils.c)
 
+#
+# Turn -fPIC on, in order to use this library in another shared library.
+#
+set_property (TARGET ${target_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 target_link_libraries (
     ${target_name}
     PUBLIC aduc::adu_types aduc::c_utils

--- a/src/utils/parson_json_utils/CMakeLists.txt
+++ b/src/utils/parson_json_utils/CMakeLists.txt
@@ -6,6 +6,11 @@ add_library (${PROJECT_NAME} STATIC src/parson_json_utils.c)
 add_library (aduc::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories (${PROJECT_NAME} PUBLIC inc)
 
+#
+# Turn -fPIC on, in order to use this library in another shared library.
+#
+set_property (TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 find_package (Parson REQUIRED)
 
 target_link_libraries (

--- a/src/utils/permission_utils/CMakeLists.txt
+++ b/src/utils/permission_utils/CMakeLists.txt
@@ -9,6 +9,11 @@ add_library (aduc::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories (${PROJECT_NAME} PUBLIC inc ${ADUC_EXPORT_INCLUDES})
 
+#
+# Turn -fPIC on, in order to use this library in another shared library.
+#
+set_property (TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 target_link_libraries (${PROJECT_NAME} PUBLIC aduc::c_utils)
 
 if (ADUC_BUILD_UNIT_TESTS)

--- a/src/utils/workflow_data_utils/CMakeLists.txt
+++ b/src/utils/workflow_data_utils/CMakeLists.txt
@@ -14,6 +14,11 @@ target_include_directories (
     PUBLIC inc ${ADUC_EXPORT_INCLUDES}
     PRIVATE src)
 
+#
+# Turn -fPIC on, in order to use this library in another shared library.
+#
+set_property (TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 target_link_libraries (
     ${PROJECT_NAME}
     PRIVATE aduc::adu_core_export_helpers


### PR DESCRIPTION
Other libraries in this project set POSITION_INDEPENDENT_CODE, ex. workflow_utils, and *depend* on these libraries.

Therefore, they need to be position indepent as well.

Fixes compilation issues seen first in OpenWRT for device update v0.8.0.