### PR TITLE
add elf_size.sh to find footprint hogs in binaries

### DIFF
--- a/scripts/elf_size.sh
+++ b/scripts/elf_size.sh
@@ -74,6 +74,7 @@ for elf_filpath in "${ELF_FILEPATHS[@]}"; do
     result="$(nm -C --print-size --size-sort --radix=d "$elf_filpath")"
 
     if [[ -n $PATTERN ]]; then
+        echo Pattern: "$PATTERN"
         result="$(echo "$result" | grep "${PATTERN}")"
     fi
 

--- a/scripts/elf_size.sh
+++ b/scripts/elf_size.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+PROG_NAME=$0
+
+usage() {
+    cat << EOF
+
+Usage: ${PROG_NAME} [options] /path/to/elf/binary
+
+  -p, --pattern          pattern of nm line output such as in symbol name.
+
+  -s, --sum              Sum up the bytes of the matching ELF sections.
+
+  -h, --help             Show this help message.
+
+
+  Examples:
+
+  ${PROG_NAME} -s -p zlog /usr/bin/AducIotAgent         # sum all contributions to ELF size for zlog library
+  ${PROG_NAME} -s -p "azure::" /usr/bin/AducIotAgent    # sum all contributions from symbols that contain "azure::"
+
+  ${PROG_NAME} /usr/bin/AducIotAgent | tail -n 5        # print top 5 contributors to binary size
+EOF
+}
+
+SUM=0
+PATTERN=0
+ELF_FILEPATHS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    -p | --pattern)
+        shift
+        if [[ -z $1 || $1 == -* ]]; then
+            error "-p | --pattern requires value"
+            exit 1
+        fi
+        PATTERN="$1"
+        ;;
+
+    -s | --sum)
+        SUM=1
+        ;;
+
+    -h | --help)
+        usage
+        exit 0
+        ;;
+
+    --* | -*)
+        echo bad option "$1"
+        exit 1
+        ;;
+
+    *)
+        ELF_FILEPATHS+=("$1")
+        ;;
+    esac
+    shift
+done
+
+if [[ ${#ELF_FILEPATHS[@]} -eq 0 ]]; then
+    echo no elf binary filepaths specified.
+    exit 1
+fi
+
+IFS=
+for elf_filpath in "${ELF_FILEPATHS[@]}"; do
+    echo -e "\nProcessing $elf_filpath ...\n"
+
+    result="$(nm -C --print-size --size-sort --radix=d "$elf_filpath")"
+
+    if [[ -n $PATTERN ]]; then
+        result="$(echo "$result" | grep "${PATTERN}")"
+    fi
+
+    if [[ $SUM == 1 ]]; then
+        result="$(echo "$result" | awk '{print$2}' | awk '{s+=$1}END{print s}')"
+        echo Total usage in bytes:
+    fi
+
+    echo -e "$result\n"
+done

--- a/scripts/elf_size.sh
+++ b/scripts/elf_size.sh
@@ -3,6 +3,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+# set -x
+
 PROG_NAME=$0
 
 usage() {
@@ -14,6 +16,10 @@ Usage: ${PROG_NAME} [options] /path/to/elf/binary
 
   -s, --sum              Sum up the bytes of the matching ELF sections.
 
+  -b, --bss              Filter for BSS data section
+  -t, --text             Filter for TEXT (code) section
+  -w, --weak             Filter for weak symbols
+
   -h, --help             Show this help message.
 
 
@@ -23,11 +29,17 @@ Usage: ${PROG_NAME} [options] /path/to/elf/binary
   ${PROG_NAME} -s -p "azure::" /usr/bin/AducIotAgent    # sum all contributions from symbols that contain "azure::"
 
   ${PROG_NAME} /usr/bin/AducIotAgent | tail -n 5        # print top 5 contributors to binary size
+
+  ${PROG_NAME} --bss --text /usr/bin/AducIotAgent | tail -n 10   # print top ten BSS and TEXT
+  ${PROG_NAME} --sum --weak -p "Azure::" /usr/bin/AducIotAgent   # sum footprint usage of only WEAK symbols that contain "Azure::"
 EOF
 }
 
+PATTERN=
 SUM=0
-PATTERN=0
+TEXT=0
+BSS=0
+WEAK=0
 ELF_FILEPATHS=()
 
 while [[ $# -gt 0 ]]; do
@@ -43,6 +55,18 @@ while [[ $# -gt 0 ]]; do
 
     -s | --sum)
         SUM=1
+        ;;
+
+    -b | --bss)
+        BSS=1
+        ;;
+
+    -t | --text)
+        TEXT=1
+        ;;
+
+    -w | --weak)
+        WEAK=1
         ;;
 
     -h | --help)
@@ -73,13 +97,43 @@ for elf_filpath in "${ELF_FILEPATHS[@]}"; do
 
     result="$(nm -C --print-size --size-sort --radix=d "$elf_filpath")"
 
+    section_filter=""
+    if [[ $TEXT == 1 ]]; then
+        echo "Filtering for TEXT(code) section - " t " or " T " in nm output..."
+        section_filter='t|T'
+    fi
+
+    if [[ $BSS == 1 ]]; then
+        echo "Filtering for BSS data section - " b " or " B " in nm output..."
+        if [[ -n $section_filter ]]; then
+            section_filter="$section_filter|b|B"
+        else
+            section_filter='b|B'
+        fi
+    fi
+
+    if [[ $WEAK == 1 ]]; then
+        echo "Filtering for undefined symbols - " w " or " W " in nm output..."
+        if [[ -n $section_filter ]]; then
+            section_filter="$section_filter|w|W"
+        else
+            section_filter='w|W'
+        fi
+    fi
+
+    if [[ $TEXT == 1 || $BSS == 1 || $WEAK == 1 ]]; then
+        # match column 3 against the section_filter regex and print $0, the entire line.
+        awk_expr="\$3~/($section_filter)/ {print \$0}"
+        result="$(echo "$result" | awk "$awk_expr")"
+    fi
+
     if [[ -n $PATTERN ]]; then
         echo Pattern: "$PATTERN"
         result="$(echo "$result" | grep "${PATTERN}")"
     fi
 
     if [[ $SUM == 1 ]]; then
-        result="$(echo "$result" | awk '{print$2}' | awk '{s+=$1}END{print s}')"
+        result="$(echo "$result" | awk '{print $2}' | awk '{s+=$1}END{print s}')"
         echo Total usage in bytes:
     fi
 


### PR DESCRIPTION
# Useful script for printing symbols and their sizes in ELF binaries
## Usage
```sh
./scripts/elf_size.sh -h

Usage: ./scripts/elf_size.sh [options] /path/to/elf/binary

  -p, --pattern          pattern of nm line output such as in symbol name.

  -s, --sum              Sum up the bytes of the matching ELF sections.

  -b, --bss              Filter for BSS data section
  -t, --text             Filter for TEXT (code) section
  -w, --weak             Filter for weak symbols

  -h, --help             Show this help message.


  Examples:

  ./scripts/elf_size.sh -s -p zlog /usr/bin/AducIotAgent         # sum all contributions to ELF size for zlog library
  ./scripts/elf_size.sh -s -p "azure::" /usr/bin/AducIotAgent    # sum all contributions from symbols that contain "azure::"

  ./scripts/elf_size.sh /usr/bin/AducIotAgent | tail -n 5        # print top 5 contributors to binary size

  ./scripts/elf_size.sh --bss --text /usr/bin/AducIotAgent | tail -n 10   # print top ten BSS and TEXT
  ./scripts/elf_size.sh --sum --weak -p "Azure::" /usr/bin/AducIotAgent   # sum footprint usage of only WEAK symbols that contain "Azure::"

```

## Find sum of all symbols that contain "zlog" in AducIotAgent binary
```sh
./scripts/elf_size.sh --sum --pattern zlog /usr/bin/AducIotAgent

Processing /usr/bin/AducIotAgent ...

Pattern: zlog
Total usage in bytes:
528086
```

## Show all zlog symbol sizes in TEXT section
```sh
./scripts/elf_size.sh --text --pattern zlog /usr/bin/AducIotAgent

Processing /usr/bin/AducIotAgent ...

Filtering for TEXT(code) section -  t  or  T  in nm output...
Pattern: zlog
0000000001823359 0000000000000012 t zlog_finish_buffer_and_unlock
0000000001822670 0000000000000019 t _zlog_buffer_lock
0000000001822689 0000000000000019 t _zlog_buffer_unlock
0000000001819766 0000000000000023 t zlog_is_file_log_open
0000000001820755 0000000000000026 T zlog_flush_buffer
0000000001819840 0000000000000040 t zlog_is_stdout_a_tty
0000000001819789 0000000000000051 t zlog_close_file_log
0000000001820781 0000000000000056 T zlog_finish
0000000001823287 0000000000000072 t zlog_lock_and_get_buffer
0000000001823105 0000000000000182 t _zlog_flush_buffer
0000000001822913 0000000000000192 t _zlog_roll_over_if_file_size_too_large
0000000001819880 0000000000000255 t zlog_term_supports_color
0000000001823371 0000000000000395 T zlog_ensure_at_most_n_logfiles
0000000001820135 0000000000000620 T zlog_init
0000000001820837 0000000000001760 T zlog_log
```
