### PR TITLE
fix CancelApply swupdate_handler_v1

### DIFF
--- a/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
+++ b/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
@@ -513,7 +513,7 @@ static ADUC_Result CancelApply(const char* logFolder)
         const std::vector<std::string> aduShellArgs{
             adushconst::config_folder_opt,     config->configFolder,
             adushconst::update_type_opt,       adushconst::update_type_microsoft_swupdate,
-            adushconst::update_action_opt,     adushconst::update_action_apply,
+            adushconst::update_action_opt,     adushconst::update_action_rollback,
             adushconst::target_log_folder_opt, logFolder
         };
 


### PR DESCRIPTION
- calls now the correct revert action in the adu-swupdate.sh script