### PR TITLE
Add cmake fn to add test root keys only for debug builds

### DIFF
--- a/cmake/aduc_security.cmake
+++ b/cmake/aduc_security.cmake
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Embeds the test root keys into the target binary if applicable.
+#
+# Inputs: target - The cmake target that may be affected.
+#
+# Dependencies: CMAKE_BUILD_TYPE - The build type factors into applicability decision.
+# Side-effects: When applicable, the target's compile definitions will be affected.
+#
+function (embed_test_root_keys_if_applicable target)
+    message (STATUS "  CMAKE_BUILD_TYPE is: " ${CMAKE_BUILD_TYPE})
+    if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
+        message (STATUS "Adding Test Root Keys for Debug Build.")
+
+        set (test_root_keys_flag -DBUILD_WITH_TEST_KEYS=1)
+        target_compile_definitions (${target} PRIVATE ${test_root_keys_flag})
+    endif ()
+endfunction ()

--- a/src/utils/crypto_utils/CMakeLists.txt
+++ b/src/utils/crypto_utils/CMakeLists.txt
@@ -18,10 +18,10 @@ set_property (TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries (
     ${PROJECT_NAME}
     PUBLIC aduc::c_utils
-    PRIVATE aziotsharedutil aduc::root_key_utils OpenSSL::Crypto )
+    PRIVATE aziotsharedutil aduc::root_key_utils OpenSSL::Crypto)
 
-# Always support test root keys.
-add_definitions (-DBUILD_WITH_TEST_KEYS=1)
+include (aduc_security)
+embed_test_root_keys_if_applicable (${PROJECT_NAME})
 
 if (ADUC_BUILD_UNIT_TESTS)
     add_subdirectory (tests)

--- a/src/utils/root_key_utils/CMakeLists.txt
+++ b/src/utils/root_key_utils/CMakeLists.txt
@@ -22,15 +22,13 @@ set_property (TARGET ${target_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries (
     ${target_name}
     PUBLIC aduc::c_utils aduc::crypto_utils aduc::rootkeypackage_utils
-    PRIVATE
-           aduc::logging aziotsharedutil)
+    PRIVATE aduc::logging aziotsharedutil)
 
+include (aduc_security)
+embed_test_root_keys_if_applicable (${target_name})
 
-# Always support test root keys.
-add_definitions (-DBUILD_WITH_TEST_KEYS=1)
-
-target_compile_definitions (${target_name}
-                            PRIVATE ADUC_ROOTKEY_STORE_PACKAGE_PATH="${ADUC_ROOTKEY_STORE_PACKAGE_PATH}")
+target_compile_definitions (
+    ${target_name} PRIVATE ADUC_ROOTKEY_STORE_PACKAGE_PATH="${ADUC_ROOTKEY_STORE_PACKAGE_PATH}")
 
 if (ADUC_BUILD_UNIT_TESTS)
     find_package (umock_c REQUIRED CONFIG)


### PR DESCRIPTION
- Add embed_test_root_keys_if_applicable cmake function into new security.cmake
- Invoke embed_test_root_keys_if_applicable instead of unconditionally including test root keys
- Ran cmake-format.sh
- Verified the following using `objdump -s out/src/utils/root_key_utils/CMakeFiles/root_key_utils.dir/src/root_key_lists.c.o`:
  - `--type=Debug`  has 2 retail *and 2 test keys*
  - `--type=RelWithDebInfo` has only 2 retail keys
  -   `--type=Relelease` has only 2 retail keys
  -   `--type=MinSizeRel` has only 2 retail keys