### PR TITLE
Fix Bug: Remove mandatory PLATFORM parameter for DO bootstrap script and DU install-deps

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -72,7 +72,7 @@ install_githooks=false
 
 du_test_data_dir_path="/tmp/adu/"
 # DO Deps
-default_do_ref=develop
+default_do_ref=02c9ae2c7484182903c66ad986a834762fc569e6
 install_do=false
 do_ref=$default_do_ref
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -72,7 +72,7 @@ install_githooks=false
 
 du_test_data_dir_path="/tmp/adu/"
 # DO Deps
-default_do_ref=v1.0.1
+default_do_ref=develop
 install_do=false
 do_ref=$default_do_ref
 
@@ -444,14 +444,9 @@ do_install_do() {
 
     git clone --recursive --single-branch --branch $do_ref --depth 1 $do_url . || return
 
-    distro=$OS$VER
-    install_do_deps_distro="${distro//./}"
-
-    if [[ $install_do_deps_distro != "" ]]; then
-        local bootstrap_file=$do_dir/build/scripts/bootstrap.sh
-        chmod +x $bootstrap_file || return
-        $SUDO $bootstrap_file --platform "$install_do_deps_distro" --install build || return
-    fi
+    bootstrap_file=$do_dir/build/scripts/bootstrap.sh
+    chmod +x $bootstrap_file || return
+    $SUDO $bootstrap_file --install build || return
 
     mkdir cmake || return
     pushd cmake > /dev/null || return

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -72,7 +72,7 @@ install_githooks=false
 
 du_test_data_dir_path="/tmp/adu/"
 # DO Deps
-default_do_ref=02c9ae2c7484182903c66ad986a834762fc569e6
+default_do_ref=develop
 install_do=false
 do_ref=$default_do_ref
 
@@ -444,6 +444,8 @@ do_install_do() {
 
     git clone --recursive --single-branch --branch $do_ref --depth 1 $do_url . || return
 
+    #TODO: Remove the sepecif commit once DO publishs a new tag
+    git checkout 02c9ae2c7484182903c66ad986a834762fc569e6
     bootstrap_file=$do_dir/build/scripts/bootstrap.sh
     chmod +x $bootstrap_file || return
     $SUDO $bootstrap_file --install build || return


### PR DESCRIPTION
Because DO has not created the latest tag, to adopt the change we will use `develop` branch, and then update it to v1.0.2 once DO creates the new tag. 

Quoted from Shishir:  the fixes are only in develop currently and I would like to avoid cherry-picking non-trivial changes. Can you point to our develop branch instead? If not, I will see when we can merge into main and create a tag.
If we like it to point to v1.0.2 instead, we can ask Shishir help create a tag new