### PR TITLE
Adding DPS and MQTTBroker configurations support in du-config.json

### DIFF
--- a/src/utils/config_utils/inc/aduc/config_utils.h
+++ b/src/utils/config_utils/inc/aduc/config_utils.h
@@ -33,54 +33,56 @@ EXTERN_C_BEGIN
 
 #define ADUC_CONNECTION_TYPE_AIS "AIS"
 #define ADUC_CONNECTION_TYPE_MQTTBROKER "MQTTBroker"
-#define ADUC_CONNECTION_TYPE_ADPS2 "ADPS2"
+#define ADUC_CONNECTION_TYPE_ADPS2_MQTT "ADPS2/MQTT"
 #define ADUC_CONNECTION_TYPE_STRING "string"
 
 /**
  * @brief ADUC_AgentInfo that stores all the agent information from configuration file.
  *
  * Fields:
- *  `name` : The user-defined friendly name of the agent.
- *  `runas` : The user name to run the agent as.
+ *  'name' : The user-defined friendly name of the agent.
+ *  'runas' : The user name to run the agent as.
  *
- *  `connectionType` can be 'AIS' (Azure Identity Service), MQTTBroker, ADPS2 (Azure Device Provisioning Service v2), or string.
- *           If it is 'AIS', the `connectionData` is the name of the principal in AIS.
+ *  'connectionType' can be 'string', 'AIS' (Azure Identity Service), 'MQTTBroker' or 'ADPS2/MQTT' (Azure Device Provisioning Service v2 over MQTT).
  *
- *           If it is 'MQTTBroker', the `connectionData` is not used. The `connectionDataJson` is used instead. It contains
+ *   For version 1.x, the supported connection types are 'AIS' and 'string'.
+ *           If it is 'AIS', the 'connectionData' is the name of the principal in AIS.
+ *           If it is 'string', the 'connectionData' is used as a string. For Device Update Agent V1, this is the connection string from the IoT Hub.
+ *
+ *   For version 2.x, the supported connection types are 'AIS', 'MQTTBroker', and 'ADPS2/MQTT'.
+ *           If it is 'MQTTBroker', the 'connectionData' is not used. The 'connectionDataJson' is used instead. It contains
  *           the following fields:
- *             `hostName` : The fully qualified domain name of the MQTT broker.
- *             `tcpPort` : The port number of the MQTT broker.
- *             `useTLS` : Whether to use TLS for the MQTT connection.
- *             `cleanSession` : Whether to use a clean session for the MQTT connection.
- *             `keepAliveInSeconds` : The keep alive interval in seconds for the MQTT connection.
- *             `clientId` : The client ID for the MQTT connection.
- *             `userName` : The user name for the MQTT connection.
- *             `password` : The password for the MQTT connection.
- *             `caFile` : The path to the CA certificate file for the MQTT connection.
- *             `certFile` : The path to the client certificate file for the MQTT connection.
- *             `keyFile` : The path to the client key file for the MQTT connection.
+ *             'hostName' : The fully qualified domain name of the MQTT broker.
+ *             'tcpPort' : The port number of the MQTT broker.
+ *             'useTLS' : Whether to use TLS for the MQTT connection.
+ *             'cleanSession' : Whether to use a clean session for the MQTT connection.
+ *             'keepAliveInSeconds' : The keep alive interval in seconds for the MQTT connection.
+ *             'clientId' : The client ID for the MQTT connection.
+ *             'userName' : The user name for the MQTT connection.
+ *             'password' : [NOT RECOMMEND FOR PRODUCTION] The password for the MQTT connection.
+ *             'caFile' : The path to the CA certificate file for the MQTT connection.
+ *             'certFile' : The path to the client certificate file for the MQTT connection.
+ *             'keyFile' : The path to the client key file for the MQTT connection.
  *
- *           If it is 'ADPS2', the `connectionData` is not used. The `connectionDataJson` is used instead. It contains fields:
- *             `idScope`: The ID scope of the device provisioning service.
- *             `registrationId`: The registration ID of the device.
- *             `globalDeviceEndpoint`: The global device endpoint of the device provisioning service.
+ *           If it is 'ADPS2/MQTT', the 'connectionData' is not used. The 'connectionDataJson' is used instead. It contains fields:
+ *             'idScope': The ID scope of the device provisioning service.
+ *             'registrationId': The registration ID of the device.
+ *             'globalDeviceEndpoint': The global device endpoint of the device provisioning service.
  *
- *             `tcpPort` : The port number of the MQTT broker.
- *             `useTLS` : Whether to use TLS for the MQTT connection.
- *             `cleanSession` : Whether to use a clean session for the MQTT connection.
- *             `keepAliveInSeconds` : The keep alive interval in seconds for the MQTT connection.
- *             `clientId` : The client ID for the MQTT connection.
- *             `userName` : The user name for the MQTT connection.
- *             `password` : The password for the MQTT connection.
- *             `caFile` : The path to the CA certificate file for the MQTT connection.
- *             `certFile` : The path to the client certificate file for the MQTT connection.
- *             `keyFile` : The path to the client key file for the MQTT connection.
+ *             'tcpPort' : The port number of the MQTT broker.
+ *             'useTLS' : Whether to use TLS for the MQTT connection.
+ *             'cleanSession' : Whether to use a clean session for the MQTT connection.
+ *             'keepAliveInSeconds' : The keep alive interval in seconds for the MQTT connection.
+ *             'clientId' : The client ID for the MQTT connection.
+ *             'userName' : The user name for the MQTT connection.
+ *             'password' : [NOT RECOMMENDED FOR PRODUCTION] The password for the MQTT connection.
+ *             'caFile' : The path to the CA certificate file for the MQTT connection.
+ *             'certFile' : The path to the client certificate file for the MQTT connection.
+ *             'keyFile' : The path to the client key file for the MQTT connection.
  *
- *          If it is 'string', the `connectionData` is used as a string. For Device Update Agent V1, this is the connection string from the IoT Hub.
- *
- *  `manufacturer` : The manufacturer of the device.
- *  `model` : The model of the device.
- *  `additionalDeviceProperties` : Additional device properties.
+ *  'manufacturer' : The manufacturer of the device.
+ *  'model' : The model of the device.
+ *  'additionalDeviceProperties' : Additional device properties.
  *
  */
 typedef struct tagADUC_AgentInfo
@@ -89,11 +91,11 @@ typedef struct tagADUC_AgentInfo
 
     char* runas; /**< Run as a trusted user. */
 
-    char* connectionType; /**< It can be AIS, MQTTBroker, ADPS2, or string. */
+    char* connectionType; /**< It can be 'AIS', 'MQTTBroker', 'ADPS2/MQTT', or 'string'. */
 
     char* connectionData; /**< the name in AIS principal (AIS); the connectionString (connectionType string). */
 
-    JSON_Value* connectionDataJson; /**< The connection data as a JSON object. (for MQTTBroker and ADPS2)*/
+    JSON_Value* connectionDataJson; /**< The connection data as a JSON object. (for MQTTBroker and ADPS2/MQTT)*/
 
     char* manufacturer; /**< Device property manufacturer. */
 
@@ -125,7 +127,7 @@ typedef struct tagADUC_ConfigInfo
 
     ADUC_AgentInfo* agents; /**< Array of agents that are configured. */
 
-    unsigned int agentCount; /**< Total number of agents configured. */
+    size_t agentCount; /**< Total number of agents configured. */
 
     const char* compatPropertyNames; /**< Compat property names. */
 
@@ -211,7 +213,7 @@ VECTOR_HANDLE ADUC_ConfigInfo_GetAduShellTrustedUsers(const ADUC_ConfigInfo* con
 void ADUC_ConfigInfo_FreeAduShellTrustedUsers(VECTOR_HANDLE users);
 
 /**
- * @brief Get DU AGent's connection data field of type string.
+ * @brief Get DU Agent's connection data field of type string.
  *
  * @param agent Pointer to ADUC_AgentInfo object.
  * @param fieldName The field name to get. This can be null or a nested field name, e.g. "name" or "updateId.name".

--- a/src/utils/config_utils/inc/aduc/config_utils.h
+++ b/src/utils/config_utils/inc/aduc/config_utils.h
@@ -31,15 +31,69 @@
 
 EXTERN_C_BEGIN
 
+#define ADUC_CONNECTION_TYPE_AIS "AIS"
+#define ADUC_CONNECTION_TYPE_MQTTBROKER "MQTTBroker"
+#define ADUC_CONNECTION_TYPE_ADPS2 "ADPS2"
+#define ADUC_CONNECTION_TYPE_STRING "string"
+
+/**
+ * @brief ADUC_AgentInfo that stores all the agent information from configuration file.
+ *
+ * Fields:
+ *  `name` : The user-defined friendly name of the agent.
+ *  `runas` : The user name to run the agent as.
+ *
+ *  `connectionType` can be 'AIS' (Azure Identity Service), MQTTBroker, ADPS2 (Azure Device Provisioning Service v2), or string.
+ *           If it is 'AIS', the `connectionData` is the name of the principal in AIS.
+ *
+ *           If it is 'MQTTBroker', the `connectionData` is not used. The `connectionDataJson` is used instead. It contains
+ *           the following fields:
+ *             `hostName` : The fully qualified domain name of the MQTT broker.
+ *             `tcpPort` : The port number of the MQTT broker.
+ *             `useTLS` : Whether to use TLS for the MQTT connection.
+ *             `cleanSession` : Whether to use a clean session for the MQTT connection.
+ *             `keepAliveInSeconds` : The keep alive interval in seconds for the MQTT connection.
+ *             `clientId` : The client ID for the MQTT connection.
+ *             `userName` : The user name for the MQTT connection.
+ *             `password` : The password for the MQTT connection.
+ *             `caFile` : The path to the CA certificate file for the MQTT connection.
+ *             `certFile` : The path to the client certificate file for the MQTT connection.
+ *             `keyFile` : The path to the client key file for the MQTT connection.
+ *
+ *           If it is 'ADPS2', the `connectionData` is not used. The `connectionDataJson` is used instead. It contains fields:
+ *             `idScope`: The ID scope of the device provisioning service.
+ *             `registrationId`: The registration ID of the device.
+ *             `globalDeviceEndpoint`: The global device endpoint of the device provisioning service.
+ *
+ *             `tcpPort` : The port number of the MQTT broker.
+ *             `useTLS` : Whether to use TLS for the MQTT connection.
+ *             `cleanSession` : Whether to use a clean session for the MQTT connection.
+ *             `keepAliveInSeconds` : The keep alive interval in seconds for the MQTT connection.
+ *             `clientId` : The client ID for the MQTT connection.
+ *             `userName` : The user name for the MQTT connection.
+ *             `password` : The password for the MQTT connection.
+ *             `caFile` : The path to the CA certificate file for the MQTT connection.
+ *             `certFile` : The path to the client certificate file for the MQTT connection.
+ *             `keyFile` : The path to the client key file for the MQTT connection.
+ *
+ *          If it is 'string', the `connectionData` is used as a string. For Device Update Agent V1, this is the connection string from the IoT Hub.
+ *
+ *  `manufacturer` : The manufacturer of the device.
+ *  `model` : The model of the device.
+ *  `additionalDeviceProperties` : Additional device properties.
+ *
+ */
 typedef struct tagADUC_AgentInfo
 {
     char* name; /**< The name of the agent. */
 
     char* runas; /**< Run as a trusted user. */
 
-    char* connectionType; /**< It can be either AIS or string. */
+    char* connectionType; /**< It can be AIS, MQTTBroker, ADPS2, or string. */
 
-    char* connectionData; /**< the name in AIS principal (AIS); or the connectionString (connectionType string). */
+    char* connectionData; /**< the name in AIS principal (AIS); the connectionString (connectionType string). */
+
+    JSON_Value* connectionDataJson; /**< The connection data as a JSON object. (for MQTTBroker and ADPS2)*/
 
     char* manufacturer; /**< Device property manufacturer. */
 
@@ -71,7 +125,7 @@ typedef struct tagADUC_ConfigInfo
 
     ADUC_AgentInfo* agents; /**< Array of agents that are configured. */
 
-    size_t agentCount; /**< Total number of agents configured. */
+    unsigned int agentCount; /**< Total number of agents configured. */
 
     const char* compatPropertyNames; /**< Compat property names. */
 
@@ -155,6 +209,38 @@ VECTOR_HANDLE ADUC_ConfigInfo_GetAduShellTrustedUsers(const ADUC_ConfigInfo* con
  * @param users Object to free. The vector (type VECTOR_HANDLE) containing users (type STRING_HANDLE)
  */
 void ADUC_ConfigInfo_FreeAduShellTrustedUsers(VECTOR_HANDLE users);
+
+/**
+ * @brief Get DU AGent's connection data field of type string.
+ *
+ * @param agent Pointer to ADUC_AgentInfo object.
+ * @param fieldName The field name to get. This can be null or a nested field name, e.g. "name" or "updateId.name".
+ *                  If fieldName not null, this function will return a connectionDataJson
+ * @param value Pointer to a char* to receive the value. Caller must free.
+ * @return bool True if successful.
+ */
+bool ADUC_AgentInfo_ConnectionData_GetStringField(const ADUC_AgentInfo* agent, const char* fieldName, char** value);
+
+/**
+ * @brief Get DU AGent's connection data field of type boolean.
+ *
+ * @param agent Pointer to ADUC_AgentInfo object.
+ * @param fieldName The field name to get. This can be a nested field name, e.g. "useSTL" or "options.keepAlive".
+ * @param value Pointer to a bool to receive the value.
+ * @return bool True if successful.
+ */
+bool ADUC_AgentInfo_ConnectionData_GetBooleanField(const ADUC_AgentInfo* agent, const char* fieldName, bool* value);
+
+/**
+ * @brief Get DU AGent's connection data field of type unsigned int.
+ *
+ * @param agent Pointer to ADUC_AgentInfo object.
+ * @param fieldName The field name to get. This can be a nested field name, e.g. "port" or "options.maxRetry".
+ * @param value Pointer to an unsigned int to receive the value.
+ * @return bool True if successful.
+ */
+bool ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(
+    const ADUC_AgentInfo* agent, const char* fieldName, unsigned int* value);
 
 // clang-format off
 // NOLINTNEXTLINE: clang-tidy doesn't like UMock macro expansions

--- a/src/utils/config_utils/inc/aduc/config_utils.h
+++ b/src/utils/config_utils/inc/aduc/config_utils.h
@@ -224,7 +224,7 @@ void ADUC_ConfigInfo_FreeAduShellTrustedUsers(VECTOR_HANDLE users);
 bool ADUC_AgentInfo_ConnectionData_GetStringField(const ADUC_AgentInfo* agent, const char* fieldName, char** value);
 
 /**
- * @brief Get DU AGent's connection data field of type boolean.
+ * @brief Get DU Agent's connection data field of type boolean.
  *
  * @param agent Pointer to ADUC_AgentInfo object.
  * @param fieldName The field name to get. This can be a nested field name, e.g. "useSTL" or "options.keepAlive".
@@ -234,7 +234,7 @@ bool ADUC_AgentInfo_ConnectionData_GetStringField(const ADUC_AgentInfo* agent, c
 bool ADUC_AgentInfo_ConnectionData_GetBooleanField(const ADUC_AgentInfo* agent, const char* fieldName, bool* value);
 
 /**
- * @brief Get DU AGent's connection data field of type unsigned int.
+ * @brief Get DU Agent's connection data field of type unsigned int.
  *
  * @param agent Pointer to ADUC_AgentInfo object.
  * @param fieldName The field name to get. This can be a nested field name, e.g. "port" or "options.maxRetry".

--- a/src/utils/config_utils/src/config_utils.c
+++ b/src/utils/config_utils/src/config_utils.c
@@ -205,9 +205,9 @@ static void ADUC_AgentInfo_Free(ADUC_AgentInfo* agent)
  * @param agentCount Count of objects in agents.
  * @param agents Array of ADUC_AgentInfo objects to free.
  */
-static void ADUC_AgentInfoArray_Free(unsigned int agentCount, ADUC_AgentInfo* agents)
+static void ADUC_AgentInfoArray_Free(size_t agentCount, ADUC_AgentInfo* agents)
 {
-    for (unsigned int index = 0; index < agentCount; ++index)
+    for (size_t index = 0; index < agentCount; ++index)
     {
         ADUC_AgentInfo* agent = agents + index;
         ADUC_AgentInfo_Free(agent);
@@ -221,7 +221,7 @@ static void ADUC_AgentInfoArray_Free(unsigned int agentCount, ADUC_AgentInfo* ag
  * @param agents ADUC_AgentInfo (size agentCount). Array to be freed using free(), objects must also be freed.
  * @return bool Success state.
  */
-bool ADUC_Json_GetAgents(JSON_Value* root_value, unsigned int* agentCount, ADUC_AgentInfo** agents)
+bool ADUC_Json_GetAgents(JSON_Value* root_value, size_t* agentCount, ADUC_AgentInfo** agents)
 {
     bool succeeded = false;
     if ((agentCount == NULL) || (agents == NULL))

--- a/src/utils/config_utils/src/config_utils.c
+++ b/src/utils/config_utils/src/config_utils.c
@@ -20,7 +20,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 static pthread_mutex_t s_config_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -716,7 +715,7 @@ done:
 }
 
 /**
- * @brief Get DU AGent's connection data field of type string.
+ * @brief Get DU Agent's connection data field of type string.
  *
  * @param agent Pointer to ADUC_AgentInfo object.
  * @param fieldName The field name to get. This can be null or a nested field name, e.g. "name" or "updateId.name".
@@ -787,7 +786,7 @@ done:
 }
 
 /**
- * @brief Get DU AGent's connection data field of type boolean.
+ * @brief Get DU Agent's connection data field of type boolean.
  *
  * @param agent Pointer to ADUC_AgentInfo object.
  * @param fieldName The field name to get. This can be a nested field name, e.g. "useSTL" or "options.keepAlive".
@@ -831,7 +830,7 @@ done:
 }
 
 /**
- * @brief Get DU AGent's connection data field of type unsigned int.
+ * @brief Get DU Agent's connection data field of type unsigned int.
  *
  * @param agent Pointer to ADUC_AgentInfo object.
  * @param fieldName The field name to get. This can be a nested field name, e.g. "port" or "options.maxRetry".

--- a/src/utils/config_utils/src/config_utils.c
+++ b/src/utils/config_utils/src/config_utils.c
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 static pthread_mutex_t s_config_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -101,11 +102,26 @@ static bool ADUC_AgentInfo_Init(ADUC_AgentInfo* agent, const JSON_Object* agent_
     }
 
     connection_type = json_object_get_string(connection_source, CONFIG_CONNECTION_TYPE);
-    connection_data = json_object_get_string(connection_source, CONFIG_CONNECTION_DATA);
+
+    // For v2.0, the connection data can be string or complex value (object)
+    agent->connectionDataJson = json_object_get_value(connection_source, CONFIG_CONNECTION_DATA);
+
+    if (json_value_get_type(agent->connectionDataJson) == JSONString)
+    {
+        connection_data = json_object_get_string(connection_source, CONFIG_CONNECTION_DATA);
+        if (mallocAndStrcpy_s(&(agent->connectionData), connection_data) != 0)
+        {
+            goto done;
+        }
+    }
+    else
+    {
+        agent->connectionData = NULL;
+    }
 
     // As these fields are mandatory, if any of the fields doesn't exist, the agent will fail to be constructed.
-    if (name == NULL || runas == NULL || connection_type == NULL || connection_data == NULL || manufacturer == NULL
-        || model == NULL)
+    if (name == NULL || runas == NULL || connection_type == NULL
+        || (connection_data == NULL && agent->connectionDataJson == NULL) || manufacturer == NULL || model == NULL)
     {
         goto done;
     }
@@ -121,11 +137,6 @@ static bool ADUC_AgentInfo_Init(ADUC_AgentInfo* agent, const JSON_Object* agent_
     }
 
     if (mallocAndStrcpy_s(&(agent->connectionType), connection_type) != 0)
-    {
-        goto done;
-    }
-
-    if (mallocAndStrcpy_s(&(agent->connectionData), connection_data) != 0)
     {
         goto done;
     }
@@ -173,12 +184,16 @@ static void ADUC_AgentInfo_Free(ADUC_AgentInfo* agent)
     free(agent->connectionData);
     agent->connectionData = NULL;
 
+    // connectionDataJson is not allocated, so no need to free it.
+    agent->connectionDataJson = NULL;
+
     free(agent->manufacturer);
     agent->manufacturer = NULL;
 
     free(agent->model);
     agent->model = NULL;
 
+    // additionalDeviceProperties is not allocated, so no need to free it.
     agent->additionalDeviceProperties = NULL;
 }
 
@@ -190,11 +205,11 @@ static void ADUC_AgentInfo_Free(ADUC_AgentInfo* agent)
  * @param agentCount Count of objects in agents.
  * @param agents Array of ADUC_AgentInfo objects to free.
  */
-static void ADUC_AgentInfoArray_Free(size_t agentCount, ADUC_AgentInfo* agents)
+static void ADUC_AgentInfoArray_Free(unsigned int agentCount, ADUC_AgentInfo* agents)
 {
-    for (size_t index = 0; index < agentCount; ++index)
+    for (unsigned int index = 0; index < agentCount; ++index)
     {
-        ADUC_AgentInfo* agent = (ADUC_AgentInfo*)(agents + index);
+        ADUC_AgentInfo* agent = agents + index;
         ADUC_AgentInfo_Free(agent);
     }
     free(agents);
@@ -206,7 +221,7 @@ static void ADUC_AgentInfoArray_Free(size_t agentCount, ADUC_AgentInfo* agents)
  * @param agents ADUC_AgentInfo (size agentCount). Array to be freed using free(), objects must also be freed.
  * @return bool Success state.
  */
-bool ADUC_Json_GetAgents(JSON_Value* root_value, size_t* agentCount, ADUC_AgentInfo** agents)
+bool ADUC_Json_GetAgents(JSON_Value* root_value, unsigned int* agentCount, ADUC_AgentInfo** agents)
 {
     bool succeeded = false;
     if ((agentCount == NULL) || (agents == NULL))
@@ -240,7 +255,7 @@ bool ADUC_Json_GetAgents(JSON_Value* root_value, size_t* agentCount, ADUC_AgentI
         goto done;
     }
 
-    *agentCount = (unsigned int)agents_count;
+    *agentCount = agents_count;
 
     for (size_t index = 0; index < agents_count; ++index)
     {
@@ -698,4 +713,164 @@ int ADUC_ConfigInfo_ReleaseInstance(const ADUC_ConfigInfo* configInfo)
 done:
     s_config_unlock();
     return ret;
+}
+
+/**
+ * @brief Get DU AGent's connection data field of type string.
+ *
+ * @param agent Pointer to ADUC_AgentInfo object.
+ * @param fieldName The field name to get. This can be null or a nested field name, e.g. "name" or "updateId.name".
+ *                  If fieldName not null, this function will return a connectionDataJson
+ * @param value Pointer to a char* to receive the value. Caller must free.
+ * @return bool True if successful.
+ */
+bool ADUC_AgentInfo_ConnectionData_GetStringField(const ADUC_AgentInfo* agent, const char* fieldName, char** value)
+{
+    bool succeeded = false;
+
+    if (agent == NULL)
+    {
+        Log_Error("AgentInfo is NULL.");
+        return false;
+    }
+
+    if (value == NULL)
+    {
+        Log_Error("Value is NULL.");
+        return false;
+    }
+
+    *value = NULL;
+
+    if (fieldName == NULL)
+    {
+        if (agent->connectionData == NULL)
+        {
+            Log_Error("Connection data is not a string.");
+            return false;
+        }
+
+        if (mallocAndStrcpy_s(value, agent->connectionData) != 0)
+        {
+            Log_Error("Failed to allocate memory for connectionData return value.");
+            return false;
+        }
+    }
+    else
+    {
+        if (agent->connectionDataJson == NULL)
+        {
+            Log_Error("Connection data is not an object.");
+            return false;
+        }
+
+        if (!ADUC_JSON_GetStringField(agent->connectionDataJson, fieldName, value))
+        {
+            Log_Error("Failed to get connection data field %s.", fieldName);
+            goto done;
+        }
+    }
+
+    succeeded = true;
+
+done:
+    if (!succeeded)
+    {
+        if (*value != NULL)
+        {
+            free(*value);
+            *value = NULL;
+        }
+    }
+
+    return succeeded;
+}
+
+/**
+ * @brief Get DU AGent's connection data field of type boolean.
+ *
+ * @param agent Pointer to ADUC_AgentInfo object.
+ * @param fieldName The field name to get. This can be a nested field name, e.g. "useSTL" or "options.keepAlive".
+ * @param value Pointer to a bool to receive the value.
+ * @return bool True if successful.
+ */
+bool ADUC_AgentInfo_ConnectionData_GetBooleanField(const ADUC_AgentInfo* agent, const char* fieldName, bool* value)
+{
+    bool succeeded = false;
+
+    if (agent == NULL)
+    {
+        Log_Error("AgentInfo is NULL.");
+        return false;
+    }
+
+    if (value == NULL)
+    {
+        Log_Error("Value is NULL.");
+        return false;
+    }
+
+    *value = false;
+
+    if (agent->connectionDataJson == NULL)
+    {
+        Log_Error("Connection data is not an object.");
+        return false;
+    }
+
+    if (!ADUC_JSON_GetBooleanField(agent->connectionDataJson, fieldName, value))
+    {
+        Log_Error("Failed to get connection data field %s.", fieldName);
+        goto done;
+    }
+
+    succeeded = true;
+
+done:
+    return succeeded;
+}
+
+/**
+ * @brief Get DU AGent's connection data field of type unsigned int.
+ *
+ * @param agent Pointer to ADUC_AgentInfo object.
+ * @param fieldName The field name to get. This can be a nested field name, e.g. "port" or "options.maxRetry".
+ * @param value Pointer to an unsigned int to receive the value.
+ * @return bool True if successful.
+ */
+bool ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(
+    const ADUC_AgentInfo* agent, const char* fieldName, unsigned int* value)
+{
+    bool succeeded = false;
+
+    if (agent == NULL)
+    {
+        Log_Error("AgentInfo is NULL.");
+        return false;
+    }
+
+    if (value == NULL)
+    {
+        Log_Error("Value is NULL.");
+        return false;
+    }
+
+    *value = 0;
+
+    if (agent->connectionDataJson == NULL)
+    {
+        Log_Error("Connection data is not an object.");
+        return false;
+    }
+
+    if (!ADUC_JSON_GetUnsignedIntegerField(agent->connectionDataJson, fieldName, value))
+    {
+        Log_Error("Failed to get connection data field %s.", fieldName);
+        goto done;
+    }
+
+    succeeded = true;
+
+done:
+    return succeeded;
 }

--- a/src/utils/config_utils/tests/CMakeLists.txt
+++ b/src/utils/config_utils/tests/CMakeLists.txt
@@ -7,7 +7,8 @@ include (agentRules)
 compileasc99 ()
 disablertti ()
 
-set (sources main.cpp config_utils_ut.cpp)
+set (sources main.cpp
+             config_utils_ut.cpp)
 
 find_package (Catch2 REQUIRED)
 

--- a/src/utils/config_utils/tests/config_utils_ut.cpp
+++ b/src/utils/config_utils/tests/config_utils_ut.cpp
@@ -386,7 +386,7 @@ static const char* testADSP2Config =
             R"("name": "main",)"
             R"("runas": "adu",)"
             R"("connectionSource": {)"
-            R"("connectionType": "ADPS2",)"
+            R"("connectionType": "ADPS2/MQTT",)"
             R"("connectionData": {)"
               R"("dps" : {)"
                 R"("idScope" : "0ne0123456789abcdef",)"
@@ -536,10 +536,10 @@ static bool _read_mock_adps_settings(Mock_ADPS_Settings* settings)
 
     agent_info = ADUC_ConfigInfo_GetAgent(config, 0);
 
-    // Currently only support "ADPS2" connection data.
-    if (strcmp(agent_info->connectionType, ADUC_CONNECTION_TYPE_ADPS2) != 0)
+    // Currently only support 'ADPS2/MQTT' connection data.
+    if (strcmp(agent_info->connectionType, ADUC_CONNECTION_TYPE_ADPS2_MQTT) != 0)
     {
-        printf("Connection type is not ADPS2");
+        printf("Connection type is not ADPS2/MQTT");
         goto done;
     }
 
@@ -1033,7 +1033,7 @@ TEST_CASE_METHOD(GlobalMockHookTestCaseFixture, "ADUC_ConfigInfo_Init Functional
         CHECK(config->refCount == 0);
     }
 
-    SECTION("ADPS2 connection config test")
+    SECTION("ADPS2/MQTT connection config test")
     {
         REQUIRE(mallocAndStrcpy_s(&g_configContentString, testADSP2Config) == 0);
         ADUC::StringUtils::cstr_wrapper configStr{ g_configContentString };

--- a/src/utils/config_utils/tests/config_utils_ut.cpp
+++ b/src/utils/config_utils/tests/config_utils_ut.cpp
@@ -10,9 +10,10 @@
 
 #include <catch2/catch.hpp>
 
-#include <aduc/c_utils.h>
-#include <aduc/calloc_wrapper.hpp>
+#include "aduc/c_utils.h"
+#include "aduc/calloc_wrapper.hpp"
 #include <azure_c_shared_utility/crt_abstractions.h>
+#include <azure_c_shared_utility/strings.h>
 #include <parson.h>
 #include <string.h>
 
@@ -373,13 +374,399 @@ static const char* invalidConfigContentDownloadTimeout =
         R"(])"
     R"(})";
 
+static const char* testADSP2Config =
+    R"({)"
+        R"("schemaVersion": "2.0",)"
+        R"("aduShellTrustedUsers": [)"
+        R"("adu")"
+        R"(],)"
+        R"("manufacturer": "contoso",)"
+        R"("model": "espresso-v1",)"
+        R"("agents" : [{)"
+            R"("name": "main",)"
+            R"("runas": "adu",)"
+            R"("connectionSource": {)"
+            R"("connectionType": "ADPS2",)"
+            R"("connectionData": {)"
+                R"("idScope" : "0ne0123456789abcdef",)"
+                R"("registrationId" : "adu-dps-client-unit-test-device",)"
+                R"("dpsApiVersion" : "2021-06-01",)"
+                R"("globalDeviceEndpoint" : "global.azure-devices-provisioning.net",)"
+                R"("tcpPort" : 8883,)"
+                R"("useTLS": true,)"
+                R"("cleanSession" : false,)"
+                R"("keepAliveInSeconds" : 3600,)"
+                R"("clientId" : "adu-dps-client-unit-test-device",)"
+                R"("userName" : "adu-dps-client-unit-test-user-1",)"
+                R"("password" : "adu-dps-client-unit-test-password-1",)"
+                R"("caFile" : "adu-dps-client-unit-test-ca-1",)"
+                R"("certFile" : "adu-dps-client-unit-test-cert-1.pem",)"
+                R"("keyFile" : "adu-dps-client-unit-test-key-1.pem",)"
+                R"("keyFilePassword" : "adu-dps-client-unit-test-key-password-1")"
+            R"(})"
+            R"(},)"
+            R"("manufacturer": "contoso",)"
+            R"("model": "espresso-v1")"
+        R"(}])"
+    R"(})";
+
+static const char* testMQTTBrokerConfig =
+    R"({)"
+        R"("schemaVersion": "2.0",)"
+        R"("aduShellTrustedUsers": [)"
+        R"("adu")"
+        R"(],)"
+        R"("manufacturer": "contoso",)"
+        R"("model": "espresso-v1",)"
+        R"("agents" : [{)"
+            R"("name": "main",)"
+            R"("runas": "adu",)"
+            R"("connectionSource": {)"
+            R"("connectionType": "MQTTBroker",)"
+            R"("connectionData": {)"
+                R"("hostName" : "contoso-red-devbox-wus3-eg.westus2-1.ts.eventgrid.azure.net",)"
+                R"("tcpPort" : 8883,)"
+                R"("useTLS": true,)"
+                R"("cleanSession" : true,)"
+                R"("keepAliveInSeconds" : 3600,)"
+                R"("clientId" : "adu-mqtt-client-unit-test-device",)"
+                R"("userName" : "adu-mqtt-client-unit-test-user-1",)"
+                R"("password" : "adu-mqtt-client-unit-test-password-1",)"
+                R"("caFile" : "adu-mqtt-client-unit-test-ca-1",)"
+                R"("certFile" : "adu-mqtt-client-unit-test-cert-1.pem",)"
+                R"("keyFile" : "adu-mqtt-client-unit-test-key-1.pem",)"
+                R"("keyFilePassword" : "adu-mqtt-client-unit-test-key-password-1")"
+            R"(})"
+            R"(},)"
+            R"("manufacturer": "contoso",)"
+            R"("model": "espresso-v1")"
+        R"(}])"
+    R"(})";
 
 static char* g_configContentString = nullptr;
 
+/**
+ * @brief Mock for json_parse_file. This function will return a JSON_Value* based on the value of g_configContentString, if specified.
+ * Otherwise, it fallback to the default implementation.
+ *
+ * @param configFilePath A path to a file containing JSON data.
+ *
+ * @return JSON_Value* A JSON_Value containing the parsed data.
+ */
 static JSON_Value* MockParse_JSON_File(const char* configFilePath)
 {
     UNREFERENCED_PARAMETER(configFilePath);
     return json_parse_string(g_configContentString);
+}
+
+/**
+ * @brief Struct containing the connection settings for the Azure DPS .
+ * This is a data structure that is used for unit testing only.
+ * The actual MQTT broker connection settings are defined in src/extensions/agent_modules/communication_modules/inc.
+ * This data structure is used to compare the values read from the config file with the expected values.
+ */
+typedef struct _mock_adps_settings
+{
+  char* idScope;           /*< Device Provisioning Service Id Scope */
+  char* registrationId;    /*< Device Provisioning Service Registration Id */
+  char* dpsApiVersion;     /*< Device Provisioning Service API Version */
+  char* caFile;            /*< Path to a PEM file with the chain required to trust the TLS endpoint certificate */
+  char* certFile;          /*< Path to a PEM file to establish X509 client authentication */
+  char* clientId;          /*< MQTT Client Id */
+  char* hostname;          /*< FQDM to the MQTT Broker endpoint, eg: mybroker.mydomain.com */
+  char* keyFile;           /*< Path to a KEY file to establish X509 client authentication */
+  char* keyFilePassword;   /*< Password (aka pass-phrase) to protect the key file */
+  char* password;          /*< MQTT Password to authenticate the connection */
+  char* username;          /*< MQTT Username to authenticate the connection */
+  unsigned int keepAliveInSeconds; /*< Seconds to send the ping to keep the connection open */
+  unsigned int tcpPort;    /*< TCP port to access the endpoint eg: 8883 */
+  bool cleanSession;       /*< MQTT Clean Session, might require to set the ClientId [existing sessions are not supported now] */
+  bool useTLS;             /*< Disable TLS negotiation (not recommended for production)*/
+} Mock_ADPS_Settings;
+
+#define DEFAULT_TCP_PORT 8883
+#define DEFAULT_KEEP_ALIVE_IN_SECONDS 30
+#define DEFAULT_USE_TLS true
+#define DEFAULT_CLEAN_SESSION false
+#define DEFAULT_MQTTBROKER_CLEAN_SESSION true
+
+static void _free_mock_adps_settings(Mock_ADPS_Settings* settings)
+{
+    if (settings == NULL)
+    {
+        return;
+    }
+
+    free(settings->idScope);
+    free(settings->registrationId);
+    free(settings->dpsApiVersion);
+
+    free(settings->hostname);
+    free(settings->clientId);
+    free(settings->username);
+    free(settings->password);
+    free(settings->caFile);
+    free(settings->certFile);
+    free(settings->keyFile);
+    free(settings->keyFilePassword);
+    memset(settings, 0, sizeof(*settings));
+}
+
+static bool _read_mock_adps_settings(Mock_ADPS_Settings* settings)
+{
+    bool result = false;
+    const ADUC_ConfigInfo* config = NULL;
+    const ADUC_AgentInfo* agent_info = NULL;
+
+    if (settings == NULL)
+    {
+        goto done;
+    }
+
+    memset(settings, 0, sizeof(*settings));
+
+    config = ADUC_ConfigInfo_GetInstance();
+    if (config == NULL) {
+        goto done;
+    }
+
+    agent_info = ADUC_ConfigInfo_GetAgent(config, 0);
+
+    // Currently only support "ADPS2" connection data.
+    if (strcmp(agent_info->connectionType, ADUC_CONNECTION_TYPE_ADPS2) != 0)
+    {
+        printf("Connection type is not ADPS2");
+        goto done;
+    }
+
+    // NOTE: This is the 'globalDeviceEndpoint' field in the config file.
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "globalDeviceEndpoint", &settings->hostname))
+    {
+        printf("Failed to get hostname");
+        goto done;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "idScope", &settings->idScope))
+    {
+        printf("Failed to get idScope");
+        goto done;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dpsApiVersion", &settings->dpsApiVersion))
+    {
+        printf("Failed to get dpsApiVersion");
+        goto done;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "registrationId", &settings->registrationId))
+    {
+        printf("Failed to get registrationId");
+        goto done;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "tcpPort", &settings->tcpPort))
+    {
+        settings->tcpPort = DEFAULT_TCP_PORT;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "useTLS", &settings->useTLS))
+    {
+        settings->useTLS = DEFAULT_USE_TLS;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "cleanSession", &settings->cleanSession))
+    {
+        settings->cleanSession = DEFAULT_CLEAN_SESSION;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "keepAliveInSeconds", &settings->keepAliveInSeconds))
+    {
+        settings->keepAliveInSeconds = DEFAULT_KEEP_ALIVE_IN_SECONDS;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "clientId", &settings->clientId))
+    {
+        settings->clientId = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "userName", &settings->username))
+    {
+        settings->username = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "password", &settings->password))
+    {
+        settings->password = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "caFile", &settings->caFile))
+    {
+        settings->caFile = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "certFile", &settings->certFile))
+    {
+        settings->certFile = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "keyFile", &settings->keyFile))
+    {
+        settings->keyFile = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "keyFilePassword", &settings->keyFilePassword))
+    {
+        settings->keyFilePassword = NULL;
+    }
+
+    result = true;
+
+done:
+    ADUC_ConfigInfo_ReleaseInstance(config);
+    if (!result)
+    {
+        _free_mock_adps_settings(settings);
+    }
+    return result;
+}
+
+/**
+ * @brief Struct containing the connection settings for the MQTT client.
+ * This is a data structure that is used for unit testing only.
+ * The actual MQTT broker connection settings are defined in src/extensions/agent_modules/communication_modules/inc.
+ * This data structure is used to compare the values read from the config file with the expected values.
+ */
+typedef struct _mock_mqtt_broker_settings
+{
+  char* caFile;            /*< Path to a PEM file with the chain required to trust the TLS endpoint certificate */
+  char* certFile;          /*< Path to a PEM file to establish X509 client authentication */
+  char* clientId;          /*< MQTT Client Id */
+  char* hostname;          /*< FQDM to the MQTT Broker endpoint, eg: mybroker.mydomain.com */
+  char* keyFile;           /*< Path to a KEY file to establish X509 client authentication */
+  char* keyFilePassword;   /*< Password (aka pass-phrase) to protect the key file */
+  char* password;          /*< MQTT Password to authenticate the connection */
+  char* username;          /*< MQTT Username to authenticate the connection */
+  unsigned int keepAliveInSeconds; /*< Seconds to send the ping to keep the connection open */
+  unsigned int tcpPort;    /*< TCP port to access the endpoint eg: 8883 */
+  bool cleanSession;       /*< MQTT Clean Session, might require to set the ClientId [existing sessions are not supported now] */
+  bool useTLS;             /*< Disable TLS negotiation (not recommended for production)*/
+} Mock_MQTT_Broker_Settings;
+
+static void _free_mock_mqtt_broker_settings(Mock_MQTT_Broker_Settings* settings)
+{
+    if (settings == NULL)
+    {
+        return;
+    }
+
+    free(settings->hostname);
+    free(settings->clientId);
+    free(settings->username);
+    free(settings->password);
+    free(settings->caFile);
+    free(settings->certFile);
+    free(settings->keyFile);
+    free(settings->keyFilePassword);
+    memset(settings, 0, sizeof(*settings));
+}
+
+static bool _read_mock_mqtt_broker_settings(Mock_MQTT_Broker_Settings* settings)
+{
+    bool result = false;
+    const ADUC_ConfigInfo* config = NULL;
+    const ADUC_AgentInfo* agent_info = NULL;
+
+    if (settings == NULL)
+    {
+        goto done;
+    }
+
+    memset(settings, 0, sizeof(*settings));
+
+    config = ADUC_ConfigInfo_GetInstance();
+    if (config == NULL) {
+        goto done;
+    }
+
+    agent_info = ADUC_ConfigInfo_GetAgent(config, 0);
+
+    // Currently only support "MQTTBroker" connection data. (DPS Gen2 support will be available after 2023/Q4)
+    if (strcmp(agent_info->connectionType, ADUC_CONNECTION_TYPE_MQTTBROKER) != 0)
+    {
+        printf("Connection type is not MQTTBroker");
+        goto done;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "hostName", &settings->hostname))
+    {
+        printf("Failed to get hostname");
+        goto done;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "tcpPort", &settings->tcpPort))
+    {
+        settings->tcpPort = DEFAULT_TCP_PORT;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "useTLS", &settings->useTLS))
+    {
+        settings->useTLS = DEFAULT_USE_TLS;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "cleanSession", &settings->cleanSession))
+    {
+        settings->cleanSession = DEFAULT_MQTTBROKER_CLEAN_SESSION;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "keepAliveInSeconds", &settings->keepAliveInSeconds))
+    {
+        settings->keepAliveInSeconds = DEFAULT_KEEP_ALIVE_IN_SECONDS;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "clientId", &settings->clientId))
+    {
+        settings->clientId = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "userName", &settings->username))
+    {
+        settings->username = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "password", &settings->password))
+    {
+        settings->password = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "caFile", &settings->caFile))
+    {
+        settings->caFile = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "certFile", &settings->certFile))
+    {
+        settings->certFile = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "keyFile", &settings->keyFile))
+    {
+        settings->keyFile = NULL;
+    }
+
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "keyFilePassword", &settings->keyFilePassword))
+    {
+        settings->keyFilePassword = NULL;
+    }
+
+    result = true;
+
+done:
+    ADUC_ConfigInfo_ReleaseInstance(config);
+    if (!result)
+    {
+        _free_mock_mqtt_broker_settings(settings);
+    }
+    return result;
 }
 
 class GlobalMockHookTestCaseFixture
@@ -640,5 +1027,60 @@ TEST_CASE_METHOD(GlobalMockHookTestCaseFixture, "ADUC_ConfigInfo_Init Functional
         CHECK_THAT(config->downloadsFolder, Equals("/var/lib/adu/mydata/downloads"));
         ADUC_ConfigInfo_ReleaseInstance(config);
         CHECK(config->refCount == 0);
+    }
+
+    SECTION("ADPS2 connection config test")
+    {
+        REQUIRE(mallocAndStrcpy_s(&g_configContentString, testADSP2Config) == 0);
+        ADUC::StringUtils::cstr_wrapper configStr{ g_configContentString };
+
+        Mock_ADPS_Settings settings;
+
+        bool success = _read_mock_adps_settings(&settings);
+        CHECK(success);
+
+        CHECK_THAT(settings.hostname, Equals("global.azure-devices-provisioning.net"));
+        CHECK_THAT(settings.clientId, Equals("adu-dps-client-unit-test-device"));
+        CHECK_THAT(settings.registrationId, Equals("adu-dps-client-unit-test-device"));
+        CHECK_THAT(settings.idScope, Equals("0ne0123456789abcdef"));
+        CHECK_THAT(settings.dpsApiVersion, Equals("2021-06-01"));
+        CHECK_THAT(settings.username, Equals("adu-dps-client-unit-test-user-1"));
+        CHECK_THAT(settings.password, Equals("adu-dps-client-unit-test-password-1"));
+        CHECK_THAT(settings.caFile, Equals("adu-dps-client-unit-test-ca-1"));
+        CHECK_THAT(settings.certFile, Equals("adu-dps-client-unit-test-cert-1.pem"));
+        CHECK_THAT(settings.keyFile, Equals("adu-dps-client-unit-test-key-1.pem"));
+        CHECK_THAT(settings.keyFilePassword, Equals("adu-dps-client-unit-test-key-password-1"));
+        CHECK(settings.keepAliveInSeconds == 3600);
+        CHECK(settings.tcpPort == 8883);
+        CHECK(settings.cleanSession == false);
+        CHECK(settings.useTLS == true);
+
+        _free_mock_adps_settings(&settings);
+    }
+
+    SECTION("MQTTBroker connection config test")
+    {
+        REQUIRE(mallocAndStrcpy_s(&g_configContentString, testMQTTBrokerConfig) == 0);
+        ADUC::StringUtils::cstr_wrapper configStr{ g_configContentString };
+
+        Mock_MQTT_Broker_Settings settings;
+
+        bool success = _read_mock_mqtt_broker_settings(&settings);
+        CHECK(success);
+
+        CHECK_THAT(settings.hostname, Equals("contoso-red-devbox-wus3-eg.westus2-1.ts.eventgrid.azure.net"));
+        CHECK_THAT(settings.clientId, Equals("adu-mqtt-client-unit-test-device"));
+        CHECK_THAT(settings.username, Equals("adu-mqtt-client-unit-test-user-1"));
+        CHECK_THAT(settings.password, Equals("adu-mqtt-client-unit-test-password-1"));
+        CHECK_THAT(settings.caFile, Equals("adu-mqtt-client-unit-test-ca-1"));
+        CHECK_THAT(settings.certFile, Equals("adu-mqtt-client-unit-test-cert-1.pem"));
+        CHECK_THAT(settings.keyFile, Equals("adu-mqtt-client-unit-test-key-1.pem"));
+        CHECK_THAT(settings.keyFilePassword, Equals("adu-mqtt-client-unit-test-key-password-1"));
+        CHECK(settings.keepAliveInSeconds == 3600);
+        CHECK(settings.tcpPort == 8883);
+        CHECK(settings.cleanSession == true);
+        CHECK(settings.useTLS == true);
+
+        _free_mock_mqtt_broker_settings(&settings);
     }
 }

--- a/src/utils/config_utils/tests/config_utils_ut.cpp
+++ b/src/utils/config_utils/tests/config_utils_ut.cpp
@@ -388,9 +388,10 @@ static const char* testADSP2Config =
             R"("connectionSource": {)"
             R"("connectionType": "ADPS2",)"
             R"("connectionData": {)"
+              R"("dps" : {)"
                 R"("idScope" : "0ne0123456789abcdef",)"
                 R"("registrationId" : "adu-dps-client-unit-test-device",)"
-                R"("dpsApiVersion" : "2021-06-01",)"
+                R"("apiVersion" : "2021-06-01",)"
                 R"("globalDeviceEndpoint" : "global.azure-devices-provisioning.net",)"
                 R"("tcpPort" : 8883,)"
                 R"("useTLS": true,)"
@@ -403,6 +404,7 @@ static const char* testADSP2Config =
                 R"("certFile" : "adu-dps-client-unit-test-cert-1.pem",)"
                 R"("keyFile" : "adu-dps-client-unit-test-key-1.pem",)"
                 R"("keyFilePassword" : "adu-dps-client-unit-test-key-password-1")"
+              R"(})"
             R"(})"
             R"(},)"
             R"("manufacturer": "contoso",)"
@@ -424,6 +426,7 @@ static const char* testMQTTBrokerConfig =
             R"("connectionSource": {)"
             R"("connectionType": "MQTTBroker",)"
             R"("connectionData": {)"
+              R"("mqttBroker" : {)"
                 R"("hostName" : "contoso-red-devbox-wus3-eg.westus2-1.ts.eventgrid.azure.net",)"
                 R"("tcpPort" : 8883,)"
                 R"("useTLS": true,)"
@@ -436,6 +439,7 @@ static const char* testMQTTBrokerConfig =
                 R"("certFile" : "adu-mqtt-client-unit-test-cert-1.pem",)"
                 R"("keyFile" : "adu-mqtt-client-unit-test-key-1.pem",)"
                 R"("keyFilePassword" : "adu-mqtt-client-unit-test-key-password-1")"
+              R"(})"
             R"(})"
             R"(},)"
             R"("manufacturer": "contoso",)"
@@ -540,81 +544,81 @@ static bool _read_mock_adps_settings(Mock_ADPS_Settings* settings)
     }
 
     // NOTE: This is the 'globalDeviceEndpoint' field in the config file.
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "globalDeviceEndpoint", &settings->hostname))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.globalDeviceEndpoint", &settings->hostname))
     {
         printf("Failed to get hostname");
         goto done;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "idScope", &settings->idScope))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.idScope", &settings->idScope))
     {
         printf("Failed to get idScope");
         goto done;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dpsApiVersion", &settings->dpsApiVersion))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.apiVersion", &settings->dpsApiVersion))
     {
         printf("Failed to get dpsApiVersion");
         goto done;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "registrationId", &settings->registrationId))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.registrationId", &settings->registrationId))
     {
         printf("Failed to get registrationId");
         goto done;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "tcpPort", &settings->tcpPort))
+    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "dps.tcpPort", &settings->tcpPort))
     {
         settings->tcpPort = DEFAULT_TCP_PORT;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "useTLS", &settings->useTLS))
+    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "dps.useTLS", &settings->useTLS))
     {
         settings->useTLS = DEFAULT_USE_TLS;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "cleanSession", &settings->cleanSession))
+    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "dps.cleanSession", &settings->cleanSession))
     {
         settings->cleanSession = DEFAULT_CLEAN_SESSION;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "keepAliveInSeconds", &settings->keepAliveInSeconds))
+    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "dps.keepAliveInSeconds", &settings->keepAliveInSeconds))
     {
         settings->keepAliveInSeconds = DEFAULT_KEEP_ALIVE_IN_SECONDS;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "clientId", &settings->clientId))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.clientId", &settings->clientId))
     {
         settings->clientId = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "userName", &settings->username))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.userName", &settings->username))
     {
         settings->username = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "password", &settings->password))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.password", &settings->password))
     {
         settings->password = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "caFile", &settings->caFile))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.caFile", &settings->caFile))
     {
         settings->caFile = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "certFile", &settings->certFile))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.certFile", &settings->certFile))
     {
         settings->certFile = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "keyFile", &settings->keyFile))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.keyFile", &settings->keyFile))
     {
         settings->keyFile = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "keyFilePassword", &settings->keyFilePassword))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.keyFilePassword", &settings->keyFilePassword))
     {
         settings->keyFilePassword = NULL;
     }
@@ -697,63 +701,63 @@ static bool _read_mock_mqtt_broker_settings(Mock_MQTT_Broker_Settings* settings)
         goto done;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "hostName", &settings->hostname))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "mqttBroker.hostName", &settings->hostname))
     {
         printf("Failed to get hostname");
         goto done;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "tcpPort", &settings->tcpPort))
+    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "mqttBroker.tcpPort", &settings->tcpPort))
     {
         settings->tcpPort = DEFAULT_TCP_PORT;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "useTLS", &settings->useTLS))
+    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "mqttBroker.useTLS", &settings->useTLS))
     {
         settings->useTLS = DEFAULT_USE_TLS;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "cleanSession", &settings->cleanSession))
+    if (!ADUC_AgentInfo_ConnectionData_GetBooleanField(agent_info, "mqttBroker.cleanSession", &settings->cleanSession))
     {
         settings->cleanSession = DEFAULT_MQTTBROKER_CLEAN_SESSION;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "keepAliveInSeconds", &settings->keepAliveInSeconds))
+    if (!ADUC_AgentInfo_ConnectionData_GetUnsignedIntegerField(agent_info, "mqttBroker.keepAliveInSeconds", &settings->keepAliveInSeconds))
     {
         settings->keepAliveInSeconds = DEFAULT_KEEP_ALIVE_IN_SECONDS;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "clientId", &settings->clientId))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "mqttBroker.clientId", &settings->clientId))
     {
         settings->clientId = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "userName", &settings->username))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "mqttBroker.userName", &settings->username))
     {
         settings->username = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "password", &settings->password))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "mqttBroker.password", &settings->password))
     {
         settings->password = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "caFile", &settings->caFile))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "mqttBroker.caFile", &settings->caFile))
     {
         settings->caFile = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "certFile", &settings->certFile))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "mqttBroker.certFile", &settings->certFile))
     {
         settings->certFile = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "keyFile", &settings->keyFile))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "mqttBroker.keyFile", &settings->keyFile))
     {
         settings->keyFile = NULL;
     }
 
-    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "keyFilePassword", &settings->keyFilePassword))
+    if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "mqttBroker.keyFilePassword", &settings->keyFilePassword))
     {
         settings->keyFilePassword = NULL;
     }

--- a/src/utils/config_utils/tests/config_utils_ut.cpp
+++ b/src/utils/config_utils/tests/config_utils_ut.cpp
@@ -494,7 +494,7 @@ typedef struct _mock_adps_settings
 #define DEFAULT_CLEAN_SESSION false
 #define DEFAULT_MQTTBROKER_CLEAN_SESSION true
 
-static void _free_mock_adps_settings(Mock_ADPS_Settings* settings)
+static void free_mock_adps_settings(Mock_ADPS_Settings* settings)
 {
     if (settings == NULL)
     {
@@ -539,32 +539,27 @@ static bool _read_mock_adps_settings(Mock_ADPS_Settings* settings)
     // Currently only support 'ADPS2/MQTT' connection data.
     if (strcmp(agent_info->connectionType, ADUC_CONNECTION_TYPE_ADPS2_MQTT) != 0)
     {
-        printf("Connection type is not ADPS2/MQTT");
         goto done;
     }
 
     // NOTE: This is the 'globalDeviceEndpoint' field in the config file.
     if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.globalDeviceEndpoint", &settings->hostname))
     {
-        printf("Failed to get hostname");
         goto done;
     }
 
     if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.idScope", &settings->idScope))
     {
-        printf("Failed to get idScope");
         goto done;
     }
 
     if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.apiVersion", &settings->dpsApiVersion))
     {
-        printf("Failed to get dpsApiVersion");
         goto done;
     }
 
     if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "dps.registrationId", &settings->registrationId))
     {
-        printf("Failed to get registrationId");
         goto done;
     }
 
@@ -629,7 +624,7 @@ done:
     ADUC_ConfigInfo_ReleaseInstance(config);
     if (!result)
     {
-        _free_mock_adps_settings(settings);
+        free_mock_adps_settings(settings);
     }
     return result;
 }
@@ -656,7 +651,7 @@ typedef struct _mock_mqtt_broker_settings
   bool useTLS;             /*< Disable TLS negotiation (not recommended for production)*/
 } Mock_MQTT_Broker_Settings;
 
-static void _free_mock_mqtt_broker_settings(Mock_MQTT_Broker_Settings* settings)
+static void free_mock_mqtt_broker_settings(Mock_MQTT_Broker_Settings* settings)
 {
     if (settings == NULL)
     {
@@ -697,13 +692,11 @@ static bool _read_mock_mqtt_broker_settings(Mock_MQTT_Broker_Settings* settings)
     // Currently only support "MQTTBroker" connection data. (DPS Gen2 support will be available after 2023/Q4)
     if (strcmp(agent_info->connectionType, ADUC_CONNECTION_TYPE_MQTTBROKER) != 0)
     {
-        printf("Connection type is not MQTTBroker");
         goto done;
     }
 
     if (!ADUC_AgentInfo_ConnectionData_GetStringField(agent_info, "mqttBroker.hostName", &settings->hostname))
     {
-        printf("Failed to get hostname");
         goto done;
     }
 
@@ -768,7 +761,7 @@ done:
     ADUC_ConfigInfo_ReleaseInstance(config);
     if (!result)
     {
-        _free_mock_mqtt_broker_settings(settings);
+        free_mock_mqtt_broker_settings(settings);
     }
     return result;
 }
@@ -1059,7 +1052,7 @@ TEST_CASE_METHOD(GlobalMockHookTestCaseFixture, "ADUC_ConfigInfo_Init Functional
         CHECK(settings.cleanSession == false);
         CHECK(settings.useTLS == true);
 
-        _free_mock_adps_settings(&settings);
+        free_mock_adps_settings(&settings);
     }
 
     SECTION("MQTTBroker connection config test")
@@ -1085,6 +1078,6 @@ TEST_CASE_METHOD(GlobalMockHookTestCaseFixture, "ADUC_ConfigInfo_Init Functional
         CHECK(settings.cleanSession == true);
         CHECK(settings.useTLS == true);
 
-        _free_mock_mqtt_broker_settings(&settings);
+        free_mock_mqtt_broker_settings(&settings);
     }
 }

--- a/src/utils/parson_json_utils/inc/parson_json_utils.h
+++ b/src/utils/parson_json_utils/inc/parson_json_utils.h
@@ -24,7 +24,7 @@ bool ADUC_JSON_SetStringField(const JSON_Value* jsonValue, const char* jsonField
 
 bool ADUC_JSON_GetStringField(const JSON_Value* jsonValue, const char* jsonFieldName, char** value);
 
-bool ADUC_JSON_GetBooleanField(const JSON_Value* jsonValue, const char* jsonFieldName);
+bool ADUC_JSON_GetBooleanField(const JSON_Value* jsonValue, const char* jsonFieldName, bool* value);
 
 bool ADUC_JSON_GetUnsignedIntegerField(const JSON_Value* jsonValue, const char* jsonFieldName, unsigned int* value);
 

--- a/src/utils/parson_json_utils/src/parson_json_utils.c
+++ b/src/utils/parson_json_utils/src/parson_json_utils.c
@@ -9,13 +9,8 @@
 
 #include <aduc/logging.h>
 #include <aduc/string_c_utils.h>
-#include <azure_c_shared_utility/crt_abstractions.h>
+#include <azure_c_shared_utility/crt_abstractions.h> // For mallocAndStrcpy_s
 #include <azure_c_shared_utility/strings.h>
-#include <stdbool.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
-#include <unistd.h>
 
 /**
  * @brief Returns the pointer to the @p jsonFieldName from the JSON_Value

--- a/src/utils/parson_json_utils/src/parson_json_utils.c
+++ b/src/utils/parson_json_utils/src/parson_json_utils.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
 
 /**
  * @brief Returns the pointer to the @p jsonFieldName from the JSON_Value
@@ -33,7 +34,7 @@ const char* ADUC_JSON_GetStringFieldPtr(const JSON_Value* jsonValue, const char*
         return NULL;
     }
 
-    return json_object_get_string(object, jsonFieldName);
+    return json_object_dotget_string(object, jsonFieldName);
 }
 
 /**
@@ -41,24 +42,27 @@ const char* ADUC_JSON_GetStringFieldPtr(const JSON_Value* jsonValue, const char*
  *
  * @param jsonValue The JSON Value.
  * @param jsonFieldName The name of the JSON field to get.
- * @return the boolean value of the jsonFieldName, returns false on fail and logs error
+ * @param value Pointer to a bool to receive the value.
+ * @return bool Tree if successful.
  */
-bool ADUC_JSON_GetBooleanField(const JSON_Value* jsonValue, const char* jsonFieldName)
+bool ADUC_JSON_GetBooleanField(const JSON_Value* jsonValue, const char* jsonFieldName, bool* value)
 {
     JSON_Object* object = json_value_get_object(jsonValue);
 
-    if (object == NULL)
+    if (object == NULL || value == NULL)
     {
         return false;
     }
 
-    int result = json_object_get_boolean(object, jsonFieldName);
+    int result = json_object_dotget_boolean(object, jsonFieldName);
     if (result == -1)
     {
         Log_Error("Cannot get json field name %s, default to false.", jsonFieldName);
         return false;
     }
-    return result;
+
+    *value = (result != 0);
+    return true;
 }
 
 /**
@@ -78,7 +82,7 @@ bool ADUC_JSON_SetStringField(const JSON_Value* jsonValue, const char* jsonField
         return false;
     }
 
-    return json_object_set_string(object, jsonFieldName, value) == JSONSuccess;
+    return json_object_dotset_string(object, jsonFieldName, value) == JSONSuccess;
 }
 
 /**
@@ -101,7 +105,7 @@ bool ADUC_JSON_GetStringField(const JSON_Value* jsonValue, const char* jsonField
         goto done;
     }
 
-    const char* value_val = json_object_get_string(root_object, jsonFieldName);
+    const char* value_val = json_object_dotget_string(root_object, jsonFieldName);
     if (value_val == NULL)
     {
         goto done;
@@ -142,7 +146,7 @@ bool ADUC_JSON_GetStringFieldFromObj(const JSON_Object* jsonObj, const char* jso
         return false;
     }
 
-    const char* fieldValue = json_object_get_string(jsonObj, jsonFieldName);
+    const char* fieldValue = json_object_dotget_string(jsonObj, jsonFieldName);
 
     if (mallocAndStrcpy_s(value, fieldValue) != 0)
     {
@@ -179,7 +183,7 @@ bool ADUC_JSON_GetUnsignedIntegerField(const JSON_Value* jsonValue, const char* 
     }
 
     // Note: cannot determine failure in this call as 0 is a valid return, always assume succeeded at this point
-    val = json_object_get_number(jsonObj, jsonFieldName);
+    val = json_object_dotget_number(jsonObj, jsonFieldName);
 
     // Note: check value is not negative and is a whole number for safe casting to an unsigned int
     if (val < 0 || ((int)val) != val)
@@ -224,7 +228,7 @@ bool ADUC_JSON_GetLongLongField(const JSON_Value* jsonValue, const char* jsonFie
     }
 
     // Note: cannot determine failure in this call as 0 is a valid return, always assume succeeded at this point
-    val = json_object_get_number(jsonObj, jsonFieldName);
+    val = json_object_dotget_number(jsonObj, jsonFieldName);
 
     // Note: check value is a whole number for safe casting to an unsigned int
     if (((long long)val) != val)


### PR DESCRIPTION
These changes are essential modifications to facilitate device registration through the Device Provisioning Service (via MQTT) and to communicate with the MQTT broker.

- Introduced connection types: `"ADPS2"` and `"MQTTBroker"`
- For the "ADPS2" type, connection details can be found at **"agents[###].connectionData.dps"**
- For the "MQTTBroker" type, connection details are located under **"agents[###].connectionData.mqttBroker"**.**

See [Using the MQTT protocol directly (as a device)](https://learn.microsoft.com/en-us/azure/iot/iot-mqtt-connect-to-iot-dps#using-the-mqtt-protocol-directly-as-a-device) and [Overview of the MQTT Support in Azure Event Grid (Preview)](https://learn.microsoft.com/en-us/azure/event-grid/mqtt-overview) for more details.