### PR TITLE
Add the compile time configuration location for the /tmp directory for portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,13 @@ set (
           "The path segment in source tree where testdata for various test folders will be found.")
 
 set (
+    ADUC_TMP_DIR_PATH
+    "/tmp"
+    CACHE STRING "Path to the temporary directory")
+
+set (
     ADUC_TEST_DATA_FOLDER
-    "/tmp/adu/${ADUC_TEST_DATA_PATH_SEGMENT}"
+    "${ADUC_TMP_DIR_PATH}/adu/${ADUC_TEST_DATA_PATH_SEGMENT}"
     CACHE
         STRING
         "Path to the folder containing test data file(s) copied from tests/testdata/<testname> folders in the source tree."
@@ -150,7 +155,10 @@ set (
 set (
     ADUC_EXTENSIONS_INSTALL_FOLDER
     "${ADUC_EXTENSIONS_FOLDER}/sources"
-    CACHE STRING "Path to the folder containing extensions .so file(s). This value can not be overridden by du-config.json.")
+    CACHE
+        STRING
+        "Path to the folder containing extensions .so file(s). This value can not be overridden by du-config.json."
+)
 
 set (
     ADUC_UPDATE_CONTENT_HANDLER_REG_FILENAME
@@ -188,14 +196,11 @@ set (
     CACHE STRING "Sub folder for download handler extensions.")
 
 # Define the mapping from step handler names to subdirectory names
-set(ADUC_STEP_HANDLER_NAME_TO_DIRECOTRY_MAP
-    "microsoft/apt,apt_handler"
-    "microsoft/script,script_handler"
-    "microsoft/simulator,simulator_handler"
-    "microsoft/swupdate,swupdate_handler"
-    "microsoft/swupdate_v2,swupdate_handler_v2"
-    "microsoft/wim,wim_handler"
-)
+set (
+    ADUC_STEP_HANDLER_NAME_TO_DIRECOTRY_MAP
+    "microsoft/apt,apt_handler" "microsoft/script,script_handler"
+    "microsoft/simulator,simulator_handler" "microsoft/swupdate,swupdate_handler"
+    "microsoft/swupdate_v2,swupdate_handler_v2" "microsoft/wim,wim_handler")
 
 if (WIN32)
     set (

--- a/src/extensions/step_handlers/apt_handler/tests/CMakeLists.txt
+++ b/src/extensions/step_handlers/apt_handler/tests/CMakeLists.txt
@@ -23,8 +23,9 @@ target_include_directories (
             ${PROJECT_SOURCE_DIR}/inc ${PROJECT_SOURCE_DIR}/../../inc ${PROJECT_SOURCE_DIR}/../inc)
 
 target_compile_definitions (
-    ${PROJECT_NAME} PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="/tmp/adu-test-installedcriteria"
-                            ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}")
+    ${PROJECT_NAME}
+    PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="/${ADUC_TMP_DIR_PATH}/adu-test-installedcriteria"
+            ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}")
 
 target_link_libraries (
     ${PROJECT_NAME}

--- a/src/extensions/step_handlers/apt_handler/tests/CMakeLists.txt
+++ b/src/extensions/step_handlers/apt_handler/tests/CMakeLists.txt
@@ -24,7 +24,8 @@ target_include_directories (
 
 target_compile_definitions (
     ${PROJECT_NAME}
-    PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="/${ADUC_TMP_DIR_PATH}/adu-test-installedcriteria")
+    PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="/${ADUC_TMP_DIR_PATH}/adu-test-installedcriteria"
+            ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}")
 
 target_link_libraries (
     ${PROJECT_NAME}

--- a/src/extensions/step_handlers/apt_handler/tests/CMakeLists.txt
+++ b/src/extensions/step_handlers/apt_handler/tests/CMakeLists.txt
@@ -24,8 +24,7 @@ target_include_directories (
 
 target_compile_definitions (
     ${PROJECT_NAME}
-    PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="/${ADUC_TMP_DIR_PATH}/adu-test-installedcriteria"
-            ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}")
+    PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="/${ADUC_TMP_DIR_PATH}/adu-test-installedcriteria")
 
 target_link_libraries (
     ${PROJECT_NAME}

--- a/src/extensions/step_handlers/simulator_handler/CMakeLists.txt
+++ b/src/extensions/step_handlers/simulator_handler/CMakeLists.txt
@@ -12,29 +12,19 @@ find_package (Parson REQUIRED)
 target_include_directories (
     ${target_name}
     PUBLIC inc
-    PRIVATE ${PROJECT_SOURCE_DIR}/inc
-            ${ADU_EXTENSION_INCLUDES}
-            ${ADU_SHELL_INCLUDES}
-            ${ADUC_EXPORT_INCLUDES}
-            ${ADUC_TYPES_INCLUDES})
+    PRIVATE ${PROJECT_SOURCE_DIR}/inc ${ADU_EXTENSION_INCLUDES} ${ADU_SHELL_INCLUDES}
+            ${ADUC_EXPORT_INCLUDES} ${ADUC_TYPES_INCLUDES})
 
-get_filename_component (
-    ADUC_INSTALLEDCRITERIA_FILE_PATH
-    "${ADUC_DATA_FOLDER}/${ADUC_INSTALLEDCRITERIA_FILE}"
-    ABSOLUTE
-    "/")
+get_filename_component (ADUC_INSTALLEDCRITERIA_FILE_PATH
+                        "${ADUC_DATA_FOLDER}/${ADUC_INSTALLEDCRITERIA_FILE}" ABSOLUTE "/")
 
 target_compile_definitions (
-    ${target_name} PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="${ADUC_INSTALLEDCRITERIA_FILE_PATH}")
+    ${target_name} PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="${ADUC_INSTALLEDCRITERIA_FILE_PATH}"
+                           ADUC_TMP_DIR_PATH="${ADUC_TMP_DIR_PATH}")
 
 target_link_libraries (
-    ${target_name}
-    PRIVATE aduc::agent_workflow
-            aduc::contract_utils
-            aduc::logging
-            aduc::parser_utils
-            aduc::workflow_utils
-            Parson::parson)
+    ${target_name} PRIVATE aduc::agent_workflow aduc::contract_utils aduc::logging
+                           aduc::parser_utils aduc::workflow_utils Parson::parson)
 
 target_link_libraries (${target_name} PRIVATE libaducpal)
 

--- a/src/extensions/step_handlers/simulator_handler/CMakeLists.txt
+++ b/src/extensions/step_handlers/simulator_handler/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required (VERSION 3.5)
 set (target_name microsoft_simulator_1)
 
 add_library (${target_name} MODULE)
+
 target_sources (${target_name} PRIVATE src/simulator_handler.cpp)
 
 add_library (aduc::${target_name} ALIAS ${target_name})

--- a/src/extensions/step_handlers/simulator_handler/src/simulator_handler.cpp
+++ b/src/extensions/step_handlers/simulator_handler/src/simulator_handler.cpp
@@ -91,7 +91,7 @@ const char* _GetTemporaryPathName()
                 env = getenv("TEMPDIR");
                 if (env == nullptr)
                 {
-                    static const char* root_tmp_folder = ADUC_TMP_DIR_PATH;
+                    static const char* root_tmp_folder = "/tmp";
                     env = root_tmp_folder;
                 }
             }

--- a/src/extensions/step_handlers/simulator_handler/src/simulator_handler.cpp
+++ b/src/extensions/step_handlers/simulator_handler/src/simulator_handler.cpp
@@ -91,7 +91,7 @@ const char* _GetTemporaryPathName()
                 env = getenv("TEMPDIR");
                 if (env == nullptr)
                 {
-                    static const char* root_tmp_folder = "/tmp";
+                    static const char* root_tmp_folder = ADUC_TMP_DIR_PATH;
                     env = root_tmp_folder;
                 }
             }

--- a/src/utils/installed_criteria_utils/tests/CMakeLists.txt
+++ b/src/utils/installed_criteria_utils/tests/CMakeLists.txt
@@ -16,14 +16,12 @@ target_include_directories (${PROJECT_NAME} PRIVATE ${ADUC_EXPORT_INCLUDES})
 target_sources (${PROJECT_NAME} PRIVATE main.cpp installed_criteria_utils_ut.cpp)
 
 target_compile_definitions (
-    ${PROJECT_NAME} PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="/tmp/adu-test-installedcriteria")
+    ${PROJECT_NAME}
+    PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="${ADUC_TMP_DIR_PATH}/adu-test-installedcriteria")
 
 target_link_libraries (
-    ${PROJECT_NAME}
-    PRIVATE aduc::adu_core_interface
-            aduc::installed_criteria_utils
-            aduc::platform_layer
-            Catch2::Catch2)
+    ${PROJECT_NAME} PRIVATE aduc::adu_core_interface aduc::installed_criteria_utils
+                            aduc::platform_layer Catch2::Catch2)
 
 # Ensure that ctest discovers catch2 tests.
 # Use catch_discover_tests() rather than add_test()


### PR DESCRIPTION
- Added in to remove the dependency on hard coded /tmp directories in some parts of the code base
