### PR TITLE
Packer for Deb11 ARM64 docker image containing DU Agent build artifacts

### DIFF
--- a/tools/packer/README.md
+++ b/tools/packer/README.md
@@ -1,0 +1,7 @@
+# Packer Tooling
+
+This dir is for HCL configs used by [Hashicorp packer](https://www.packer.io/) for building VM and Docker images for various purposes.
+
+## BuildContainers
+
+Builds VMs and Docker images for building DeviceUpdate agent on various Distros and cpu architectures.

--- a/tools/packer/README.md
+++ b/tools/packer/README.md
@@ -2,6 +2,7 @@
 
 This dir is for HCL configs used by [Hashicorp packer](https://www.packer.io/) for building VM and Docker images for various purposes.
 
-## BuildContainers
+## build dir
 
-Builds VMs and Docker images for building DeviceUpdate agent on various Distros and cpu architectures.
+The `build` dir contains HCL for building docker images that will contain the build artifacts of building DU Agent, Unit tests, and .deb package during image creation time.
+See README.md in `build` dir for more details.

--- a/tools/packer/build/README.md
+++ b/tools/packer/build/README.md
@@ -42,7 +42,7 @@ ctest
 docker run -it --platform=linux/arm64 --rm --name container 112a56
 ```
 
-Detach with <CTRL>-P <CTRL>-Q
+Detach with CTRL-P CTRL-Q
 
 ```sh
 $ docker ps

--- a/tools/packer/build/README.md
+++ b/tools/packer/build/README.md
@@ -1,0 +1,11 @@
+# Build Container for Debian 11 and ARM64
+
+## How to run Packer to build the Dockerfile
+
+## How to run the docker container
+
+## Expected side-effects
+
+## Artifacts produced
+
+## How to get the artifacts

--- a/tools/packer/build/README.md
+++ b/tools/packer/build/README.md
@@ -1,11 +1,76 @@
-# Build Container for Debian 11 and ARM64
+# Build Container for Debian 11 stable
+
+The .HCL will build a docker image that contains the results of building DU agent, its unit test, and the debian package.
 
 ## How to run Packer to build the Dockerfile
 
-## How to run the docker container
+### Build only arm64 debian 11
 
-## Expected side-effects
+packer build -only=duagent.docker.debian_arm64 .
 
-## Artifacts produced
+### Build all arch (arm64 and amd64) debian 11
 
-## How to get the artifacts
+packer build .
+
+## Build Artifacts Produced from packer build
+
+The `packer build .` will result in the following build artifacts in the docker container:
+- /usr/local/lib/ artifacts
+  - deviceupdate-openssl
+  - libparson.a
+  - libumock_c.a
+  - libaziotsharedutil.a
+  - libumqtt.a
+  - libuhttp.a
+  - libiothub_client_http_transport.a
+  - libiothub_client_mqtt_ws_transport.a
+  - libiothub_client_mqtt_transport.a
+  - libiothub_client.a
+  - libserializer.a
+  - libgtest.a
+  - libgmock.a
+  - libgmock_main.a
+  - libgtest_main.a
+  - libdeliveryoptimization.so.1.0.0
+  - libdeliveryoptimization.so.1 -> libdeliveryoptimization.so.1.0.0
+  - libdeliveryoptimization.so -> libdeliveryoptimization.so.1
+  - libazure-core.a
+  - libazure-security-attestation.a
+  - libazure-identity.a
+  - libazure-security-keyvault-keys.a
+  - libazure-security-keyvault-secrets.a
+  - libazure-security-keyvault-certificates.a
+  - libazure-storage-common.a
+  - libazure-storage-blobs.a
+  - libazure-storage-files-datalake.a
+  - libazure-storage-files-shares.a
+  - libazure-storage-queues.a
+  - libazure-template.a
+  - libazure_blob_storage_file_upload_utility.a
+
+- /iot-hub-device-update/out/ artifacts
+  - deviceupdate-agent_1.0.2_arm64.deb
+
+## The resultant docker image
+
+$ docker image ls
+REPOSITORY                   TAG            IMAGE ID       CREATED         SIZE
+<none>                       <none>         112a56228b1a   5 hours ago     2.52GB
+arm64v8/debian               11             2c4d303cc7f7   2 weeks ago     118MB
+
+The correct IMAGE ID would be 112a56228b1a in the above.
+
+## How to run the unit tests in the docker container
+
+docker run -it --platform=linux/arm64 --rm --name container 112a56228b1a
+cd /iot-hub-device-update/out
+ctest
+
+## How to get the artifacts off of docker container
+
+docker run -it --platform=linux/arm64 --rm --name container 112a56228b1a
+bash
+apt-get install -y rsync
+pushd / && tar czvf ./iot-hub-device-update/out/* /usr/local/lib/* ./device-update-debian11-arm64-build-artifacts.tgz
+rsync -av --progress ./device-update-debian11-arm64-build-artifacts.tgz user@myhost:~/
+

--- a/tools/packer/build/duagent-build.pkr.hcl
+++ b/tools/packer/build/duagent-build.pkr.hcl
@@ -1,0 +1,36 @@
+packer {
+  required_plugins {
+    docker = {
+      version = ">= 0.0.7"
+      source  = "github.com/hashicorp/docker"
+    }
+  }
+}
+
+source "docker" "debian_arm64" {
+  image    = "arm64v8/debian:11"
+  commit   = true
+  platform = "linux/arm64"
+}
+
+source "docker" "debian_amd64" {
+  image    = "amd64/debian:11"
+  commit   = true
+  platform = "linux/amd64"
+}
+
+build {
+  name = "duagent"
+  sources = [
+    "source.docker.debian_arm64",
+    "source.docker.debian_amd64"
+  ]
+
+  provisioner "shell" {
+    inline = [
+      "apt-get update && apt-get --yes install apt-utils git",
+      "git clone https://github.com/azure/iot-hub-device-update --branch develop",
+      "cd iot-hub-device-update && ./scripts/install-deps.sh -a && ./scripts/build.sh -c -u --build-packages"
+    ]
+  }
+}

--- a/tools/packer/build/scripts/README.md
+++ b/tools/packer/build/scripts/README.md
@@ -1,1 +1,0 @@
-This directory has provisioning scripts run by the packer build.

--- a/tools/packer/build/scripts/README.md
+++ b/tools/packer/build/scripts/README.md
@@ -1,0 +1,1 @@
+This directory has provisioning scripts run by the packer build.


### PR DESCRIPTION
- Add packer HCL to do build docker image with cross-compiled build of DU agent in Debian11 ARM64

- Add README.md on how to run packer, docker container, and get build artifacts off of container

Addresses github issue: https://github.com/Azure/iot-hub-device-update/issues/484