### PR TITLE
null terminate after strncpy of jws header (#417)

### DIFF
--- a/src/utils/jws_utils/src/jws_utils.c
+++ b/src/utils/jws_utils/src/jws_utils.c
@@ -219,6 +219,7 @@ static bool ExtractJWSHeader(const char* jws, char** header)
     }
 
     strncpy(tempHeader, jws, headerLen);
+    tempHeader[headerLen] = '\0';
     success = true;
 
 done:


### PR DESCRIPTION
- Cherry-Pick the following commit to main from develop branch: https://github.com/Azure/iot-hub-device-update/commit/e40b7e3d611d7fe9d6af99af325eb550ff0d5c49
- Originally reported by github issue https://github.com/Azure/iot-hub-device-update/issues/406