### PR TITLE
Move extern Default_ExtensionManager_Download_Options into header

### DIFF
--- a/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/utils/src/microsoft_delta_download_handler_utils.c
+++ b/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/utils/src/microsoft_delta_download_handler_utils.c
@@ -16,9 +16,6 @@
 #include <azure_c_shared_utility/strings.h> // STRING_*
 #include <stdlib.h> // free
 
-/* external linkage */
-extern ExtensionManager_Download_Options Default_ExtensionManager_Download_Options;
-
 EXTERN_C_BEGIN
 
 /**

--- a/src/extensions/extension_manager/inc/aduc/extension_manager_download_options.h
+++ b/src/extensions/extension_manager/inc/aduc/extension_manager_download_options.h
@@ -1,6 +1,8 @@
 #ifndef ADUC_EXTENSION_MANAGER_DOWNLOAD_OPTIONS_H
 #define ADUC_EXTENSION_MANAGER_DOWNLOAD_OPTIONS_H
 
+#include <aduc/c_utils.h>
+
 // Default Content Downloader Download Timeout of 8 hours.
 #define CONTENT_DOWNLOADER_MAX_TIMEOUT_IN_MINUTES_DEFAULT (8 * 60)
 
@@ -9,5 +11,9 @@ typedef struct tagADUC_ExtensionManager_Download_Options
     unsigned int
         timeoutInMinutes; /**< The maximum number of minutes the content downloader should wait for the download to complete(whilst the network interface stays up). */
 } ExtensionManager_Download_Options;
+
+EXTERN_C_BEGIN
+extern ExtensionManager_Download_Options Default_ExtensionManager_Download_Options;
+EXTERN_C_END
 
 #endif // #define ADUC_EXTENSION_MANAGER_DOWNLOAD_OPTIONS_H

--- a/src/extensions/extension_manager/src/extension_manager.cpp
+++ b/src/extensions/extension_manager/src/extension_manager.cpp
@@ -44,12 +44,6 @@ using GET_CONTRACT_INFO_PROC = ADUC_Result (*)(ADUC_ExtensionContractInfo* contr
 using WorkflowHandle = void*;
 using ADUC::StringUtils::cstr_wrapper;
 
-EXTERN_C_BEGIN
-ExtensionManager_Download_Options Default_ExtensionManager_Download_Options = {
-    CONTENT_DOWNLOADER_MAX_TIMEOUT_IN_MINUTES_DEFAULT /* timeoutInMinutes */
-};
-EXTERN_C_END
-
 // Static members.
 std::unordered_map<std::string, void*> ExtensionManager::_libs;
 std::unordered_map<std::string, ContentHandler*> ExtensionManager::_contentHandlers;

--- a/src/extensions/extension_manager/src/extension_manager_helper.cpp
+++ b/src/extensions/extension_manager/src/extension_manager_helper.cpp
@@ -15,6 +15,10 @@
 #include <aduc/string_c_utils.h>
 #include <aduc/workflow_utils.h>
 
+ExtensionManager_Download_Options Default_ExtensionManager_Download_Options = {
+    CONTENT_DOWNLOADER_MAX_TIMEOUT_IN_MINUTES_DEFAULT /* timeoutInMinutes */
+};
+
 /**
  * @brief Processes Download Handler extensibility for the downloadHandlerId in the file entity.
  *

--- a/src/extensions/step_handlers/apt_handler/src/apt_handler.cpp
+++ b/src/extensions/step_handlers/apt_handler/src/apt_handler.cpp
@@ -34,9 +34,6 @@
 
 namespace adushconst = Adu::Shell::Const;
 
-/* external linkage */
-extern ExtensionManager_Download_Options Default_ExtensionManager_Download_Options;
-
 EXTERN_C_BEGIN
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/extensions/step_handlers/script_handler/src/script_handler.cpp
+++ b/src/extensions/step_handlers/script_handler/src/script_handler.cpp
@@ -27,8 +27,6 @@ namespace adushconst = Adu::Shell::Const;
 
 EXTERN_C_BEGIN
 
-extern ExtensionManager_Download_Options Default_ExtensionManager_Download_Options;
-
 /////////////////////////////////////////////////////////////////////////////
 // BEGIN Shared Library Export Functions
 //

--- a/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
+++ b/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
@@ -43,8 +43,6 @@ namespace adushconst = Adu::Shell::Const;
 
 EXTERN_C_BEGIN
 
-extern ExtensionManager_Download_Options Default_ExtensionManager_Download_Options;
-
 /////////////////////////////////////////////////////////////////////////////
 // BEGIN Shared Library Export Functions
 //

--- a/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
+++ b/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
@@ -37,9 +37,6 @@
 
 namespace adushconst = Adu::Shell::Const;
 
-/* external linkage */
-extern ExtensionManager_Download_Options Default_ExtensionManager_Download_Options;
-
 struct JSONValueDeleter
 {
     void operator()(JSON_Value* value)

--- a/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
@@ -31,8 +31,6 @@ using ADUC::StringUtils::cstr_wrapper;
 
 #define DEFAULT_REF_STEP_HANDLER "microsoft/steps:1"
 
-extern ExtensionManager_Download_Options Default_ExtensionManager_Download_Options;
-
 /**
  * @brief Check whether to show additional debug logs.
  *


### PR DESCRIPTION
[Bug 42998192](https://microsoft.visualstudio.com/OS/_workitems/edit/42998192): Why isn't Default_ExtensionManager_Download_Options extern in extension_manager.hpp ?