### PR TITLE
added handling to restart adu in case of "unauthenticated:no network"

### DIFF
--- a/src/communication_managers/iothub_communication_manager/CMakeLists.txt
+++ b/src/communication_managers/iothub_communication_manager/CMakeLists.txt
@@ -19,7 +19,8 @@ find_package (umqtt REQUIRED)
 target_link_libraries (
     ${PROJECT_NAME}
     PUBLIC aduc::adu_types
-    PRIVATE aduc::communication_abstraction
+    PRIVATE aduc::adu_core_export_helpers
+            aduc::communication_abstraction
             aduc::config_utils
             aduc::c_utils
             aduc::eis_utils

--- a/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
+++ b/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
@@ -5,6 +5,7 @@
  * @copyright Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
  */
+#include "aduc/adu_core_export_helpers.h" // ADUC_MethodCall_RestartAgent
 #include "aduc/adu_types.h"
 #include "aduc/client_handle_helper.h"
 #include "aduc/config_utils.h"
@@ -725,9 +726,14 @@ static void Connection_Maintenance()
             additionalDelayInSeconds = TIME_SPAN_FIVE_MINUTES_IN_SECONDS;
             break;
         case IOTHUB_CLIENT_CONNECTION_NO_NETWORK:
-            // Could be transient error, wait for at least 5 minutes to retry.
+            // 1) try to restart agent to prevent empty reported properties in module twin 
+            // 2) if restart agent could not be performed, wait for at least 5 minutes to retry.
             Log_Error("No network.");
-            additionalDelayInSeconds = TIME_SPAN_FIVE_MINUTES_IN_SECONDS;
+            if (ADUC_MethodCall_RestartAgent() != 0)
+            {
+                additionalDelayInSeconds = TIME_SPAN_FIVE_MINUTES_IN_SECONDS;
+                Log_Error("Agent restart attempt failed.");
+            }
             break;
 
         case IOTHUB_CLIENT_CONNECTION_COMMUNICATION_ERROR:


### PR DESCRIPTION
Hi iot-hub-device-update Team,

Regarding issue 
https://github.com/Azure/iot-hub-device-update/issues/367 
and 
https://github.com/Azure/iot-hub-device-update/issues/212

i added a new handling for the communication handler in case of "unauthenticated " state with reason "no network".
I saw on multiple logs on my side that in case "no network" the module twin is empty for the reported properties items.
That could happen if the identity service re-provision the device. This PR should fix that behaviour.

new handling:
1) try to restart agent to prevent empty reported properties in module twin  
2) if restart agent could not be performed, wait for at least 5 minutes to retry.