### PR TITLE
Ubuntu Core Snap - AzIoTIdentity integration

### DIFF
--- a/snap/local/README.md
+++ b/snap/local/README.md
@@ -216,14 +216,12 @@ sudo snap connect azure-iot-identity:system-observe
 
 sudo snap connect azure-iot-identity:tpm 
 ```
-This guide will walk you through the process of configuring Azure IoT Edge using a `config.toml` file and creating a `testing.toml` file for identity management. 
+Here is the process of configuring AIS using a `config.toml` file and creating a `testing.toml` file for cloud identity creation. 
 
-First, create a new file named `.config.toml` in the home directory for your Azure IoT Edge Snap configuration. 
-
-Use the following command to set the configuration for the Azure IoT Edge Snap:
+Use the following commands:
 
 ```shell
-sudo snap set azure-iot-identity raw-config="$(cat ~/config.toml)"
+sudo snap set azure-iot-identity raw-config="$(cat /path/to/config.toml)"
 ```
 ```shell
 $ sudo cat testing.toml 
@@ -237,7 +235,7 @@ sudo chmod 0600 testing.toml
 
 sudo mv testing.toml /var/snap/azure-iot-identity/current/shared/config/aziot/identityd/config.d/testing.toml 
 ```
-then use the following command:
+then use the following command to connect Device Update and AIS:
 
 ```shell
 sudo snap connect deviceupdate-agent:identity-service azure-iot-identity:identity-service

--- a/snap/local/README.md
+++ b/snap/local/README.md
@@ -207,6 +207,42 @@ sudo snap connect deviceupdate-agent:snapd-control
 
 ```
 
+### Azure Identity Service Integration
+To connect to Azure Identity Service, install AIS with this command `sudo snap install --edge azure-iot-identity`, wiring it up with the following command,
+```shell
+sudo snap connect azure-iot-identity:log-observe 
+
+sudo snap connect azure-iot-identity:system-observe 
+
+sudo snap connect azure-iot-identity:tpm 
+```
+This guide will walk you through the process of configuring Azure IoT Edge using a `config.toml` file and creating a `testing.toml` file for identity management. 
+
+First, create a new file named `.config.toml` in the home directory for your Azure IoT Edge Snap configuration. 
+
+Use the following command to set the configuration for the Azure IoT Edge Snap:
+
+```shell
+sudo snap set azure-iot-identity raw-config="$(cat ~/config.toml)"
+```
+```shell
+$ sudo cat testing.toml 
+[[principal]] 
+uid = <REPLACE WITH uid> 
+name = "testing" 
+idtype = ["module"] 
+
+sudo chown root:root testing.toml 
+sudo chmod 0600 testing.toml 
+
+sudo mv testing.toml /var/snap/azure-iot-identity/current/shared/config/aziot/identityd/config.d/testing.toml 
+```
+then use the following command:
+
+```shell
+sudo snap connect deviceupdate-agent:identity-service azure-iot-identity:identity-service
+```
+
 Verify that connections are ok:
 
 ```shell
@@ -216,6 +252,7 @@ Interface                              Plug                                     
 content[deviceupdate-agent-downloads]  deliveryoptimization-client:deviceupdate-agent-downloads  deviceupdate-agent:downloads-folder          manual
 content[do-configs]                    deviceupdate-agent:do-configs                             deliveryoptimization-client:do-configs       manual
 content[do-port-numbers]               deviceupdate-agent:do-port-numbers                        deliveryoptimization-client:do-port-numbers  manual
+content[aziot-identity-service]        deviceupdate-agent:identity-service                       azure-iot-identity:identity-service          manual
 home                                   deviceupdate-agent:home                                   :home                                        -
 network                                deviceupdate-agent:network                                :network                                     -
 snapd-control                          deviceupdate-agent:snapd-control                          -                                            -

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -196,6 +196,12 @@ plugs:
   snapd-control:
     interface: snapd-control
 
+  identity-service:
+    interface: content
+    content: aziot-identity-service
+    target: $SNAP_DATA
+
+
 
 # Provides resources to be accssed by other snaps.
 slots:
@@ -235,3 +241,9 @@ layout:
 # curl command
   /usr/bin/curl-downloader:
     symlink: $SNAP/usr/bin/curl
+# aziot config
+  /etc/aziot:
+    symlink: $SNAP_DATA/shared/config/aziot
+# aziot sockets
+  /var/sockets/aziot:
+    symlink: $SNAP_DATA/shared/sockets/aziot

--- a/src/utils/eis_utils/CMakeLists.txt
+++ b/src/utils/eis_utils/CMakeLists.txt
@@ -19,6 +19,11 @@ target_link_libraries (
             aziotsharedutil
             uhttp)
 
+target_compile_definitions (
+    ${PROJECT_NAME}
+    PRIVATE ADUC_BUILD_SNAP="${ADUC_BUILD_SNAP}"
+)
+
 if (ADUC_BUILD_UNIT_TESTS)
     find_package (umock_c REQUIRED CONFIG)
     target_link_libraries (${PROJECT_NAME} PRIVATE umock_c)

--- a/src/utils/eis_utils/src/eis_coms.c
+++ b/src/utils/eis_utils/src/eis_coms.c
@@ -32,17 +32,29 @@
 /**
  * @brief Unix Domain Socket (UDS) for the Identity Service API
  */
-#define EIS_UDS_IDENTITY_SOCKET_PATH "/run/aziot/identityd.sock"
+#ifdef ADUC_BUILD_SNAP
+#    define EIS_UDS_IDENTITY_SOCKET_PATH "/var/sockets/aziot/identityd.sock"
+#else
+#    define EIS_UDS_IDENTITY_SOCKET_PATH "/run/aziot/identityd.sock"
+#endif
 
 /**
  * @brief Unix Domain Socket (UDS) for the KeyServices API
  */
-#define EIS_UDS_SIGN_SOCKET_PATH "/run/aziot/keyd.sock"
+#ifdef ADUC_BUILD_SNAP
+#    define EIS_UDS_SIGN_SOCKET_PATH "/var/sockets/aziot/keyd.sock"
+#else
+#    define EIS_UDS_SIGN_SOCKET_PATH "/run/aziot/keyd.sock"
+#endif
 
 /**
  * @brief Unix Domain Socket (UDS) for the Certificate API
  */
-#define EIS_UDS_CERT_SOCKET_PATH "/run/aziot/certd.sock"
+#ifdef ADUC_BUILD_SNAP
+#    define EIS_UDS_CERT_SOCKET_PATH "/var/sockets/aziot/certd.sock"
+#else
+#    define EIS_UDS_CERT_SOCKET_PATH "/run/aziot/certd.sock"
+#endif
 
 /**
  * @brief EIS API version for all calls to EIS


### PR DESCRIPTION
[Bug 43844560](https://microsoft.visualstudio.com/OS/_workitems/edit/43844560): Setting euid with Strict Confinement in Snap, for AIS & DU integration

This full AIS integration is blocked by the strict confinement restriction.
Right now this can still work, with detailed documentation, but this is not the appropriate designed communication mechanism between AIS and DU