### PR TITLE
Wait for any apt or apt-get process to finish before doing apt update during TF vm creation

### DIFF
--- a/azurepipelines/e2e_test/e2etest.yaml
+++ b/azurepipelines/e2e_test/e2etest.yaml
@@ -102,7 +102,7 @@ stages:
             continueOnError: False
             steps:
                 - script: |
-                      sudo apt update && sudo apt install curl
+                      while pgrep apt > /dev/null; do sleep 1; done; sudo apt update && sudo apt install curl
                       curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
                       sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
                       sudo apt install terraform

--- a/azurepipelines/e2e_test/templates/e2e_test_vm_cleanup.yaml
+++ b/azurepipelines/e2e_test/templates/e2e_test_vm_cleanup.yaml
@@ -6,7 +6,7 @@ parameters:
       type: string
 steps:
     - script: |
-          sudo apt update && sudo apt install curl
+          while pgrep apt > /dev/null; do sleep 1; done; sudo apt update && sudo apt install curl
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
           sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
           sudo apt install terraform

--- a/azurepipelines/e2e_test/templates/e2e_vm_setup.yaml
+++ b/azurepipelines/e2e_test/templates/e2e_vm_setup.yaml
@@ -112,7 +112,7 @@ steps:
       displayName: "Copying tarball over to the terraform host"
 
     - script: |
-          sudo apt update && sudo apt install curl
+          while pgrep apt > /dev/null; do sleep 1; done; sudo apt update && sudo apt install curl
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
           sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
           sudo apt install terraform

--- a/azurepipelines/e2e_test/terraform/host/DeviceUpdateHost.tf
+++ b/azurepipelines/e2e_test/terraform/host/DeviceUpdateHost.tf
@@ -167,12 +167,6 @@ resource "azurerm_linux_virtual_machine" "deviceupdatevm" {
     #
     # Changes to provide the setup information should go here
     #
-    # There may already be a system apt or apt-get process running that is
-    # using fcntl to take an exclusive write file lock on /var/lib/apt/lists/lock.
-    # For fcntl, the lock will be released once the process dies.
-    # We use pgrep to find all processes with pattern of "apt" and only execute
-    # the apt update once those processes no longer exist.
-    #
     provisioner "remote-exec" {
         inline = [
         "while pgrep apt > /dev/null; do sleep 1; done; sudo apt update",

--- a/azurepipelines/e2e_test/terraform/host/DeviceUpdateHost.tf
+++ b/azurepipelines/e2e_test/terraform/host/DeviceUpdateHost.tf
@@ -175,7 +175,7 @@ resource "azurerm_linux_virtual_machine" "deviceupdatevm" {
     #
     provisioner "remote-exec" {
         inline = [
-        "while pgrep apt > /dev/null; do sleep 1; done; sudo apt update"
+        "while pgrep apt > /dev/null; do sleep 1; done; sudo apt update",
         var.vm_du_tarball_script
         ]
     }

--- a/azurepipelines/e2e_test/terraform/host/DeviceUpdateHost.tf
+++ b/azurepipelines/e2e_test/terraform/host/DeviceUpdateHost.tf
@@ -169,7 +169,7 @@ resource "azurerm_linux_virtual_machine" "deviceupdatevm" {
     #
     provisioner "remote-exec" {
         inline = [
-        "sudo apt update",
+        "sudo pkill apt; sudo pkill apt-get; rm -f /var/lib/apt/lists/lock; sudo apt update",
         var.vm_du_tarball_script
         ]
     }

--- a/azurepipelines/e2e_test/terraform/host/DeviceUpdateHost.tf
+++ b/azurepipelines/e2e_test/terraform/host/DeviceUpdateHost.tf
@@ -167,9 +167,15 @@ resource "azurerm_linux_virtual_machine" "deviceupdatevm" {
     #
     # Changes to provide the setup information should go here
     #
+    # There may already be a system apt or apt-get process running that is
+    # using fcntl to take an exclusive write file lock on /var/lib/apt/lists/lock.
+    # For fcntl, the lock will be released once the process dies.
+    # We use pgrep to find all processes with pattern of "apt" and only execute
+    # the apt update once those processes no longer exist.
+    #
     provisioner "remote-exec" {
         inline = [
-        "sudo pkill apt; sudo pkill apt-get; rm -f /var/lib/apt/lists/lock; sudo apt update",
+        "while pgrep apt > /dev/null; do sleep 1; done; sudo apt update"
         var.vm_du_tarball_script
         ]
     }


### PR DESCRIPTION
This addresses the following intermittent errors in "Creating the virtual machines" in E2E test runs that produce:
```
azurerm_linux_virtual_machine.deviceupdatevm (remote-exec): E: Could not get lock /var/lib/apt/lists/lock - open (11: Resource temporarily unavailable)
azurerm_linux_virtual_machine.deviceupdatevm (remote-exec): E: Unable to lock directory /var/lib/apt/lists/
```