### PR TITLE
Remove remaining usages of _Bool from generated error code.

### DIFF
--- a/scripts/error_code_generator_defs/error_code_defs_generator.py
+++ b/scripts/error_code_generator_defs/error_code_defs_generator.py
@@ -46,7 +46,7 @@ typedef enum tagADUC_GeneralResult
 /**
 * @brief Determines if a result code is succeeded.
 */
-static inline _Bool IsAducResultCodeSuccess(const ADUC_Result_t resultCode)
+static inline bool IsAducResultCodeSuccess(const ADUC_Result_t resultCode)
 {{
     return (resultCode > 0);
 }}
@@ -54,7 +54,7 @@ static inline _Bool IsAducResultCodeSuccess(const ADUC_Result_t resultCode)
 /**
 * @brief Determines if a result code is failed.
 */
-static inline _Bool IsAducResultCodeFailure(const ADUC_Result_t resultCode)
+static inline bool IsAducResultCodeFailure(const ADUC_Result_t resultCode)
 {{
     return (resultCode <= 0);
 }}


### PR DESCRIPTION
All other previous usages of `_Bool` were already removed in PR #268.

These seem to be the last two left.

This patch is actually necessary in some compiler scenarios using Musl.