### PR TITLE
Fix read.2 count arg off by one nul term write to buffer

### DIFF
--- a/src/utils/c_utils/src/string_c_utils.c
+++ b/src/utils/c_utils/src/string_c_utils.c
@@ -92,12 +92,12 @@ bool ReadDelimitedValueFromFile(const char* fileName, const char* key, char* val
  * @brief Function that sets @p strBuffers to the contents of the file at @p filePath if the contents are smaller in size than the buffer
  * @param filePath path to the file who's contents will be read
  * @param strBuffer buffer which will be loaded with the contents of @p filePath
- * @param strBuffSize the size of the buffer
+ * @param strBuffSize the size of the buffer to hold file contents plus a null terminator.
  * @returns false on failure, true on success
  */
 bool LoadBufferWithFileContents(const char* filePath, char* strBuffer, const size_t strBuffSize)
 {
-    if (filePath == NULL || strBuffer == NULL || strBuffSize == 0)
+    if (filePath == NULL || strBuffer == NULL || strBuffSize < 2)
     {
         return false;
     }
@@ -121,7 +121,7 @@ bool LoadBufferWithFileContents(const char* filePath, char* strBuffer, const siz
 
     long fileSize = bS.st_size;
 
-    if (fileSize == 0 || fileSize > strBuffSize)
+    if (fileSize == 0 || fileSize > (strBuffSize - 1))
     {
         goto done;
     }

--- a/src/utils/process_utils/src/process_utils.cpp
+++ b/src/utils/process_utils/src/process_utils.cpp
@@ -93,7 +93,7 @@ int ADUC_LaunchChildProcess(const std::string& command, std::vector<std::string>
     {
         char buffer[1024];
         ssize_t count;
-        count = read(filedes[READ_END], buffer, sizeof(buffer));
+        count = read(filedes[READ_END], buffer, sizeof(buffer) - 1);
 
         if (count == -1)
         {


### PR DESCRIPTION
read(2) can read `count` (3rd arg) bytes, so writing of null term at array index of "num bytes read" in the buffer could overrun the buffer by 1.
- Fix process_utils `ADU_LaunchChildProcess` to read buf size minus one to address issue reported by:  https://github.com/Azure/iot-hub-device-update/issues/526
- Fix another instance in string_c_utils LoadBufferWithFileContents