### PR TITLE
Fix Bug: Connection retry uses fuzzy math (perhaps just a tracing issue?)

### DIFF
--- a/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
+++ b/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
@@ -222,10 +222,11 @@ void IoTHub_CommunicationManager_ConnectionStatus_Callback(
         }
         else
         {
+            int time_until_next_retry = g_next_authentication_attempt_time - now_time;
             Log_Error(
                 "IoTHub connection is broken for %d seconds (will retry in %d seconds)",
                 now_time - g_first_unauthenticated_time,
-                g_next_authentication_attempt_time - now_time);
+                time_until_next_retry);
         }
         break;
     }


### PR DESCRIPTION
Bug: The `g_next_authentication_attempt_time` variable is updated in the `Connection_Maintenance` function, but the `IoTHub_CommunicationManager_ConnectionStatus_Callback` function may not always be in sync with the latest value of `g_next_authentication_attempt_time`. This can cause a discrepancy between the actual time until the next authentication attempt and the time reported in the log message.