### PR TITLE
E2E pipeline failure: apt lock

### DIFF
--- a/azurepipelines/e2e_test/templates/e2e_test_vm_cleanup.yaml
+++ b/azurepipelines/e2e_test/templates/e2e_test_vm_cleanup.yaml
@@ -6,10 +6,12 @@ parameters:
       type: string
 steps:
     - script: |
-          while pgrep apt > /dev/null; do sleep 1; done; sudo apt update && sudo apt install curl
+          while pgrep -f 'apt|dpkg' > /dev/null; do sleep 1; done
+          sleep 2
+          sudo apt update && sudo apt install -y curl
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
           sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-          sudo apt install terraform
+          sudo apt install -y terraform
       displayName: Installing Terraform
     - script: |
           mkdir $(Pipeline.Workspace)/terraformStateVM_${{parameters.distroName}}


### PR DESCRIPTION
1. Check for both apt and dpkg processes.
2. Add a sleep command between the commands for a small delay.