### PR TITLE
Fix FormatFilePathHelper off by one for trailing fwd slash

### DIFF
--- a/src/utils/system_utils/CMakeLists.txt
+++ b/src/utils/system_utils/CMakeLists.txt
@@ -18,8 +18,8 @@ find_package (azure_c_shared_utility REQUIRED)
 set_property (TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries (
     ${PROJECT_NAME}
-    PUBLIC aduc::c_utils
-    PRIVATE aduc::logging aziotsharedutil)
+    PUBLIC aduc::c_utils aziotsharedutil
+    PRIVATE aduc::logging)
 
 target_compile_definitions (${PROJECT_NAME} PRIVATE ADUC_FILE_GROUP="${ADUC_FILE_GROUP}"
                                                     ADUC_FILE_USER="${ADUC_FILE_USER}")

--- a/src/utils/system_utils/inc/aduc/system_utils.h
+++ b/src/utils/system_utils/inc/aduc/system_utils.h
@@ -9,6 +9,7 @@
 #define ADUC_SYSTEM_UTILS_H
 
 #include <aduc/c_utils.h>
+#include <azure_c_shared_utility/strings.h>
 #include <stdbool.h>
 #include <sys/types.h>
 
@@ -58,6 +59,8 @@ bool SystemUtils_IsFile(const char* path, int* err);
 
 int SystemUtils_ForEachDir(
     const char* baseDir, const char* excludeDir, ADUC_SystemUtils_ForEachDirFunctor* perDirActionFunctor);
+
+bool ADUC_SystemUtils_FormatFilePathHelper(STRING_HANDLE* newFilePath, const char* filePath, const char* dirPath);
 
 EXTERN_C_END
 

--- a/src/utils/system_utils/src/system_utils.c
+++ b/src/utils/system_utils/src/system_utils.c
@@ -393,7 +393,7 @@ bool ADUC_SystemUtils_FormatFilePathHelper(STRING_HANDLE* newFilePath, const cha
     STRING_HANDLE tempHandle = STRING_new();
 
     bool needForwardSlash = false;
-    if (dirPath[dirPathSize - 2] != '/')
+    if (dirPath[dirPathSize - 1] != '/')
     {
         needForwardSlash = true;
     }

--- a/src/utils/system_utils/tests/CMakeLists.txt
+++ b/src/utils/system_utils/tests/CMakeLists.txt
@@ -13,7 +13,12 @@ find_package (Catch2 REQUIRED)
 
 add_executable (${PROJECT_NAME} ${sources})
 
-target_link_libraries (${PROJECT_NAME} PRIVATE aduc::file_utils aduc::system_utils Catch2::Catch2)
+target_link_libraries (
+    ${PROJECT_NAME}
+    PRIVATE aduc::file_utils
+            aduc::string_utils
+            aduc::system_utils
+            Catch2::Catch2)
 
 include (CTest)
 include (Catch)

--- a/src/utils/system_utils/tests/system_utils_ut.cpp
+++ b/src/utils/system_utils/tests/system_utils_ut.cpp
@@ -10,6 +10,7 @@ using Catch::Matchers::Equals;
 
 #include "aduc/system_utils.h"
 #include <aduc/auto_opendir.hpp>
+#include <aduc/string_handle_wrapper.hpp>
 #include <sys/stat.h>
 #include <vector>
 
@@ -462,5 +463,34 @@ TEST_CASE_METHOD(TestCaseFixture, "SystemUtils_ForEachDir")
                 CreateCallRecord("subdir1"),
                 CreateCallRecord("subdir2"),
             });
+    }
+}
+
+TEST_CASE("ADUC_SystemUtils_FormatFilePathHelper")
+{
+    SECTION("ADUC_SystemUtils_FormatFilePathHelper without trailing forward slash")
+    {
+        const char* filePath = "/path/to/file.ext";
+        const char* dirPath = "/path/to/folder";
+
+        ADUC::StringUtils::STRING_HANDLE_wrapper newFilePath{ nullptr };
+
+        REQUIRE(ADUC_SystemUtils_FormatFilePathHelper(newFilePath.address_of(), filePath, dirPath));
+        REQUIRE_FALSE(newFilePath.is_null());
+
+        CHECK_THAT(STRING_c_str(newFilePath.get()), Equals("/path/to/folder/file.ext"));
+    }
+
+    SECTION("ADUC_SystemUtils_FormatFilePathHelper with trailing forward slash")
+    {
+        const char* filePath = "/path/to/file.ext";
+        const char* dirPath = "/path/to/folder/";
+
+        ADUC::StringUtils::STRING_HANDLE_wrapper newFilePath{ nullptr };
+
+        REQUIRE(ADUC_SystemUtils_FormatFilePathHelper(newFilePath.address_of(), filePath, dirPath));
+        REQUIRE_FALSE(newFilePath.is_null());
+
+        CHECK_THAT(STRING_c_str(newFilePath.get()), Equals("/path/to/folder/file.ext"));
     }
 }


### PR DESCRIPTION
ado bug: [Bug 43590764](https://microsoft.visualstudio.com/OS/_workitems/edit/43590764): ADUC_SystemUtils_FormatFilePathHelper has incorrect offset

- Add unit tests for with and without trailing slash in dirPath
- Correct to be dirPathSize - 1