### PR TITLE
buildtools 14.34.31931 -> 14.36.32532 to fix new enlistment.

### DIFF
--- a/scripts/install-du.ps1
+++ b/scripts/install-du.ps1
@@ -241,7 +241,7 @@ function Install-Adu-Components {
     }
 
     if ($Type -eq 'Debug') {
-        $BuildToolsDPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.34.31931\debug_nonredist\$Arch\Microsoft.VC143.DebugCRT"
+        $BuildToolsDPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.36.32532\debug_nonredist\$Arch\Microsoft.VC143.DebugCRT"
         $WindowsKitsDPath = "${env:ProgramFiles(x86)}\Windows Kits\10\bin\$WindowsKitsVer\$Arch\ucrt"
 
         # Only needed if dynamically linking: getopt, pthreadVC3d, libcrypto-1_1-x64
@@ -256,7 +256,7 @@ function Install-Adu-Components {
         (Join-Path $WindowsKitsDPath 'ucrtbased')
     }
     else {
-        $BuildToolsPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.34.31931\$Arch\Microsoft.VC143.CRT"
+        $BuildToolsPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.36.32532\$Arch\Microsoft.VC143.CRT"
         $WindowsKitsPath = "${env:ProgramFiles(x86)}\Windows Kits\10\Redist\$WindowsKitsVer\ucrt\DLLs\$Arch"
 
         $dependencies = `


### PR DESCRIPTION
Otherwise, calling ./scripts/install-du.ps1 -Type Debug -Package results in:

```ps
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Redist\MSVC\14.34.31931\debug_nonredist\x64\Microsoft.VC143.DebugCRT\msvcp140d.dll is not a file or directory doesn't exist                                                                                                                                                                
At C:\src\iot-hub-device-update\scripts\install-du.ps1:59 char:9                                                                                                             
+         throw "$Source is not a file or doesn't exist"                                                                                                                     
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                         
    + CategoryInfo          : OperationStopped: (C:\Program File...r doesn't exist:String) [], RuntimeException
    + FullyQualifiedErrorId : C:\Program Files (x86)\Microsoft Visual  Studio\2022\BuildTools\VC\Redist\MSVC\14.34.31931\debug_nonredist\x64\Microsoft.VC143.DebugCRT\msvcp140d.dll is not a file or doesn't exist
```