### PR TITLE
Small fix on snap yaml for publishing to Ubuntu Core Store

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -100,6 +100,8 @@ parts:
   du-agent:
     plugin: nil
     source: .
+    stage-snaps:
+      - deliveryoptimization-agent
     override-build: |
       ./scripts/install-deps.sh --work-folder /tmp --install-cmake
       ./scripts/build.sh --work-folder /tmp --ubuntu-core-snap-only
@@ -211,6 +213,9 @@ plugs:
   account-control:
     interface: account-control
     allow-auto-connection: true
+
+  hardware-observe:
+    interface: hardware-observe
 
   home:
     interface: home

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -190,11 +190,13 @@ plugs:
     interface: content
     content: do-port-numbers
     target: $SNAP_DATA/do-port-numbers
+    allow-auto-connection: true
 
   do-configs:
     interface: content
     content: do-configs
     target: $SNAP_DATA/do-configs
+    allow-auto-connection: true
 
   snapd-control:
     interface: snapd-control
@@ -204,12 +206,11 @@ plugs:
     interface: content
     content: aziot-identity-service
     target: $SNAP_DATA
+    allow-auto-connection: true
 
   account-control:
     interface: account-control
-
-  hardware-observe:
-    interface: hardware-observe
+    allow-auto-connection: true
 
   home:
     interface: home


### PR DESCRIPTION
add DO as stage-snaps, so that it is one of the snap dependency
add allow-auto-connection: true for DO and AIS, so that it won't need the manual connection. and add allow-auto-connection  for account-control because he account-control interface in Snap provides an application with the ability to create, delete, and manage user accounts on a system.