### PR TITLE
[PENDING]Fix Bug: install-deps.sh needs update to new DO tag for ubuntu 20.04 /usr symlink libboost issue

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -72,7 +72,7 @@ install_githooks=false
 
 du_test_data_dir_path="/tmp/adu/"
 # DO Deps
-default_do_ref=v1.0.1
+default_do_ref=v1.0.2
 install_do=false
 do_ref=$default_do_ref
 


### PR DESCRIPTION
I have verified that the latest DO's commit on develop will fix the linker issue on Ubuntu 2004. Once DO created v1.0.2, this PR can be merged