### PR TITLE
fix: use ADUC_FILE_GROUP instead of hardcoded "adu"

### DIFF
--- a/src/agent/command_helper/src/command_helper.c
+++ b/src/agent/command_helper/src/command_helper.c
@@ -168,7 +168,7 @@ static bool SecurityChecks()
     }
 
     // Verify current user
-    struct group* grp = getgrnam("adu");
+    struct group* grp = getgrnam(ADUC_FILE_GROUP);
     if (grp == NULL)
     {
         // Failed to get 'adu' group information, bail.


### PR DESCRIPTION
An hardcoded `"adu"` remained in the code, while the compilation flag `ADUC_FILE_GROUP`
allows the user to define its own group name, which could be different then `"adu"`.