### PR TITLE
Fix installs-deps -a catch2 issue on ubuntu 20.04

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -190,12 +190,17 @@ do_install_aduc_packages() {
     OS=$(lsb_release --short --id)
     if [[ $OS == "Debian" && $VER == "9" ]]; then
         $SUDO apt-get install --yes gcc-6 g++-6 || return
-    elif [[ $OS == "Debian" && $VER == "11" ]]; then
+    elif [[ ($OS == "Debian" && $VER == "11") || (\
+        $OS == "Ubuntu" && $VER == "20.04") || (\
+        $OS == "Ubuntu" && $VER == "22.04") ]] \
+            ; then
         $SUDO apt-get install --yes gcc-10 g++-10 || return
-    elif [[ $OS == "Ubuntu" && $VER == "20.04" ]]; then
-        $SUDO apt-get install --yes gcc-10 g++-10 || return
-    elif [[ $OS == "Ubuntu" && $VER == "22.04" ]]; then
-        $SUDO apt-get install --yes gcc-10 g++-10 || return
+
+        # used for dependencies like catch2 that will find system default
+        # (e.g. g++-9) despite g++-10 installed, so use CC and CXX env
+        # vars that CMake will honor.
+        export CC=/usr/bin/gcc-10
+        export CXX=/usr/bin/g++-10
     else
         $SUDO apt-get install --yes gcc-8 g++-8 || return
     fi
@@ -295,6 +300,7 @@ do_install_catch2() {
     mkdir cmake || return
     pushd cmake > /dev/null || return
 
+    export CC=/usr/bin/gcc-10 CXX=/usr/bin/g++-10
     cmake .. || return
 
     cmake --build . || return

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -192,6 +192,8 @@ do_install_aduc_packages() {
         $SUDO apt-get install --yes gcc-6 g++-6 || return
     elif [[ $OS == "Debian" && $VER == "11" ]]; then
         $SUDO apt-get install --yes gcc-10 g++-10 || return
+    elif [[ $OS == "Ubuntu" && $VER == "20.04" ]]; then
+        $SUDO apt-get install --yes gcc-10 g++-10 || return
     elif [[ $OS == "Ubuntu" && $VER == "22.04" ]]; then
         $SUDO apt-get install --yes gcc-10 g++-10 || return
     else


### PR DESCRIPTION
Building catch2 from sources fails on `#pragma GCC diagnostic ignored "-Wcomma-subscript"` due to using gcc-9 and g++-9 packages on Ubuntu 20.04

This change installs gcc-10 and g++-10 packages on Ubuntu 20.04 to resolve this and also exports CC and CXX env variables so that catch2 CMake build will use gcc-10 and g++-10 instead of gcc-9 and g++-9.

