### PR TITLE
Packer template for DeltaUpdate-Gen docker image and Run Script

### DIFF
--- a/azurepipelines/e2e_test/packer/deltagen/README.md
+++ b/azurepipelines/e2e_test/packer/deltagen/README.md
@@ -1,0 +1,50 @@
+# DeviceUpdate Docker Image to Generate Microsoft Delta Update SWUpdate Diff Payload
+
+## Overview
+
+The hcl2 file in this dir for easily creating and maintaining reproducible
+builds of the docker image that is used in the e2e test pipeline to generate
+delta update payload. The tool used is
+[Hashicorp Packer](https://developer.hashicorp.com/packer).
+
+The scripts run by packer on the base container to set up the container image
+are located in the `scripts/` directory (excluding run.sh)
+
+## Requirements Before Running Packer
+
+The working dir, `/opt/adu/` needs to have a linux64-diffgen-tool.zip that is created from
+building
+[iot-hub-device-update-delta](https://github.com/iot-hub-device-update-delta)
+
+The path to the zip on the host can be overridden by overriding the `diffgen_tool_zip_filepath` variable can be done as per the
+[assigning variables documentation](https://developer.hashicorp.com/packer/guides/hcl/variables#assigning-variables).
+
+## Install Hashicorp Packer
+
+Install packer using the [packer docs](https://developer.hashicorp.com/packer/tutorials/docker-get-started/get-started-install-cli).
+
+## Initialize Packer
+
+In this dir, run:
+
+```sh
+packer init .
+```
+
+## Build Docker Image using Packer
+
+```sh
+packer build .
+```
+
+## Confirm Existence in Docker Images
+
+```sh
+docker images
+```
+
+## Run Container to Generate Delta Update Payload
+
+```sh
+./scripts/run.sh <URL to source .swu> <URL to target .swu> /path/to/output/dir
+```

--- a/azurepipelines/e2e_test/packer/deltagen/deviceupdate-deltagen.pkr.hcl
+++ b/azurepipelines/e2e_test/packer/deltagen/deviceupdate-deltagen.pkr.hcl
@@ -1,0 +1,64 @@
+packer {
+    required_plugins {
+        docker = {
+            version = ">= 0.0.7"
+            source  = "github.com/hashicorp/docker"
+        }
+    }
+}
+
+variable "docker_tag" {
+    type    = string
+    default = "latest"
+}
+
+variable "diffgen_tool_zip_filepath" {
+    type    = string
+    default = "/opt/adu/linux64-diffgen-tool.zip"
+}
+
+source "docker" "ubuntu-focal" {
+    image  = "ubuntu:focal"
+    commit = true
+    pull = true
+    changes = [
+        "ENTRYPOINT [\"/tmp/generate-delta.sh\"]"
+    ]
+}
+
+build {
+    name = "deviceupdate-deltagen"
+    sources = [
+        "source.docker.ubuntu-focal",
+    ]
+
+    provisioner "file" {
+        source = "scripts/generate-delta.sh"
+        destination = "/tmp/generate-delta.sh"
+    }
+
+    provisioner "file" {
+        source = "scripts/install-prereqs.sh"
+        destination = "/tmp/install-prereqs.sh"
+    }
+
+    provisioner "file" {
+        source = var.diffgen_tool_zip_filepath
+        destination = "/tmp/linux64-diffgen-tool.zip"
+    }
+
+    provisioner "shell" {
+        scripts = [
+            "scripts/configure-apt-repo.sh",
+            "scripts/install-prereqs.sh",
+            "scripts/install-diffgen-tool.sh",
+        ]
+    }
+
+    post-processor "docker-tag" {
+        repository = "dudeltagen"
+        tags = ["ubuntu-focal", var.docker_tag]
+        only = ["docker.ubuntu-focal"]
+    }
+}
+

--- a/azurepipelines/e2e_test/packer/deltagen/scripts/configure-apt-repo.sh
+++ b/azurepipelines/e2e_test/packer/deltagen/scripts/configure-apt-repo.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+#
+# Taken from the following but with sudo removed:
+# https://learn.microsoft.com/en-us/windows-server/administration/linux-package-repository-for-microsoft-software#examples
+#
+apt-get update || exit 1
+apt-get install -y curl wget sudo || exit 1
+
+# PMC APT repo config for use by .net core 6 sdk install
+wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb || exit 1
+dpkg -i packages-microsoft-prod.deb || exit 1
+rm packages-microsoft-prod.deb
+
+# Install repository configuration
+curl -sSL https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/microsoft-prod.list || exit 1
+
+# Install Microsoft GPG public key
+curl -sSL https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc || exit 1
+
+# Update package index files
+apt-get update || exit 1

--- a/azurepipelines/e2e_test/packer/deltagen/scripts/generate-delta.sh
+++ b/azurepipelines/e2e_test/packer/deltagen/scripts/generate-delta.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+#
+# Runs the Delta Generation Tool using the private key at
+# /deltaoutput/priv.pem to generate the delta.dat in the same directory.
+#
+# Expected input files:
+# /deltaoutput/src.swu
+# /deltaoutput/tgt.swu
+#
+# Outputs upon success:
+# /deltaoutput/tgt-recompressed.swu - The new tgt.swu that has its ext-fs
+#                                     disk img recompressed using the ZSTD
+#                                     compression and an sw-description file
+#                                     within the .swu CPIO archive that has
+#                                     been resigned due to the changing hash
+#                                     of the recompressed disk image.
+#
+# /deltaoutput/delta.dat            - The resultant delta file that has
+#                                     microsoft delta recipe opcodes for the
+#                                     libadudiffapi.so to apply the diff to
+#                                     the src.swu that will be in the source
+#                                     cache dir on the device receiving delta
+#                                     updates.
+#
+
+base_dir="linux64-diffgen-tool"
+
+io_dir="/deltaoutput"
+delta_filepath="$io_dir/delta.dat"
+log_dir="$io_dir/DiffGenTool_Logs"
+work_dir="$io_dir/DiffGenTool_Work"
+recompressed_target_swu_filepath="$io_dir/tgt-recompressed.swu"
+
+mkdir -p "$log_dir" || exit 1
+mkdir -p "$work_dir" || exit 1
+
+cd "$base_dir" || exit 1
+
+# This is the usage. The 3rd form is what is used below.
+# Usage: DiffGenTool <source archive> <target archive> <output path> <log folder> <working folder>
+#        DiffGenTool <source archive> <target archive> <output path> <log folder> <working folder> <recompressed target archive>
+#        DiffGenTool <source archive> <target archive> <output path> <log folder> <working folder> <recompressed target archive> "<signing command>"
+
+./DiffGenTool \
+    "$io_dir/src.swu" \
+    "$io_dir/tgt.swu" \
+    "$delta_filepath" \
+    "$log_dir" \
+    "$work_dir" \
+    "$recompressed_target_swu_filepath" \
+    'openssl dgst -sign /deltaoutput/priv.pem -keyform PEM -sha256 -out sw-description.sig -binary' \
+    || exit 1

--- a/azurepipelines/e2e_test/packer/deltagen/scripts/install-diffgen-tool.sh
+++ b/azurepipelines/e2e_test/packer/deltagen/scripts/install-diffgen-tool.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+unzip /tmp/linux64-diffgen-tool.zip
+
+base_dir="linux64-diffgen-tool"
+
+files="
+ zstd_compress_file
+ working_folder_manager.py
+ sign_tool.py
+ recompress_tool.py
+ recompress_and_sign_tool.py
+ helpers.py
+ dumpextfs
+ dumpdiff
+ compress_files.py
+ bspatch
+ bsdiff
+ applydiff
+ DiffGenTool
+ "
+for x in $files; do
+    chmod 755 "${base_dir}/$x"
+done
+
+cp "${base_dir}/libadudiffapi.so" /usr/local/lib/
+ldconfig -v /usr/local/lib/libadudiffapi.so

--- a/azurepipelines/e2e_test/packer/deltagen/scripts/install-prereqs.sh
+++ b/azurepipelines/e2e_test/packer/deltagen/scripts/install-prereqs.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+apt-get install -y git
+apt-get install -y \
+    apt-utils \
+    curl \
+    openssl \
+    unzip \
+    || exit 1
+
+# Install .net core 5.0 sdk for Delta Generation Tool
+
+# First install tzdata dep non-interactively to prevent interactive blocking
+DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata || exit 1
+dpkg-reconfigure -f noninteractive tzdata || exit 1
+
+apt-get install -y dotnet-sdk-5.0 || exit 1

--- a/azurepipelines/e2e_test/packer/deltagen/scripts/run.sh
+++ b/azurepipelines/e2e_test/packer/deltagen/scripts/run.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+#
+# To be run from docker host after running:
+# packer build .
+#
+
+usage() {
+    cat <<- EOS
+Usage: $(basename "$0") <src .swu URL> <tgt .swu URL> <output dir for delta file>
+  e.g. $(basename "$0") https://example.com/source.swu https://example.com/target.swu /path/to/host/outdir/for/delta/
+EOS
+
+    exit 1
+}
+
+test "$#" -eq 3 || usage
+
+docker_image=dudeltagen:latest
+
+SRC_SWU_URL="$1"
+TGT_SWU_URL="$2"
+HOST_DELTA_OUTPUT_DIR="$3"
+
+rm -rf /tmp/dockercp
+mkdir -p /tmp/dockercp || exit 1
+
+echo -e "\nDownloading Source .swu at $SRC_SWU_URL ..."
+wget -O "$HOST_DELTA_OUTPUT_DIR/src.swu" "$SRC_SWU_URL" || exit 1
+
+echo -e "\nDownloading Target .swu at $TGT_SWU_URL ..."
+wget -O "$HOST_DELTA_OUTPUT_DIR/tgt.swu" "$TGT_SWU_URL" || exit 1
+
+echo -e "\nRunning container with mount /deltaoutput bound to host's $HOST_DELTA_OUTPUT_DIR ..."
+docker run -it --rm --name deltagen \
+    -v "$HOST_DELTA_OUTPUT_DIR:/deltaoutput" \
+    ${docker_image} \
+    || exit 1
+
+echo -e "\nAll done!"


### PR DESCRIPTION
- Add packer hcl to facilitate building docker image for building DeltaUpdate payloads
- Add scripts in scripts dir are run during `packer build .` to get the docker image ready
- Add scripts/run.sh for running the container to build the delta from source/target .swu and priv.pem