### PR TITLE
Add ARM64 Cross-Compilation to Windows Build Pipeline

### DIFF
--- a/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
+++ b/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
@@ -31,8 +31,8 @@ pool:
 jobs:
     - job: BuildAduAgent_WindowsServer2022_msvc2022_amd64
       displayName: "Build ADU Agent - Windows Server 2022 - MSVC 2022 (amd64)"
-      timeoutInMinutes: 45
-      cancelTimeoutInMinutes: 45
+      timeoutInMinutes: 60
+      cancelTimeoutInMinutes: 60
       steps:
           - task: PowerShell@2
             displayName: "Build Client + UTs - amd64_debug"
@@ -71,8 +71,8 @@ jobs:
 
     - job: BuildAduAgent_WindowsServer2022_msvc2022_arm64
       displayName: "Build ADU Agent - Windows Server 2022 - MSVC 2022 (arm64)"
-      timeoutInMinutes: 45
-      cancelTimeoutInMinutes: 45
+      timeoutInMinutes: 60
+      cancelTimeoutInMinutes: 60
       steps:
           - task: PowerShell@2
             displayName: "Build Client + UTs - arm64_release"

--- a/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
+++ b/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
@@ -3,7 +3,6 @@ pr:
     branches:
         include:
             - feature/wiot-s1
-            - user/jw-msft/win-pipeline
     paths:
         exclude:
             - docs/*
@@ -19,7 +18,6 @@ trigger:
     branches:
         include:
             - feature/wiot-s1
-            - user/jw-msft/win-pipeline
     paths:
         exclude:
             - docs/*
@@ -37,7 +35,7 @@ pool:
 steps:
 
     - task: PowerShell@2
-      displayName: "Build Client, Unit Tests: Debug"
+      displayName: "Build Client, Unit Tests: amd64_debug"
       inputs:
           targetType: "filePath"
           filePath: $(Build.SourcesDirectory)\scripts\build.ps1
@@ -48,7 +46,7 @@ steps:
               -Pipeline
 
     - task: PowerShell@2
-      displayName: "Run Unit Tests"
+      displayName: "Run Unit Tests - amd64_debug"
       inputs:
           targetType: inline
           script: $(Build.SourcesDirectory)\scripts\run_uts.ps1 -Pipeline
@@ -62,11 +60,36 @@ steps:
     - task: PublishPipelineArtifact@1
       inputs:
         targetPath: 'out/Debug/bin/Debug'
-        artifact: 'bin'
+        artifact: 'bin-amd64_debug'
         publishLocation: 'pipeline'
 
     - task: PublishPipelineArtifact@1
       inputs:
         targetPath: 'out/Debug/lib/Debug'
-        artifact: 'lib'
+        artifact: 'lib-Debug-amd64'
         publishLocation: 'pipeline'
+
+    - task: PowerShell@2
+      displayName: "Build Client, Unit Tests: arm64_release"
+      inputs:
+          targetType: "filePath"
+          filePath: $(Build.SourcesDirectory)\scripts\build.ps1
+          arguments: >
+              -Type Release
+              -GeneratorPlatform ARM64
+              -Clean
+              -BuildUnitTests
+              -Pipeline
+
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: 'out/ARM64-Release/bin/Release'
+        artifact: 'bin-arm64_release'
+        publishLocation: 'pipeline'
+
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: 'out/ARM64-Release/lib/Release'
+        artifact: 'lib-arm64_release'
+        publishLocation: 'pipeline'
+

--- a/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
+++ b/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
@@ -43,7 +43,7 @@ steps:
               -Type Debug
               -Clean
               -BuildUnitTests
-              -Pipeline
+              -NoPrompt
 
     - task: PowerShell@2
       displayName: "Run Unit Tests - amd64_debug"
@@ -79,7 +79,7 @@ steps:
               -GeneratorPlatform ARM64
               -Clean
               -BuildUnitTests
-              -Pipeline
+              -NoPrompt
 
     - task: PublishPipelineArtifact@1
       inputs:

--- a/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
+++ b/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
@@ -5,14 +5,12 @@ pr:
             - feature/wiot-s1
     paths:
         exclude:
-            - docs/*
-            - README.md
-            - LICENSE.md
-            - .clang-format
-            - .cmake-format.json
-            - tools/*
-            - docker/*
-            - licenses/*
+            - daemon
+            - docker
+            - docs
+            - licenses
+            - tools
+            - "**/*.md"
 
 trigger:
     branches:
@@ -20,14 +18,12 @@ trigger:
             - feature/wiot-s1
     paths:
         exclude:
-            - docs/*
-            - README.md
-            - LICENSE.md
-            - .clang-format
-            - .cmake-format.json
-            - tools/*
-            - docker/*
-            - licenses/*
+            - daemon
+            - docker
+            - docs
+            - licenses
+            - tools
+            - "**/*.md"
 
 pool:
     vmImage: windows-2022

--- a/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
+++ b/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
@@ -28,63 +28,73 @@ trigger:
 pool:
     vmImage: windows-2022
 
-steps:
-    - task: PowerShell@2
-      displayName: "Build Client + UTs - amd64_debug"
-      inputs:
-          targetType: "filePath"
-          filePath: $(Build.SourcesDirectory)\scripts\build.ps1
-          arguments: >
-              -Type Debug
-              -Clean
-              -BuildUnitTests
-              -NoPrompt
+jobs:
+    - job: BuildAduAgent_WindowsServer2022_msvc2022_amd64
+      displayName: "Build ADU Agent - Windows Server 2022 - MSVC 2022 (amd64)"
+      timeoutInMinutes: 45
+      cancelTimeoutInMinutes: 45
+      steps:
+          - task: PowerShell@2
+            displayName: "Build Client + UTs - amd64_debug"
+            inputs:
+                targetType: "filePath"
+                filePath: $(Build.SourcesDirectory)\scripts\build.ps1
+                arguments: >
+                    -Type Debug
+                    -Clean
+                    -BuildUnitTests
+                    -NoPrompt
 
-    - task: PowerShell@2
-      displayName: "Run Unit Tests - amd64_debug"
-      inputs:
-          targetType: inline
-          script: $(Build.SourcesDirectory)\scripts\run_uts.ps1 -Pipeline
+          - task: PowerShell@2
+            displayName: "Run Unit Tests - amd64_debug"
+            inputs:
+                targetType: inline
+                script: $(Build.SourcesDirectory)\scripts\run_uts.ps1 -Pipeline
 
-    - task: PublishTestResults@2
-      inputs:
-          testResultsFormat: 'JUnit'
-          testResultsFiles: '**/TEST-*.xml'
-          failTaskOnFailedTests: true
+          - task: PublishTestResults@2
+            inputs:
+                testResultsFormat: 'JUnit'
+                testResultsFiles: '**/TEST-*.xml'
+                failTaskOnFailedTests: true
 
-    - task: PublishPipelineArtifact@1
-      inputs:
-        targetPath: 'out/Debug/bin/Debug'
-        artifact: 'bin-amd64_debug'
-        publishLocation: 'pipeline'
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'out/Debug/bin/Debug'
+              artifact: 'bin-amd64_debug'
+              publishLocation: 'pipeline'
 
-    - task: PublishPipelineArtifact@1
-      inputs:
-        targetPath: 'out/Debug/lib/Debug'
-        artifact: 'lib-Debug-amd64'
-        publishLocation: 'pipeline'
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'out/Debug/lib/Debug'
+              artifact: 'lib-Debug-amd64'
+              publishLocation: 'pipeline'
 
-    - task: PowerShell@2
-      displayName: "Build Client + UTs - arm64_release"
-      inputs:
-          targetType: "filePath"
-          filePath: $(Build.SourcesDirectory)\scripts\build.ps1
-          arguments: >
-              -Type Release
-              -GeneratorPlatform ARM64
-              -Clean
-              -BuildUnitTests
-              -NoPrompt
+    - job: BuildAduAgent_WindowsServer2022_msvc2022_arm64
+      displayName: "Build ADU Agent - Windows Server 2022 - MSVC 2022 (arm64)"
+      timeoutInMinutes: 45
+      cancelTimeoutInMinutes: 45
+      steps:
+          - task: PowerShell@2
+            displayName: "Build Client + UTs - arm64_release"
+            inputs:
+                targetType: "filePath"
+                filePath: $(Build.SourcesDirectory)\scripts\build.ps1
+                arguments: >
+                    -Type Release
+                    -GeneratorPlatform ARM64
+                    -Clean
+                    -BuildUnitTests
+                    -NoPrompt
 
-    - task: PublishPipelineArtifact@1
-      inputs:
-        targetPath: 'out/ARM64-Release/bin/Release'
-        artifact: 'bin-arm64_release'
-        publishLocation: 'pipeline'
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'out/ARM64-Release/bin/Release'
+              artifact: 'bin-arm64_release'
+              publishLocation: 'pipeline'
 
-    - task: PublishPipelineArtifact@1
-      inputs:
-        targetPath: 'out/ARM64-Release/lib/Release'
-        artifact: 'lib-arm64_release'
-        publishLocation: 'pipeline'
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: 'out/ARM64-Release/lib/Release'
+              artifact: 'lib-arm64_release'
+              publishLocation: 'pipeline'
 

--- a/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
+++ b/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
@@ -33,7 +33,6 @@ pool:
     vmImage: windows-2022
 
 steps:
-
     - task: PowerShell@2
       displayName: "Build Client, Unit Tests: amd64_debug"
       inputs:

--- a/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
+++ b/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
@@ -30,7 +30,7 @@ pool:
 
 steps:
     - task: PowerShell@2
-      displayName: "Build Client, Unit Tests: amd64_debug"
+      displayName: "Build Client + UTs - amd64_debug"
       inputs:
           targetType: "filePath"
           filePath: $(Build.SourcesDirectory)\scripts\build.ps1
@@ -65,7 +65,7 @@ steps:
         publishLocation: 'pipeline'
 
     - task: PowerShell@2
-      displayName: "Build Client, Unit Tests: arm64_release"
+      displayName: "Build Client + UTs - arm64_release"
       inputs:
           targetType: "filePath"
           filePath: $(Build.SourcesDirectory)\scripts\build.ps1

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -253,9 +253,9 @@ $runtime_dir = "$BuildOutputPath/bin"
 $library_dir = "$BuildOutputPath/lib"
 
 $cmake_bin = 'cmake.exe'
-$cmake_cmd = Get-Command cmake.exe
+$cmake_cmd = Get-Command -CommandType Application cmake.exe
 $cmake_bin = $cmake_cmd.Path
-Write-Verbose ('Using $cmake_cmd.Path')
+Write-Verbose "Using CMake path: $cmake_bin"
 
 $PlatformLayer = 'windows'
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -29,8 +29,8 @@ Param(
     # Log folder to use for DU logs
     # TODO(JeffMill): Change this when folder structure determined.
     [string]$LogDir = '/var/log/adu',
-    # Running in pipeline?
-    [switch]$Pipeline
+    # Non-Interactive?
+    [switch]$NoPrompt
 )
 
 function Show-Warning {
@@ -308,7 +308,7 @@ if (-not $Clean) {
 }
 
 if ($Clean) {
-    if (-not $Pipeline) {
+    if (-not $NoPrompt) {
         $decision = $Host.UI.PromptForChoice(
             'Clean Build',
             'Are you sure?',


### PR DESCRIPTION
- Add steps to cross-compile ARM64 and generate 2 additional ARM64 build artifacts
- Address comments from the previous PR