### PR TITLE
Fix logging for content downloader extensions

### DIFF
--- a/scripts/error_code_generator_defs/result_codes.json
+++ b/scripts/error_code_generator_defs/result_codes.json
@@ -652,6 +652,14 @@
               {
                 "name": "ADUC_ERC_CONTENT_DOWNLOADER_UNSUPPORTED_CONTRACT_VERSION",
                 "value": 13
+              },
+              {
+                "name": "ADUC_ERC_CONTENT_DOWNLOADER_ONDOWNLOADPROC_NOTIMP",
+                "value": 14
+              },
+              {
+                "name": "ADUC_ERC_CONTENT_DOWNLOADER_ONDOWNLOADENDPROC_NOTIMP",
+                "value": 15
               }
             ]
           },

--- a/src/adu-shell/src/main.cpp
+++ b/src/adu-shell/src/main.cpp
@@ -145,9 +145,7 @@ static int ParseLaunchArguments(const int argc, char** argv, ADUShell_LaunchArgu
             launchArgs->logFile = optarg;
             break;
 
-        // clang-format off
-        case 'l':
-        { // clang-format on
+        case 'l': {
             char* endptr;
             errno = 0; /* To distinguish success/failure after call */
             int64_t logLevel = strtol(optarg, &endptr, 10);

--- a/src/adu-shell/src/main.cpp
+++ b/src/adu-shell/src/main.cpp
@@ -49,7 +49,7 @@ namespace adushconst = Adu::Shell::Const;
  *
  * @return 0 if succeeded.
  */
-int ParseLaunchArguments(const int argc, char** argv, ADUShell_LaunchArguments* launchArgs)
+static int ParseLaunchArguments(const int argc, char** argv, ADUShell_LaunchArguments* launchArgs)
 {
     if (launchArgs == nullptr)
     {
@@ -145,8 +145,9 @@ int ParseLaunchArguments(const int argc, char** argv, ADUShell_LaunchArguments* 
             launchArgs->logFile = optarg;
             break;
 
+        // clang-format off
         case 'l':
-        {
+        { // clang-format on
             char* endptr;
             errno = 0; /* To distinguish success/failure after call */
             int64_t logLevel = strtol(optarg, &endptr, 10);
@@ -209,7 +210,7 @@ int ParseLaunchArguments(const int argc, char** argv, ADUShell_LaunchArguments* 
     return result;
 }
 
-void ShowChildProcessLogs(const std::string& output)
+static void ShowChildProcessLogs(const std::string& output)
 {
     if (!output.empty())
     {
@@ -227,7 +228,7 @@ void ShowChildProcessLogs(const std::string& output)
 /**
  * @brief Starts a child process for task(s) for a given update actions.
  */
-int ADUShell_Dowork(const ADUShell_LaunchArguments& launchArgs)
+static int ADUShell_Dowork(const ADUShell_LaunchArguments& launchArgs)
 {
     ADUShellTaskResult taskResult;
 
@@ -260,7 +261,7 @@ int ADUShell_Dowork(const ADUShell_LaunchArguments& launchArgs)
  * @return true if the process is either in the trusted Group, or is one of the adu shell trusted users.
  * @return false otherwise
  */
-bool ADUShell_PermissionCheck()
+static bool ADUShell_PermissionCheck()
 {
     bool isTrusted = false;
 

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -92,6 +92,7 @@ target_link_libraries (
             aduc::https_proxy_utils
             aduc::iothub_communication_manager
             aduc::logging
+            aduc::loggingmanager
             aduc::permission_utils
             aduc::pnp_helper
             aduc::system_utils

--- a/src/agent/src/main.c
+++ b/src/agent/src/main.c
@@ -25,6 +25,7 @@
 #include "aduc/permission_utils.h"
 #include "aduc/string_c_utils.h"
 #include "aduc/system_utils.h"
+#include "logging_manager.h"
 #include <azure_c_shared_utility/shared_util_options.h>
 #include <azure_c_shared_utility/threadapi.h> // ThreadAPI_Sleep
 #include <ctype.h>
@@ -235,7 +236,7 @@ ADUC_ExtensionRegistrationType GetRegistrationTypeFromArg(const char* arg)
  * -1 on failure,
  *  or positive index to argv index where additional args start on success with additional args.
  */
-int ParseLaunchArguments(const int argc, char** argv, ADUC_LaunchArguments* launchArgs)
+static int ParseLaunchArguments(const int argc, char** argv, ADUC_LaunchArguments* launchArgs)
 {
     int result = 0;
     memset(launchArgs, 0, sizeof(*launchArgs));
@@ -294,8 +295,9 @@ int ParseLaunchArguments(const int argc, char** argv, ADUC_LaunchArguments* laun
             launchArgs->iotHubTracingEnabled = true;
             break;
 
+        // clang-format off
         case 'l':
-        {
+        { // clang-format on
             unsigned int logLevel = 0;
             bool ret = atoui(optarg, &logLevel);
             if (!ret || logLevel < ADUC_LOG_DEBUG || logLevel > ADUC_LOG_ERROR)
@@ -397,6 +399,8 @@ int ParseLaunchArguments(const int argc, char** argv, ADUC_LaunchArguments* laun
     {
         ADUC_StringUtils_Trim(launchArgs->connectionString);
     }
+
+    LoggingManager_SetLogLevel(launchArgs->logLevel);
 
     return result;
 }

--- a/src/agent/src/main.c
+++ b/src/agent/src/main.c
@@ -295,9 +295,7 @@ static int ParseLaunchArguments(const int argc, char** argv, ADUC_LaunchArgument
             launchArgs->iotHubTracingEnabled = true;
             break;
 
-        // clang-format off
-        case 'l':
-        { // clang-format on
+        case 'l': {
             unsigned int logLevel = 0;
             bool ret = atoui(optarg, &logLevel);
             if (!ret || logLevel < ADUC_LOG_DEBUG || logLevel > ADUC_LOG_ERROR)

--- a/src/extensions/content_downloaders/curl_downloader/CMakeLists.txt
+++ b/src/extensions/content_downloaders/curl_downloader/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries (
     PRIVATE aduc::contract_utils
             aduc::hash_utils
             aduc::logging
+            aduc::loggingmanager
             aduc::process_utils)
 
 install (TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${ADUC_EXTENSIONS_INSTALL_FOLDER})

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
@@ -45,7 +45,7 @@ ADUC_Result Initialize(const char* initializeData)
  */
 ADUC_Result OnDownloadBegin()
 {
-    ADUC_Logging_Init(LoggingManager_GetLogLevel(), "do-content-downloader");
+    ADUC_Logging_Init(LoggingManager_GetLogLevel(), "curl-content-downloader");
     return ADUC_Result{ ADUC_GeneralResult_Success, 0 };
 }
 

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
@@ -9,8 +9,10 @@
 #include "curl_content_downloader.h" // for Download_curl
 #include <aduc/c_utils.h> // for EXTERN_C_BEGIN, EXTERN_C_END
 #include <aduc/contract_utils.h> // for ADUC_ExtensionContractInfo
+#include <aduc/logging.h>
 #include <aduc/types/download.h> // for ADUC_DownloadProgressCallback
 #include <aduc/types/update_content.h> // for ADUC_FileEntity
+#include <logging_manager.h>
 
 EXTERN_C_BEGIN
 
@@ -28,6 +30,15 @@ ADUC_Result Download(
     unsigned int timeoutInSeconds,
     ADUC_DownloadProgressCallback downloadProgressCallback)
 {
+    // JIT init since Initialize is called by main thread and
+    // each logging file per area is per-thread currently.
+    static bool logging_initialized = false;
+    if (!logging_initialized)
+    {
+        ADUC_Logging_Init(LoggingManager_GetLogLevel(), "curl-content-downloader");
+        logging_initialized = true;
+    }
+
     return Download_curl(entity, workflowId, workFolder, timeoutInSeconds, downloadProgressCallback);
 }
 

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
@@ -30,15 +30,6 @@ ADUC_Result Download(
     unsigned int timeoutInSeconds,
     ADUC_DownloadProgressCallback downloadProgressCallback)
 {
-    // JIT init since Initialize is called by main thread and
-    // each logging file per area is per-thread currently.
-    static bool logging_initialized = false;
-    if (!logging_initialized)
-    {
-        ADUC_Logging_Init(LoggingManager_GetLogLevel(), "curl-content-downloader");
-        logging_initialized = true;
-    }
-
     return Download_curl(entity, workflowId, workFolder, timeoutInSeconds, downloadProgressCallback);
 }
 
@@ -46,6 +37,26 @@ ADUC_Result Initialize(const char* initializeData)
 {
     UNREFERENCED_PARAMETER(initializeData);
     return { ADUC_GeneralResult_Success };
+}
+
+/**
+ * @brief Called on the worker context when execution is beginning.
+ *
+ */
+ADUC_Result OnDownloadBegin()
+{
+    ADUC_Logging_Init(LoggingManager_GetLogLevel(), "do-content-downloader");
+    return ADUC_Result{ ADUC_GeneralResult_Success, 0 };
+}
+
+/**
+ * @brief Called on the worker context when execution is ending.
+ *
+ */
+ADUC_Result OnDownloadEnd()
+{
+    ADUC_Logging_Uninit();
+    return ADUC_Result{ ADUC_GeneralResult_Success, 0 };
 }
 
 /**

--- a/src/extensions/content_downloaders/deliveryoptimization_downloader/CMakeLists.txt
+++ b/src/extensions/content_downloaders/deliveryoptimization_downloader/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries (
             aduc::contract_utils
             aduc::hash_utils
             aduc::logging
+            aduc::loggingmanager
             aduc::process_utils
             aduc::string_utils
             atomic

--- a/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
@@ -79,6 +79,26 @@ done:
 }
 
 /**
+ * @brief Called on the worker context when execution is beginning.
+ *
+ */
+ADUC_Result OnDownloadBegin()
+{
+    ADUC_Logging_Init(LoggingManager_GetLogLevel(), "do-content-downloader");
+    return ADUC_Result{ ADUC_GeneralResult_Success, 0 };
+}
+
+/**
+ * @brief Called on the worker context when execution is ending.
+ *
+ */
+ADUC_Result OnDownloadEnd()
+{
+    ADUC_Logging_Uninit();
+    return ADUC_Result{ ADUC_GeneralResult_Success, 0 };
+}
+
+/**
  * @brief The download export.
  *
  * @param entity The file entity.
@@ -95,15 +115,6 @@ ADUC_Result Download(
     unsigned int timeoutInSeconds,
     ADUC_DownloadProgressCallback downloadProgressCallback)
 {
-    // JIT init since Initialize is called by main thread and
-    // each logging file per area is per-thread currently.
-    static bool logging_initialized = false;
-    if (!logging_initialized)
-    {
-        ADUC_Logging_Init(LoggingManager_GetLogLevel(), "do-content-downloader");
-        logging_initialized = true;
-    }
-
     return do_download(entity, workflowId, workFolder, timeoutInSeconds, downloadProgressCallback);
 }
 

--- a/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
@@ -13,6 +13,7 @@
 #include <aduc/hash_utils.h>
 #include <aduc/logging.h>
 #include <aduc/types/adu_core.h>
+#include <logging_manager.h>
 
 #include <sys/stat.h> // for stat
 
@@ -94,6 +95,15 @@ ADUC_Result Download(
     unsigned int timeoutInSeconds,
     ADUC_DownloadProgressCallback downloadProgressCallback)
 {
+    // JIT init since Initialize is called by main thread and
+    // each logging file per area is per-thread currently.
+    static bool logging_initialized = false;
+    if (!logging_initialized)
+    {
+        ADUC_Logging_Init(LoggingManager_GetLogLevel(), "do-content-downloader");
+        logging_initialized = true;
+    }
+
     return do_download(entity, workflowId, workFolder, timeoutInSeconds, downloadProgressCallback);
 }
 

--- a/src/extensions/download_handlers/download_handler_factory/CMakeLists.txt
+++ b/src/extensions/download_handlers/download_handler_factory/CMakeLists.txt
@@ -20,7 +20,7 @@ target_link_libraries (
             aduc::download_handler_plugin
             aduc::extension_utils
             aduc::hash_utils
-            aduc::logging
+            aduc::loggingmanager
             aduc::parser_utils
             aduc::shared_lib)
 

--- a/src/extensions/download_handlers/download_handler_factory/src/download_handler_factory.cpp
+++ b/src/extensions/download_handlers/download_handler_factory/src/download_handler_factory.cpp
@@ -11,11 +11,11 @@
 #include <aduc/c_utils.h> // EXTERN_C_{BEGIN,END}
 #include <aduc/extension_utils.h> // GetDownloadHandlerFileEntity
 #include <aduc/hash_utils.h> // ADUC_HashUtils_VerifyWithStrongestHash
-#include <aduc/logging.h> // ADUC_Logging_GetLevel
 #include <aduc/parser_utils.h> // ADUC_FileEntity_Uninit
 #include <aduc/plugin_exception.hpp>
 #include <aduc/types/update_content.h> // ADUC_FileEntity
 #include <cstring> // memset
+#include <logging_manager.h>
 #include <unordered_map>
 
 using DownloadHandlerHandle = void*;
@@ -90,7 +90,7 @@ DownloadHandlerPlugin* DownloadHandlerFactory::LoadDownloadHandler(const std::st
     try
     {
         auto plugin = std::unique_ptr<DownloadHandlerPlugin>(
-            new DownloadHandlerPlugin(autoFileEntity->TargetFilename, ADUC_Logging_GetLevel()));
+            new DownloadHandlerPlugin(autoFileEntity->TargetFilename, LoggingManager_GetLogLevel()));
         cachedPlugins.insert(std::make_pair(downloadHandlerId, plugin.get()));
         return plugin.release();
     }

--- a/src/extensions/extension_manager/CMakeLists.txt
+++ b/src/extensions/extension_manager/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries (
             aduc::extension_utils
             aduc::hash_utils
             aduc::logging
+            aduc::loggingmanager
             aduc::parser_utils
             aduc::path_utils
             aduc::string_utils

--- a/src/extensions/extension_manager/src/extension_manager.cpp
+++ b/src/extensions/extension_manager/src/extension_manager.cpp
@@ -34,8 +34,6 @@
 #include <cstring>
 #include <unordered_map>
 
-// Note: this requires ${CMAKE_DL_LIBS}
-#include <dlfcn.h>
 #include <unistd.h>
 
 // type aliases
@@ -805,6 +803,32 @@ ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initialize
 
 done:
     return result;
+}
+
+ADUC_Result ExtensionManager::OnDownloadBegin()
+{
+    OnDownloadBeginProc proc{};
+    ADUC_Result result =
+        LoadContentDownloaderLibraryProc<decltype(proc)>(CONTENT_DOWNLOADER__OnDownloadBegin__EXPORT_SYMBOL, &proc);
+    if (IsAducResultCodeFailure(result.ResultCode))
+    {
+        return result;
+    }
+
+    return proc();
+}
+
+ADUC_Result ExtensionManager::OnDownloadEnd()
+{
+    OnDownloadEndProc proc{};
+    ADUC_Result result =
+        LoadContentDownloaderLibraryProc<decltype(proc)>(CONTENT_DOWNLOADER__OnDownloadEnd__EXPORT_SYMBOL, &proc);
+    if (IsAducResultCodeFailure(result.ResultCode))
+    {
+        return result;
+    }
+
+    return proc();
 }
 
 ADUC_Result ExtensionManager::Download(

--- a/src/extensions/inc/aduc/content_downloader_extension.hpp
+++ b/src/extensions/inc/aduc/content_downloader_extension.hpp
@@ -13,6 +13,8 @@
 EXTERN_C_BEGIN
 
 typedef ADUC_Result (*InitializeProc)(const char* initializeData);
+typedef ADUC_Result (*OnDownloadBeginProc)();
+typedef ADUC_Result (*OnDownloadEndProc)();
 
 typedef ADUC_Result (*DownloadProc)(
     const ADUC_FileEntity* entity,

--- a/src/extensions/inc/aduc/content_handler.hpp
+++ b/src/extensions/inc/aduc/content_handler.hpp
@@ -28,6 +28,16 @@ public:
     ContentHandler(ContentHandler&&) = delete;
     ContentHandler& operator=(ContentHandler&&) = delete;
 
+    virtual ADUC_Result OnDownloadBegin()
+    {
+        return ADUC_Result{ ADUC_GeneralResult_Success, 0 };
+    }
+
+    virtual ADUC_Result OnDownloadEnd()
+    {
+        return ADUC_Result{ ADUC_GeneralResult_Success, 0 };
+    }
+
     virtual ADUC_Result Download(const tagADUC_WorkflowData* workflowData) = 0;
     virtual ADUC_Result Backup(const tagADUC_WorkflowData* workflowData) = 0;
     virtual ADUC_Result Install(const tagADUC_WorkflowData* workflowData) = 0;

--- a/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
+++ b/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
@@ -27,6 +27,20 @@
 #define CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL "Initialize"
 
 /**
+ * @brief The OnDownloadBegin export.
+ * @return ADUC_Result The result.
+ *
+ */
+#define CONTENT_DOWNLOADER__OnDownloadBegin__EXPORT_SYMBOL "OnDownloadBegin"
+
+/**
+ * @brief The OnDownloadEnd export.
+ * @return ADUC_Result The result.
+ *
+ */
+#define CONTENT_DOWNLOADER__OnDownloadEnd__EXPORT_SYMBOL "OnDownloadEnd"
+
+/**
  * @brief The download export.
  *
  * @param entity The file entity.

--- a/src/extensions/update_manifest_handlers/steps_handler/inc/aduc/steps_handler.hpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/inc/aduc/steps_handler.hpp
@@ -28,6 +28,8 @@ public:
 
     ~StepsHandlerImpl() override;
 
+    ADUC_Result OnDownloadBegin() override;
+    ADUC_Result OnDownloadEnd() override;
     ADUC_Result Download(const tagADUC_WorkflowData* workflowData) override;
     ADUC_Result Backup(const tagADUC_WorkflowData* workflowData) override;
     ADUC_Result Install(const tagADUC_WorkflowData* workflowData) override;

--- a/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
@@ -676,6 +676,26 @@ done:
 }
 
 /**
+ * @brief Runs at the begin of download thread execution.
+ *
+ * @return ADUC_Result The result.
+ */
+ADUC_Result StepsHandlerImpl::OnDownloadBegin()
+{
+    return ExtensionManager::OnDownloadBegin();
+}
+
+/**
+ * @brief Runs at the end of download thread execution.
+ *
+ * @return ADUC_Result The result.
+ */
+ADUC_Result StepsHandlerImpl::OnDownloadEnd()
+{
+    return ExtensionManager::OnDownloadEnd();
+}
+
+/**
  * @brief Performs 'Download' task by iterating through all steps and invoke each step's handler
  * to download file(s), if needed.
  *

--- a/src/logging/CMakeLists.txt
+++ b/src/logging/CMakeLists.txt
@@ -21,3 +21,5 @@ elseif (ADUC_LOGGING_LIBRARY STREQUAL "zlog")
 else ()
     message (FATAL_ERROR "Unknown logging library ${ADUC_LOGGING_LIBRARY} specified.")
 endif ()
+
+add_subdirectory (manager)

--- a/src/logging/inc/aduc/logging.h
+++ b/src/logging/inc/aduc/logging.h
@@ -40,7 +40,6 @@ typedef enum tagADUC_LOG_SEVERITY
 // These are implemented for each logging library.
 void ADUC_Logging_Init(ADUC_LOG_SEVERITY logLevel, const char* filePrefix);
 void ADUC_Logging_Uninit();
-ADUC_LOG_SEVERITY ADUC_Logging_GetLevel();
 
 /**
  * @brief Detailed informational events that are useful to debug an application.
@@ -75,7 +74,6 @@ ADUC_LOG_SEVERITY ADUC_Logging_GetLevel();
 // These are implemented for each logging library.
 #    define ADUC_Logging_Init(...)
 #    define ADUC_Logging_Uninit(...)
-#    define ADUC_Logging_GetLevel(...) (0)
 
 /**
  * @brief Detailed informational events that are useful to debug an application.

--- a/src/logging/manager/CMakeLists.txt
+++ b/src/logging/manager/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required (VERSION 3.5)
+
+set (target_name loggingmanager)
+
+add_library (${target_name} STATIC)
+add_library (aduc::${target_name} ALIAS ${target_name})
+
+# Allow it to be used in a shared library
+set_property (TARGET ${target_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+target_include_directories (${target_name} PUBLIC inc ${ADUC_EXPORT_INCLUDES})
+target_sources (${target_name} PRIVATE src/logging_manager.cpp)
+target_link_libraries (${target_name} PUBLIC aduc::c_utils aduc::logging)

--- a/src/logging/manager/inc/logging_manager.h
+++ b/src/logging/manager/inc/logging_manager.h
@@ -1,0 +1,33 @@
+/**
+ * @file logging_manager.h
+ * @brief The logging manager interface for accessors of global settings for logging.
+ *
+ * @copyright Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+#ifndef LOGGING_MANAGER_H
+#define LOGGING_MANAGER_H
+
+#include <aduc/c_utils.h>
+#include <aduc/logging.h>
+
+EXTERN_C_BEGIN
+
+/**
+ * @brief Sets the log level.
+ *
+ * @param log_level The log level.
+ */
+void LoggingManager_SetLogLevel(ADUC_LOG_SEVERITY log_level);
+
+/**
+ * @brief Gets the log level.
+ *
+ * @return ADUC_LOG_SEVERITY The log level.
+ */
+ADUC_LOG_SEVERITY LoggingManager_GetLogLevel();
+
+EXTERN_C_END
+
+#endif // LOGGING_MANAGER_H

--- a/src/logging/manager/src/logging_manager.cpp
+++ b/src/logging/manager/src/logging_manager.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file logging_manager.cpp
+ * @brief The logging manager implementation for accessors of global settings for logging.
+ *
+ * @copyright Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+#include "logging_manager.h"
+
+class LoggingManager
+{
+public:
+    static LoggingManager& GetInstance()
+    {
+        static LoggingManager instance{};
+        return instance;
+    }
+
+    ADUC_LOG_SEVERITY get_log_level() const
+    {
+        return log_level;
+    }
+
+    void set_log_level(ADUC_LOG_SEVERITY sev)
+    {
+        log_level = sev;
+    }
+
+private:
+    LoggingManager()
+    {
+    }
+
+    ADUC_LOG_SEVERITY log_level = ADUC_LOG_INFO;
+};
+
+void LoggingManager_SetLogLevel(ADUC_LOG_SEVERITY log_level)
+{
+    LoggingManager::GetInstance().set_log_level(log_level);
+}
+
+ADUC_LOG_SEVERITY LoggingManager_GetLogLevel()
+{
+    return LoggingManager::GetInstance().get_log_level();
+}

--- a/src/logging/zlog/src/init.c
+++ b/src/logging/zlog/src/init.c
@@ -56,16 +56,13 @@ ADUC_LOG_SEVERITY ZLogLevelToAducLogSeverity(enum ZLOG_SEVERITY logLevel)
     }
 }
 
-ADUC_LOG_SEVERITY g_logLevel = ADUC_LOG_INFO;
-
 /**
- * @brief Initialize logging.
- * @param logLevel log level.
+ * @brief Initializes logging.
+ * @param logLevel The log level.
+ * @param filePrefix The file prefix.
  */
 void ADUC_Logging_Init(ADUC_LOG_SEVERITY logLevel, const char* filePrefix)
 {
-    g_logLevel = ADUC_LOG_INFO;
-
     // zlog_init doesn't create the log path, so attempt to create it here if it does not exist.
     // If it can't be created, zlogging will send output to console.
     struct stat st;
@@ -100,9 +97,4 @@ void ADUC_Logging_Init(ADUC_LOG_SEVERITY logLevel, const char* filePrefix)
 void ADUC_Logging_Uninit()
 {
     zlog_finish();
-}
-
-ADUC_LOG_SEVERITY ADUC_Logging_GetLevel()
-{
-    return g_logLevel;
 }

--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
@@ -115,15 +115,14 @@ static ContentHandler* GetUpdateManifestHandler(const ADUC_WorkflowData* workflo
             updateManifestVersion,
             updateManifestHandler.get());
 
-        loadResult =
-            ExtensionManager::LoadUpdateContentHandlerExtension(updateManifestHandler.get(), &contentHandler);
+        loadResult = ExtensionManager::LoadUpdateContentHandlerExtension(updateManifestHandler.get(), &contentHandler);
 
         // If handler for the current manifest version is not available,
         // fallback to the V4 default handler.
         if (IsAducResultCodeFailure(loadResult.ResultCode))
         {
-            loadResult = ExtensionManager::LoadUpdateContentHandlerExtension(
-                UPDATE_MANIFEST_DEFAULT_HANDLER, &contentHandler);
+            loadResult =
+                ExtensionManager::LoadUpdateContentHandlerExtension(UPDATE_MANIFEST_DEFAULT_HANDLER, &contentHandler);
         }
     }
     else
@@ -156,11 +155,23 @@ ADUC_Result LinuxPlatformLayer::Download(const ADUC_WorkflowData* workflowData)
         goto done;
     }
 
+    result = contentHandler->OnDownloadBegin();
+    if (IsAducResultCodeFailure(result.ResultCode))
+    {
+        goto done;
+    }
+
     result = contentHandler->Download(workflowData);
     if (_IsCancellationRequested)
     {
         result = ADUC_Result{ ADUC_Result_Failure_Cancelled };
         _IsCancellationRequested = false; // For replacement, we can't call Idle so reset here
+    }
+
+    result = contentHandler->OnDownloadEnd();
+    if (IsAducResultCodeFailure(result.ResultCode))
+    {
+        goto done;
     }
 
 done:


### PR DESCRIPTION
## Bug Fixed

Fixes [Bug 43440951](https://microsoft.visualstudio.com/OS/_workitems/edit/43440951): deliveryoptimization_content_downloader.cpp trace not showing up in log

## Changes

- Add logging_manager to remove g_log_level hackiness, set log level at agent main at time of parsing cmdline args, and to get log level without having to modify fn signatures.
- Add OnDownloadBegin and OnDownloadEnd for begin and end of download thread execution
- Init logging in curl and DO content downloader OnDownloadBegin export (since Initialize is called in main thread and Download is called in download thread and log file paths are 1-1 with threads) and Uninit logging in OnDownloadEnd export
- Override OnDownloadBegin and OnDownloadEnd in StepsHandler impl to plumb through to the exports in the content downloader and leave the other content handlers with default, noop virtual method.
- Change some functions not used outside of CU to be static to file

## Result

After the changes, the following file is seen after doing apt pkg update:

```sh
/var/log/adu$ cat do-content-downloader.20230328-020410.log

2023-03-28T02:04:10.8268Z 315409[315415] [I] [do_download] ==== MULTI-LINE LOG BEGIN ====
Downloading File 'apt-manifest.json' from 'http://jewelden2--jewelden2.b.nlu.dl.adu.microsoft.com/eastus/jewelden2--jewelden2/272aeacb92594d51a422ed8d60f3a0c5/apt-manifest.json' to '/var/lib/adu/downloads/5935ab72-9122-4b7a-9405-a5b860b9bd87/apt-manifest.json'2023-03-28T02:04:10.8268Z 315409[315415] [I] [do_download] ==== MULTI-LINE LOG END ====

2023-03-28T02:04:11.5878Z 315409[315415] [I] Validating file hash [do_download]
2023-03-28T02:04:11.5880Z 315409[315415] [I] Download resultCode: 500, extendedCode: 0 [do_download]
====

```