### PR TITLE
set unenrolled state, refactorings, cmake corrections

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,7 +63,6 @@ set (ADUC_EXPORT_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/inc ${CMAKE_CURRENT_SOURCE
 set (ADU_SHELL_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/adu-shell/inc)
 set (ADU_EXTENSION_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/extensions/inc
                             ${CMAKE_CURRENT_SOURCE_DIR}/adu_types/inc)
-set (ADU_AGENT_SDK_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/agent_sdk/inc)
 
 add_subdirectory (libaducpal)
 add_subdirectory (adu-shell)
@@ -80,3 +79,4 @@ add_subdirectory (utils)
 add_subdirectory (extensions)
 add_subdirectory (agent)
 add_subdirectory (agent_orchestration)
+add_subdirectory (agent_sdk)

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -115,7 +115,7 @@ endif ()
 get_filename_component (ADUC_INSTALLEDCRITERIA_FILE_PATH
                         "${ADUC_DATA_FOLDER}/${ADUC_INSTALLEDCRITERIA_FILE}" ABSOLUTE "/")
 
-target_include_directories (${target_name} PRIVATE inc ${ADU_AGENT_SDK_INCLUDES})
+target_include_directories (${target_name} PRIVATE inc)
 
 target_compile_definitions (
     ${target_name}

--- a/src/agent/command_helper/inc/aduc/command_helper.h
+++ b/src/agent/command_helper/inc/aduc/command_helper.h
@@ -22,7 +22,7 @@ typedef bool (*ADUC_CommandCallbackFunc)(const char* command, void* commandConte
 /**
  * @brief A struct containing a basic command information.
  */
-typedef struct _tagADUC_Command
+typedef struct tagADUC_Command
 {
     const char* commandText; /**< command text */
     ADUC_CommandCallbackFunc callback; /**< callback function for the command */

--- a/src/agent_sdk/CMakeLists.txt
+++ b/src/agent_sdk/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+set (target_name du_agent_sdk)
+
+add_library (${target_name} INTERFACE)
+add_library (aduc::${target_name} ALIAS ${target_name})
+
+target_include_directories (${target_name} INTERFACE inc)

--- a/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/CMakeLists.txt
+++ b/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/CMakeLists.txt
@@ -10,10 +10,7 @@ find_package (Parson REQUIRED)
 
 target_sources (${target_name} PRIVATE src/adps_gen2.c src/adps2_mqtt_client_module.c)
 
-target_include_directories (
-    ${target_name}
-    PUBLIC inc
-    PRIVATE ${PROJECT_SOURCE_DIR}/inc ../inc ../../inc ${ADU_AGENT_SDK_INCLUDES})
+target_include_directories (${target_name} PUBLIC inc)
 
 target_link_libraries (
     ${target_name}

--- a/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/src/adps2_mqtt_client_module.c
+++ b/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/src/adps2_mqtt_client_module.c
@@ -29,7 +29,7 @@
 /**
  * @brief Enumeration of registration states for Azure DPS device registration management.
  */
-typedef enum ADPS_REGISTER_STATE_TAG
+typedef enum tagADPS_REGISTER_STATE
 {
     ADPS_REGISTER_STATE_FAILED = -1, /**< Device registration failed. */
     ADPS_REGISTER_STATE_UNKNOWN = 0, /**< Registration state is unknown. */
@@ -54,7 +54,7 @@ enum ADPS_ERROR
 /**
  * @brief The module state.
  */
-typedef struct ADPS_MQTT_CLIENT_MODULE_STATE_TAG
+typedef struct tagADPS_MQTT_CLIENT_MODULE_STATE
 {
     bool initialized; //!< Module is initialized
     bool subscribed; //!< Device is subscribed to DPS topics

--- a/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/src/adps2_mqtt_client_module.c
+++ b/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/src/adps2_mqtt_client_module.c
@@ -39,18 +39,6 @@ typedef enum tagADPS_REGISTER_STATE
     ADPS_REGISTER_STATE_REGISTERED = 4 /**< Device registration is successful. */
 } ADPS_REGISTER_STATE;
 
-enum ADPS_ERROR
-{
-    ADPS_ERROR_NONE = 0,
-    ADPS_ERROR_INVALID_PARAMETER = 1,
-    ADPS_ERROR_INVALID_STATE = 2,
-    ADPS_ERROR_OUT_OF_MEMORY = 3,
-    ADPS_ERROR_MQTT_ERROR = 4,
-    ADPS_ERROR_DPS_ERROR = 5,
-    ADPS_ERROR_TIMEOUT = 6,
-    ADPS_ERROR_UNKNOWN = 7,
-};
-
 /**
  * @brief The module state.
  */

--- a/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/tests/CMakeLists.txt
+++ b/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/tests/CMakeLists.txt
@@ -1,28 +1,23 @@
-cmake_minimum_required (VERSION 3.5)
-
-project (adps2mqtt_client_module_functional_test)
+set (target_name adps2mqtt_client_module_functional_test)
 
 include (agentRules)
-
 compileasc99 ()
 disablertti ()
 
-set (sources adps2mqtt_client_module_ft.cpp)
-
-add_executable (${PROJECT_NAME} ${sources})
+add_executable (${target_name} ${sources})
+target_sources (${target_name} PRIVATE adps2mqtt_client_module_ft.cpp)
 
 target_include_directories (
-    ${PROJECT_NAME}
-    PRIVATE ${ADUC_EXPORT_INCLUDES} ${ADU_EXTENSION_INCLUDES} ${ADU_AGENT_SDK_INCLUDES}
-            ${PROJECT_SOURCE_DIR}/inc ${PROJECT_SOURCE_DIR}/../inc)
+    ${target_name}
+    PRIVATE ${ADUC_EXPORT_INCLUDES} ${ADU_EXTENSION_INCLUDES})
 
-target_compile_definitions (${PROJECT_NAME}
+target_compile_definitions (${target_name}
                             PRIVATE ADUC_TEST_DATA_FOLDER="${ADUC_TEST_DATA_FOLDER}")
 
-target_link_aziotsharedutil (${PROJECT_NAME} PRIVATE)
+target_link_aziotsharedutil (${target_name} PRIVATE)
 
 target_link_libraries (
-    ${PROJECT_NAME}
+    ${target_name}
     PUBLIC aduc::agent_state_store
     PRIVATE aduc::config_utils
             aduc::microsoft_adps2_mqtt_client

--- a/src/extensions/agent_modules/cloud_communication/communication_channel/mqtt_broker/CMakeLists.txt
+++ b/src/extensions/agent_modules/cloud_communication/communication_channel/mqtt_broker/CMakeLists.txt
@@ -17,15 +17,13 @@ find_package (Parson REQUIRED)
 
 target_sources (${target_name} PRIVATE src/adu_communication_channel.c)
 
-target_include_directories (
-    ${target_name}
-    PUBLIC inc ${ADU_AGENT_SDK_INCLUDES}
-    PRIVATE ${PROJECT_SOURCE_DIR}/inc ./inc ../inc ../../inc)
+target_include_directories (${target_name} PUBLIC inc)
 
 target_link_libraries (
     ${target_name}
     PUBLIC aduc::c_utils
            aduc::agent_state_store
+           aduc::du_agent_sdk
            aduc::retry_utils
            aziotsharedutil
 

--- a/src/extensions/agent_modules/cloud_communication/communication_channel/mqtt_broker/inc/aduc/adu_mqtt_protocol.h
+++ b/src/extensions/agent_modules/cloud_communication/communication_channel/mqtt_broker/inc/aduc/adu_mqtt_protocol.h
@@ -91,21 +91,6 @@ typedef enum ADU_COMMUNICATION_CHANNEL_CONNECTION_STATE_TAG
 } ADU_COMMUNICATION_CHANNEL_CONNECTION_STATE;
 
 /**
- * @brief Describes the enrollment state of the ADU client.
- *
- * This enumeration provides different enrollment states for the ADU client
- * to better represent and track the enrollment status in the system.
- */
-typedef enum ADU_ENROLLMENT_STATE_TAG
-{
-    ADU_ENROLLMENT_STATE_NOT_ENROLLED = -1, /**< The client is not enrolled. */
-    ADU_ENROLLMENT_STATE_UNKNOWN = 0, /**< The enrollment state of the client is unknown. */
-    ADU_ENROLLMENT_STATE_SUBSCRIBED = 1, /**< The client is subscribed. */
-    ADU_ENROLLMENT_STATE_REQUESTING = 2, /**< The client is requesting an enrollment status. */
-    ADU_ENROLLMENT_STATE_ENROLLED = 3, /**< The client is successfully enrolled. */
-} ADU_ENROLLMENT_STATE;
-
-/**
  * @brief Enumeration representing the initialization states of the ADU MQTT client module.
  *
  * @note This enumeration is used to track the initialization progress of the ADU MQTT client module.

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/CMakeLists.txt
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/CMakeLists.txt
@@ -9,23 +9,25 @@ add_library (aduc::${target_name} ALIAS ${target_name})
 find_package (azure_c_shared_utility REQUIRED)
 find_package (Parson REQUIRED)
 
-target_sources (${target_name} PRIVATE src/adu_enrollment_management.c src/adu_mqtt_client_module.c
-                                       src/adu_updates_management.c src/eg_mqtt_broker_client.c)
+target_sources (${target_name} PRIVATE src/adu_enrollment_management.c
+                                       src/adu_mqtt_client_module.c
+                                       src/adu_updates_management.c
+                                       src/eg_mqtt_broker_client.c)
 
-target_include_directories (
-    ${target_name}
-    PUBLIC inc
-    PRIVATE ${PROJECT_SOURCE_DIR}/inc ./inc ../inc ../../inc ${ADU_AGENT_SDK_INCLUDES})
+target_include_directories (${target_name} PUBLIC inc)
 
 target_link_libraries (
     ${target_name}
-    PUBLIC aduc::communication_channel_mqtt_broker aduc::agent_state_store
+    PUBLIC aduc::c_utils
+           aduc::communication_channel_mqtt_broker
+           aduc::agent_state_store
+           aduc::enrollment_utils
+           aduc::mosquitto_utils
+           aduc::retry_utils
     PRIVATE aduc::adu_types
             aduc::config_utils
             aduc::logging
-            aduc::mosquitto_utils
             aduc::parson_json_utils
-            aduc::retry_utils
             Parson::parson
             aziotsharedutil)
 

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/inc/aduc/adu_mqtt_client_module.h
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/inc/aduc/adu_mqtt_client_module.h
@@ -8,6 +8,7 @@
 #ifndef __ADU_MQTT_CLIENT_MODULE_H__
 #define __ADU_MQTT_CLIENT_MODULE_H__
 
+#include "aduc/adu_enrollment.h"
 #include "aduc/adu_mqtt_protocol.h" // for ADUC_COMMUNICATION_*, ADUC_ENROLLMENT_*, ADUC_MQTT_MESSAGE_*, ADUC_MQTT_SETTINGS, ADUC_Result
 #include "aduc/mqtt_client.h" // for ADUC_MQTT_SETTINGS
 #include "aduc/result.h" // for ADUC_Result

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management.c
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management.c
@@ -270,7 +270,7 @@ void OnMessage_enr_cn(
     struct mosquitto* mosq, void* obj, const struct mosquitto_message* msg, const mosquitto_property* props)
 {
     // NOTE: NOT SUPPORTED IN V1 PROTOCOL - MVP
-    Log_Error("OnMessage_enr_cn: NOT SUPPORTED IN V1 PROTOCOL - MVP");
+    Log_Error("%s: NOT SUPPORTED IN V1 PROTOCOL - MVP", __FUNCTION__);
 }
 
 /*

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management.c
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management.c
@@ -199,7 +199,7 @@ void OnMessage_enr_resp(
     struct mosquitto* mosq, void* obj, const struct mosquitto_message* msg, const mosquitto_property* props)
 {
     bool isEnrolled = false;
-    const char* duInstance = NULL;
+    const char* scopeId = NULL;
     JSON_Value* root_value = NULL;
 
     ADUC_Retriable_Operation_Context* context = (ADUC_Retriable_Operation_Context*)obj;
@@ -236,8 +236,8 @@ void OnMessage_enr_resp(
         goto done;
     }
 
-    duInstance = ADUC_JSON_GetStringFieldPtr(root_value, "ScopeId");
-    if (duInstance == NULL)
+    scopeId = ADUC_JSON_GetStringFieldPtr(root_value, "ScopeId");
+    if (scopeId == NULL)
     {
         Log_Error("Failed to get 'ScopeId' from payload");
         goto done;
@@ -248,7 +248,7 @@ void OnMessage_enr_resp(
     if (!handle_enrollment(
         enrollmentData,
         isEnrolled,
-        duInstance,
+        scopeId,
         context))
     {
         Log_Error("Failed handling enrollment side effects.");

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management.c
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management.c
@@ -245,7 +245,7 @@ void OnMessage_enr_resp(
 
     // TODO: Read 'resultcode', 'extendedresultcode' and 'resultdescription' from the response message properties.
 
-    if (!handle_enrollment_side_effects(
+    if (!handle_enrollment(
         enrollmentData,
         isEnrolled,
         duInstance,

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management.c
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management.c
@@ -85,7 +85,7 @@ enum ADUC_RETRY_PARAMS_INDEX
     ADUC_RETRY_PARAMS_INDEX_SERVICE_UNRECOVERABLE = 4
 };
 
-typedef struct ADUC_RETRY_PARAMS_MAP_tag
+typedef struct tagADUC_RETRY_PARAMS_MAP
 {
     const char* name;
     int index;
@@ -631,7 +631,7 @@ done:
     return opSucceeded;
 }
 
-bool EnrollmentRequestOperation_CancelOperation(struct ADUC_Retriable_Operation_Context_t* context)
+bool EnrollmentRequestOperation_CancelOperation(ADUC_Retriable_Operation_Context* context)
 {
     ADUC_Enrollment_Request_Operation_Data* enrollmentData = EnrollmentData_FromOperationContext(context);
     if (enrollmentData == NULL)
@@ -646,7 +646,7 @@ bool EnrollmentRequestOperation_CancelOperation(struct ADUC_Retriable_Operation_
     return true;
 }
 
-bool EnrollmentRequestOperation_Complete(struct ADUC_Retriable_Operation_Context_t* context)
+bool EnrollmentRequestOperation_Complete(ADUC_Retriable_Operation_Context* context)
 {
     if (context == NULL)
     {
@@ -673,7 +673,7 @@ bool EnrollmentRequestOperation_Complete(struct ADUC_Retriable_Operation_Context
  * @return true if the operation is successfully retried. false otherwise.
  */
 bool EnrollmentRequestOperation_DoRetry(
-    struct ADUC_Retriable_Operation_Context_t* context, const ADUC_Retry_Params* retryParams)
+    ADUC_Retriable_Operation_Context* context, const ADUC_Retry_Params* retryParams)
 {
     Log_Info("Will retry the enrollment request operation.");
     ADUC_Enrollment_Request_Operation_Data* data = EnrollmentData_FromOperationContext(context);
@@ -688,7 +688,7 @@ bool EnrollmentRequestOperation_DoRetry(
     return true;
 }
 
-const ADUC_Retry_Params* GetRetryParamsForLastErrorClass(struct ADUC_Retriable_Operation_Context_t* context)
+const ADUC_Retry_Params* GetRetryParamsForLastErrorClass(ADUC_Retriable_Operation_Context* context)
 {
     if (context == NULL)
     {
@@ -702,7 +702,7 @@ const ADUC_Retry_Params* GetRetryParamsForLastErrorClass(struct ADUC_Retriable_O
     return &context->retryParams[ADUC_RETRY_PARAMS_INDEX_DEFAULT];
 }
 
-void EnrollmentRequestOperation_UpdateNextAttemptTime(struct ADUC_Retriable_Operation_Context_t* context)
+void EnrollmentRequestOperation_UpdateNextAttemptTime(ADUC_Retriable_Operation_Context* context)
 {
     if (context == NULL)
     {
@@ -735,7 +735,7 @@ void EnrollmentRequestOperation_UpdateNextAttemptTime(struct ADUC_Retriable_Oper
     context->attemptCount++;
 }
 
-void EnrollmentRequestOperation_DataDestroy(struct ADUC_Retriable_Operation_Context_t* context)
+void EnrollmentRequestOperation_DataDestroy(ADUC_Retriable_Operation_Context* context)
 {
     Log_Info("Destroying context data. (context:%p, data:%p)", context, context->data);
     if (context != NULL && context->data != NULL)
@@ -749,7 +749,7 @@ void EnrollmentRequestOperation_DataDestroy(struct ADUC_Retriable_Operation_Cont
     }
 }
 
-void EnrollmentRequestOperation_OperationDestroy(struct ADUC_Retriable_Operation_Context_t* context)
+void EnrollmentRequestOperation_OperationDestroy(ADUC_Retriable_Operation_Context* context)
 {
     Log_Info("Destroying operation context. (context:%p)", context);
     EnrollmentRequestOperation_DataDestroy(context);
@@ -762,23 +762,23 @@ void EnrollmentRequestOperation_OperationDestroy(struct ADUC_Retriable_Operation
  *
  * @param data The context for the operation.
 */
-void EnrollmentRequestOperation_OnExpired(struct ADUC_Retriable_Operation_Context_t* data)
+void EnrollmentRequestOperation_OnExpired(ADUC_Retriable_Operation_Context* data)
 {
     ADUC_Retriable_Set_State(data, ADUC_Retriable_Operation_State_Expired);
     ADUC_Retriable_Set_State(data, ADUC_Retriable_Operation_State_Cancelling);
 }
 
-void EnrollmentRequestOperation_OnSuccess(struct ADUC_Retriable_Operation_Context_t* data)
+void EnrollmentRequestOperation_OnSuccess(ADUC_Retriable_Operation_Context* data)
 {
     ADUC_Retriable_Set_State(data, ADUC_Retriable_Operation_State_Completed);
 }
 
-void EnrollmentRequestOperation_OnFailure(struct ADUC_Retriable_Operation_Context_t* data)
+void EnrollmentRequestOperation_OnFailure(ADUC_Retriable_Operation_Context* data)
 {
     ADUC_Retriable_Set_State(data, ADUC_Retriable_Operation_State_Failure);
 }
 
-void EnrollmentRequestOperation_OnRetry(struct ADUC_Retriable_Operation_Context_t* data)
+void EnrollmentRequestOperation_OnRetry(ADUC_Retriable_Operation_Context* data)
 {
     // Compute next attempt time.
 }

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/tests/CMakeLists.txt
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/tests/CMakeLists.txt
@@ -1,29 +1,28 @@
 cmake_minimum_required (VERSION 3.5)
 
-project (adu_mqtt_client_module_functional_test)
+set (target_name adu_mqtt_client_module_functional_test)
 
 include (agentRules)
 
 compileasc99 ()
 disablertti ()
 
-set (sources adu_mqtt_client_module_ft.cpp)
-
-add_executable (${PROJECT_NAME} ${sources})
-
 find_package (azure_c_shared_utility REQUIRED)
 
+add_executable (${target_name})
+target_sources (${target_name} PRIVATE adu_mqtt_client_module_ft.cpp)
+
 target_include_directories (
-    ${PROJECT_NAME}
+    ${target_name}
     PRIVATE ${ADUC_EXPORT_INCLUDES} ${ADU_EXTENSION_INCLUDES} ${ADU_AGENT_SDK_INCLUDES}
             ${PROJECT_SOURCE_DIR}/inc ${PROJECT_SOURCE_DIR}/../inc
             ${PROJECT_SOURCE_DIR}/../mosquitto_client_extensions/inc)
 
-target_compile_definitions (${PROJECT_NAME}
+target_compile_definitions (${target_name}
                             PRIVATE ADUC_TEST_DATA_FOLDER="${ADUC_TEST_DATA_FOLDER}")
 
 target_link_libraries (
-    ${PROJECT_NAME}
+    ${target_name}
     PUBLIC aduc::agent_state_store
             aziotsharedutil
     PRIVATE aduc::config_utils

--- a/src/extensions/agent_modules/cloud_communication/iothub_client/module/CMakeLists.txt
+++ b/src/extensions/agent_modules/cloud_communication/iothub_client/module/CMakeLists.txt
@@ -18,7 +18,7 @@ target_sources (${target_name} PRIVATE src/iothub_client_module.c)
 target_include_directories (
     ${target_name}
     PUBLIC inc
-    PRIVATE ${PROJECT_SOURCE_DIR}/inc ${ADU_AGENT_SDK_INCLUDES})
+    PRIVATE ${PROJECT_SOURCE_DIR}/inc)
 
 target_link_libraries (
     ${target_name}
@@ -31,6 +31,7 @@ target_link_libraries (
             aduc::communication_abstraction
             aduc::d2c_messaging
             aduc::device_info_interface
+            aduc::du_agent_sdk
             aduc::extension_manager
             aduc::iothub_communication_manager
             aduc::logging

--- a/src/extensions/agent_modules/device_update_workflow/module/CMakeLists.txt
+++ b/src/extensions/agent_modules/device_update_workflow/module/CMakeLists.txt
@@ -15,10 +15,7 @@ find_package (Parson REQUIRED)
 
 target_sources (${target_name} PRIVATE src/device_update_workflow_module.c)
 
-target_include_directories (
-    ${target_name}
-    PUBLIC inc
-    PRIVATE ${PROJECT_SOURCE_DIR}/inc ${ADU_AGENT_SDK_INCLUDES})
+target_include_directories (${target_name} PUBLIC inc)
 
 target_link_libraries (
     ${target_name}
@@ -30,6 +27,7 @@ target_link_libraries (
             aduc::config_utils
 #            aduc::communication_abstraction
             aduc::d2c_messaging
+            aduc::du_agent_sdk
             aduc::extension_manager
             aduc::logging
 #            aduc::pnp_helper

--- a/src/extensions/agent_modules/shared/CMakeLists.txt
+++ b/src/extensions/agent_modules/shared/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5)
-
+add_subdirectory (common)
+add_subdirectory (enrollment_utils)
 add_subdirectory (mosquitto_utils)
 add_subdirectory (state_store)

--- a/src/extensions/agent_modules/shared/common/CMakeLists.txt
+++ b/src/extensions/agent_modules/shared/common/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+set (target_name mqtt_broker_common)
+
+add_library (${target_name} INTERFACE)
+add_library (aduc::${target_name} ALIAS ${target_name})
+
+# Find the Mosquitto library package
+find_package (PkgConfig REQUIRED)
+pkg_search_module (MOSQUITTO REQUIRED libmosquitto)
+
+target_include_directories (${target_name}
+    INTERFACE
+        inc
+        ${MOSQUITTO_INCLUDE_DIRS})
+
+target_link_libraries(${target_name}
+    INTERFACE
+        aduc::retry_utils
+        ${MOSQUITTO_LIBRARIES})

--- a/src/extensions/agent_modules/shared/common/inc/aduc/adu_enrollment.h
+++ b/src/extensions/agent_modules/shared/common/inc/aduc/adu_enrollment.h
@@ -1,0 +1,50 @@
+#ifndef ADU_ENROLLMENT_H
+#define ADU_ENROLLMENT_H
+
+#include "aduc/mqtt_broker_common.h" // CORRELATION_ID_LENGTH
+#include <aduc/retry_utils.h>
+#include <mosquitto.h>
+
+/**
+ * @brief Describes the enrollment state of the ADU client.
+ *
+ * This enumeration provides different enrollment states for the ADU client
+ * to better represent and track the enrollment status in the system.
+ */
+typedef enum tagADU_ENROLLMENT_STATE
+{
+    ADU_ENROLLMENT_STATE_NOT_ENROLLED = -1, /**< The client is not enrolled. */
+    ADU_ENROLLMENT_STATE_UNKNOWN = 0, /**< The enrollment state of the client is unknown. */
+    ADU_ENROLLMENT_STATE_SUBSCRIBED = 1, /**< The client is subscribed. */
+    ADU_ENROLLMENT_STATE_REQUESTING = 2, /**< The client is requesting an enrollment status. */
+    ADU_ENROLLMENT_STATE_ENROLLED = 3, /**< The client is successfully enrolled. */
+} ADU_ENROLLMENT_STATE;
+
+typedef struct tagADUC_MQTT_Message_Context
+{
+    int messageId;
+    char correlationId[CORRELATION_ID_LENGTH];
+    char* publishTopic;
+    char* responseTopic;
+    char* payload;
+    size_t payloadLen;
+    mosquitto_property* properties;
+    int qos;
+} ADUC_MQTT_Message_Context;
+
+/**
+ * @brief Struct to represent enrollment status request operation for an Azure Device Update service enrollment.
+ */
+typedef struct tagADUC_Enrollment_Request_Operation_Data
+{
+    /// Current enrollment state.
+    ADU_ENROLLMENT_STATE enrollmentState;
+
+    ADUC_MQTT_Message_Context enrReqMessageContext;
+
+    /// @brief A reference to the parent context of this enrollment status request operation.
+    ADUC_Retriable_Operation_Context* ownerContext;
+
+} ADUC_Enrollment_Request_Operation_Data;
+
+#endif // ADU_ENROLLMENT_H

--- a/src/extensions/agent_modules/shared/common/inc/aduc/mqtt_broker_common.h
+++ b/src/extensions/agent_modules/shared/common/inc/aduc/mqtt_broker_common.h
@@ -1,0 +1,9 @@
+#ifndef MQTT_BROKER_COMMON
+#define MQTT_BROKER_COMMON
+
+/**
+ * @brief The length of a correlation ID. (including null terminator)
+ */
+#define CORRELATION_ID_LENGTH 37
+
+#endif // MQTT_BROKER_COMMON

--- a/src/extensions/agent_modules/shared/enrollment_utils/CMakeLists.txt
+++ b/src/extensions/agent_modules/shared/enrollment_utils/CMakeLists.txt
@@ -1,0 +1,16 @@
+set (target_name enrollment_utils)
+
+add_library (${target_name} STATIC)
+
+add_library (aduc::${target_name} ALIAS ${target_name})
+
+target_sources (${target_name} PRIVATE src/adu_enrollment_utils.c)
+
+target_include_directories (${target_name} PUBLIC inc)
+
+target_link_libraries (${target_name}
+    PUBLIC aduc::mqtt_broker_common
+    PRIVATE aduc::agent_state_store
+            aduc::logging
+            aduc::c_utils)
+

--- a/src/extensions/agent_modules/shared/enrollment_utils/CMakeLists.txt
+++ b/src/extensions/agent_modules/shared/enrollment_utils/CMakeLists.txt
@@ -1,10 +1,8 @@
 set (target_name enrollment_utils)
 
-add_library (${target_name} STATIC)
+add_library (${target_name} STATIC src/adu_enrollment_utils.c)
 
 add_library (aduc::${target_name} ALIAS ${target_name})
-
-target_sources (${target_name} PRIVATE src/adu_enrollment_utils.c)
 
 target_include_directories (${target_name} PUBLIC inc)
 
@@ -14,3 +12,4 @@ target_link_libraries (${target_name}
             aduc::logging
             aduc::c_utils)
 
+add_subdirectory (tests)

--- a/src/extensions/agent_modules/shared/enrollment_utils/inc/aduc/adu_enrollment_utils.h
+++ b/src/extensions/agent_modules/shared/enrollment_utils/inc/aduc/adu_enrollment_utils.h
@@ -1,0 +1,19 @@
+#ifndef ADU_ENROLLMENT_UTILS_H
+#define ADU_ENROLLMENT_UTILS_H
+
+#include <aduc/adu_enrollment.h>
+
+ADUC_Enrollment_Request_Operation_Data* EnrollmentData_FromOperationContext(ADUC_Retriable_Operation_Context* context);
+
+ADU_ENROLLMENT_STATE EnrollmentData_SetState(
+    ADUC_Enrollment_Request_Operation_Data* enrollmentData, ADU_ENROLLMENT_STATE state, const char* reason);
+
+void EnrollmentData_SetCorrelationId(ADUC_Enrollment_Request_Operation_Data* enrollmentData, const char* correlationId);
+
+bool handle_enrollment_side_effects(
+    ADUC_Enrollment_Request_Operation_Data* enrollmentData,
+    bool isEnrolled,
+    const char* duInstance,
+    ADUC_Retriable_Operation_Context* context);
+
+#endif // ADU_ENROLLMENT_UTILS_H

--- a/src/extensions/agent_modules/shared/enrollment_utils/inc/aduc/adu_enrollment_utils.h
+++ b/src/extensions/agent_modules/shared/enrollment_utils/inc/aduc/adu_enrollment_utils.h
@@ -3,6 +3,8 @@
 
 #include <aduc/adu_enrollment.h>
 
+EXTERN_C_BEGIN
+
 ADUC_Enrollment_Request_Operation_Data* EnrollmentData_FromOperationContext(ADUC_Retriable_Operation_Context* context);
 
 ADU_ENROLLMENT_STATE EnrollmentData_SetState(
@@ -10,10 +12,12 @@ ADU_ENROLLMENT_STATE EnrollmentData_SetState(
 
 void EnrollmentData_SetCorrelationId(ADUC_Enrollment_Request_Operation_Data* enrollmentData, const char* correlationId);
 
-bool handle_enrollment_side_effects(
+bool handle_enrollment(
     ADUC_Enrollment_Request_Operation_Data* enrollmentData,
     bool isEnrolled,
     const char* duInstance,
     ADUC_Retriable_Operation_Context* context);
+
+EXTERN_C_END
 
 #endif // ADU_ENROLLMENT_UTILS_H

--- a/src/extensions/agent_modules/shared/enrollment_utils/src/adu_enrollment_utils.c
+++ b/src/extensions/agent_modules/shared/enrollment_utils/src/adu_enrollment_utils.c
@@ -99,7 +99,7 @@ bool handle_enrollment(
     ADU_ENROLLMENT_STATE old_state = EnrollmentData_SetState(
         enrollmentData,
         new_state,
-        isEnrolled ? "enrolled" : "not enrolled");
+        NULL /* reason */);
 
     if (ADUC_StateStore_GetIsDeviceEnrolled() != isEnrolled)
     {
@@ -121,7 +121,7 @@ bool handle_enrollment(
             Log_Error("Failed set scopeId in store");
 
             // Reset the enrollment state. so we can retry again.
-            EnrollmentData_SetState(enrollmentData, ADU_ENROLLMENT_STATE_UNKNOWN, "reset unknown enrollment state");
+            EnrollmentData_SetState(enrollmentData, ADU_ENROLLMENT_STATE_UNKNOWN, "retry");
             goto done;
         }
     }

--- a/src/extensions/agent_modules/shared/enrollment_utils/src/adu_enrollment_utils.c
+++ b/src/extensions/agent_modules/shared/enrollment_utils/src/adu_enrollment_utils.c
@@ -74,20 +74,20 @@ void EnrollmentData_SetCorrelationId(ADUC_Enrollment_Request_Operation_Data* enr
  *
  * @param enrollmentData The enrollment data.
  * @param isEnrolled The boolean value of enrolled in the message.
- * @param duInstance The du instance.
+ * @param scopeId The du instance.
  * @param context The retriable operation context.
  * @return true on success.
  */
 bool handle_enrollment(
     ADUC_Enrollment_Request_Operation_Data* enrollmentData,
     bool isEnrolled,
-    const char* duInstance,
+    const char* scopeId,
     ADUC_Retriable_Operation_Context* context)
 {
     bool succeeded = false;
     ADUC_STATE_STORE_RESULT stateStoreResult = ADUC_STATE_STORE_RESULT_ERROR;
 
-    if (enrollmentData == NULL || duInstance == NULL || context == NULL)
+    if (enrollmentData == NULL || scopeId == NULL || context == NULL)
     {
         return false;
     }
@@ -111,14 +111,14 @@ bool handle_enrollment(
 
     if (isEnrolled)
     {
-        Log_Info("Device is currently enrolled with '%s'", duInstance);
+        Log_Info("Device is currently enrolled with scopeId '%s'", scopeId);
 
         context->completeFunc(context);
 
-        stateStoreResult = ADUC_StateStore_SetDeviceUpdateServiceInstance(duInstance);
+        stateStoreResult = ADUC_StateStore_SetDeviceUpdateServiceInstance(scopeId);
         if (stateStoreResult != ADUC_STATE_STORE_RESULT_OK)
         {
-            Log_Error("Failed set duinstance in store");
+            Log_Error("Failed set scopeId in store");
 
             // Reset the enrollment state. so we can retry again.
             EnrollmentData_SetState(enrollmentData, ADU_ENROLLMENT_STATE_UNKNOWN, "reset unknown enrollment state");
@@ -127,7 +127,7 @@ bool handle_enrollment(
     }
     else
     {
-        Log_Warn("Device is not currently enrolled with '%s'", duInstance);
+        Log_Warn("Device is not currently enrolled with '%s'", scopeId);
     }
 
     succeeded = true;

--- a/src/extensions/agent_modules/shared/enrollment_utils/src/adu_enrollment_utils.c
+++ b/src/extensions/agent_modules/shared/enrollment_utils/src/adu_enrollment_utils.c
@@ -1,0 +1,126 @@
+#include "aduc/adu_enrollment_utils.h"
+#include <aduc/agent_state_store.h>
+#include <aduc/logging.h>
+#include <aduc/string_c_utils.h>
+#include <string.h> // strncpy
+
+/**
+ * @brief Gets the enrollment data object from the enrollment operation context.
+ * @param context The enrollment operation context.
+ * @return ADUC_Enrollment_Request_Operation_Data* The enrollment data object.
+ */
+ADUC_Enrollment_Request_Operation_Data* EnrollmentData_FromOperationContext(ADUC_Retriable_Operation_Context* context)
+{
+    if (context == NULL || context->data == NULL)
+    {
+        Log_Error("Null input (context:%p, data:%p)", context, context->data);
+        return NULL;
+    }
+
+    return (ADUC_Enrollment_Request_Operation_Data*)(context->data);
+}
+
+/**
+ * @brief Sets the enrollment state and updates 'IsDeviceEnrolled' state in the DU agent state store.
+ * @param data The enrollment data object.
+ * @param state The enrollment state to set.
+ * @return ADU_ENROLLMENT_STATE The old enrollment state.
+ */
+ADU_ENROLLMENT_STATE EnrollmentData_SetState(
+    ADUC_Enrollment_Request_Operation_Data* enrollmentData, ADU_ENROLLMENT_STATE state, const char* reason)
+{
+    ADU_ENROLLMENT_STATE oldState = enrollmentData->enrollmentState;
+    if (enrollmentData->enrollmentState != state)
+    {
+        Log_Info(
+            "Enrollment state changed from %d to %d (reason:%s)",
+            enrollmentData->enrollmentState,
+            state,
+            IsNullOrEmpty(reason) ? "unknown" : reason);
+        enrollmentData->enrollmentState = state;
+
+        if (ADUC_StateStore_SetIsDeviceEnrolled(state == ADU_ENROLLMENT_STATE_ENROLLED) != ADUC_STATE_STORE_RESULT_OK)
+        {
+            Log_Error("Failed to set enrollment state in state store");
+        }
+    }
+    return oldState;
+}
+
+/**
+ * @brief Sets the correlation id for the enrollment request message.
+ * @param enrollmentData The enrollment data object.
+ * @param correlationId The correlation id to set.
+ */
+void EnrollmentData_SetCorrelationId(ADUC_Enrollment_Request_Operation_Data* enrollmentData, const char* correlationId)
+{
+    if (enrollmentData == NULL || correlationId == NULL)
+    {
+        Log_Error("Null input (enrollmentData:%p, correlationId:%p)", enrollmentData, correlationId);
+        return;
+    }
+
+    strncpy(
+        enrollmentData->enrReqMessageContext.correlationId,
+        correlationId,
+        sizeof(enrollmentData->enrReqMessageContext.correlationId) - 1);
+
+    enrollmentData->enrReqMessageContext
+        .correlationId[sizeof(enrollmentData->enrReqMessageContext.correlationId) - 1] = '\0';
+}
+
+/**
+ * @brief Handles creating side-effects in response to incoming enrollment data from enrollment response.
+ *
+ * @param enrollmentData The enrollment data.
+ * @param isEnrolled The boolean value of enrolled in the message.
+ * @param duInstance The du instance.
+ * @param context The retriable operation context.
+ * @return true on success.
+ */
+bool handle_enrollment_side_effects(
+    ADUC_Enrollment_Request_Operation_Data* enrollmentData,
+    bool isEnrolled,
+    const char* duInstance,
+    ADUC_Retriable_Operation_Context* context)
+{
+    bool succeeded = false;
+    ADUC_STATE_STORE_RESULT stateStoreResult = ADUC_STATE_STORE_RESULT_ERROR;
+
+    EnrollmentData_SetState(
+        enrollmentData,
+        isEnrolled
+            ? ADU_ENROLLMENT_STATE_ENROLLED
+            : ADU_ENROLLMENT_STATE_NOT_ENROLLED,
+        isEnrolled ? "enrolled" : "not enrolled");
+
+    if (ADUC_StateStore_GetIsDeviceEnrolled() != isEnrolled)
+    {
+        Log_Error("Failed to set enrollment state to '%s'", isEnrolled ? "true" : "false");
+        goto done;
+    }
+
+    if (isEnrolled)
+    {
+        Log_Info("Device is currently enrolled with '%s'", duInstance);
+
+        context->completeFunc(context);
+
+        stateStoreResult = ADUC_StateStore_SetDeviceUpdateServiceInstance(duInstance);
+        if (stateStoreResult != ADUC_STATE_STORE_RESULT_OK)
+        {
+            Log_Error("Failed set duinstance in store");
+
+            // Reset the enrollment state. so we can retry again.
+            EnrollmentData_SetState(enrollmentData, ADU_ENROLLMENT_STATE_UNKNOWN, "reset unknown enrollment state");
+            goto done;
+        }
+    }
+    else
+    {
+        Log_Warn("Device is not currently enrolled with '%s'", duInstance);
+    }
+
+done:
+    return succeeded;
+}

--- a/src/extensions/agent_modules/shared/enrollment_utils/tests/CMakeLists.txt
+++ b/src/extensions/agent_modules/shared/enrollment_utils/tests/CMakeLists.txt
@@ -1,0 +1,15 @@
+set (target_name enrollment_utils_unit_tests)
+
+include (agentRules)
+compileasc99 ()
+disablertti ()
+
+find_package (Catch2 REQUIRED)
+
+add_executable (${target_name} src/main.cpp src/adu_enrollment_utils_unit_tests.cpp)
+target_link_libraries (${target_name} PRIVATE Catch2::Catch2
+                                              aduc::enrollment_utils
+                                              aduc::agent_state_store)
+include (CTest)
+include (Catch)
+catch_discover_tests (${target_name})

--- a/src/extensions/agent_modules/shared/enrollment_utils/tests/src/adu_enrollment_utils_unit_tests.cpp
+++ b/src/extensions/agent_modules/shared/enrollment_utils/tests/src/adu_enrollment_utils_unit_tests.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file adu_enrollment_unit_tests.cpp
+ * @brief Unit Tests for adu_enrollment_utils.c
+ *
+ * @copyright Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+#include <catch2/catch.hpp>
+using Catch::Matchers::Equals;
+
+#include <aduc/adu_enrollment_utils.h>
+#include <aduc/agent_state_store.h>
+#include <cstring> // memset
+#include <string>
+
+char fakeDuInstance[] = "fooScopeId";
+const char* is_enrolled_json = R"( { "IsEnrolled": true } )";
+const char* is_not_enrolled_json = R"( { "IsEnrolled": true } )";
+
+bool test_operation_complete_called = false;
+bool test_operation_complete(ADUC_Retriable_Operation_Context* context)
+{
+    test_operation_complete_called = true;
+    return true;
+}
+
+TEST_CASE("handle_enrollment - should return false for NULL enrollmentData")
+{
+    ADUC_Retriable_Operation_Context operation_context;
+    memset(&operation_context, 0, sizeof(operation_context));
+
+    CHECK_FALSE(handle_enrollment(
+        nullptr, // ADUC_Enrollment_Request_Operation_Data* enrollmentData,
+        false, // bool isEnrolled,
+        &fakeDuInstance[0], // const char* duInstance,
+        &operation_context));
+}
+
+TEST_CASE("handle_enrollment - not enrolled should set state store")
+{
+    ADUC_Enrollment_Request_Operation_Data operation_data;
+    memset(&operation_data, 0, sizeof(operation_data));
+
+    ADUC_Retriable_Operation_Context operation_context;
+    memset(&operation_context, 0, sizeof(operation_context));
+
+    CHECK(ADUC_STATE_STORE_RESULT_OK == ADUC_StateStore_Initialize("/tmp/adutest/test_state_store.json"));
+
+    bool success = handle_enrollment(
+        &operation_data, // ADUC_Enrollment_Request_Operation_Data* enrollmentData,
+        false, // bool isEnrolled,
+        &fakeDuInstance[0], // const char* duInstance,
+        &operation_context);
+    CHECK(success);
+
+    CHECK(operation_data.enrollmentState == ADU_ENROLLMENT_STATE_NOT_ENROLLED);
+
+    CHECK_FALSE(ADUC_StateStore_GetIsDeviceEnrolled());
+}
+
+TEST_CASE("handle_enrollment - enrolled should set state store")
+{
+    ADUC_Enrollment_Request_Operation_Data operation_data;
+    memset(&operation_data, 0, sizeof(operation_data));
+
+    ADUC_Retriable_Operation_Context operation_context;
+    memset(&operation_context, 0, sizeof(operation_context));
+
+    test_operation_complete_called = false;
+    operation_context.completeFunc = test_operation_complete;
+
+    CHECK(ADUC_STATE_STORE_RESULT_OK == ADUC_StateStore_Initialize("/tmp/adutest/test_state_store.json"));
+
+    bool success = handle_enrollment(
+        &operation_data, // ADUC_Enrollment_Request_Operation_Data* enrollmentData,
+        true, // bool isEnrolled,
+        &fakeDuInstance[0], // const char* duInstance,
+        &operation_context);
+    CHECK(success);
+
+    CHECK(test_operation_complete_called);
+    CHECK(operation_data.enrollmentState == ADU_ENROLLMENT_STATE_ENROLLED);
+
+    CHECK(ADUC_StateStore_GetIsDeviceEnrolled());
+}

--- a/src/extensions/agent_modules/shared/enrollment_utils/tests/src/main.cpp
+++ b/src/extensions/agent_modules/shared/enrollment_utils/tests/src/main.cpp
@@ -1,0 +1,10 @@
+
+/**
+ * @file main.cpp
+ * @brief adu enrollment data utils tests main entry point.
+ *
+ * @copyright Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/src/extensions/agent_modules/shared/mosquitto_utils/CMakeLists.txt
+++ b/src/extensions/agent_modules/shared/mosquitto_utils/CMakeLists.txt
@@ -12,9 +12,6 @@ add_library (aduc::${target_name} ALIAS ${target_name})
 find_package (PkgConfig REQUIRED)
 pkg_search_module (MOSQUITTO REQUIRED libmosquitto)
 
-# Find the UUID library
-find_library (UUID_LIBRARY NAMES uuid)
-
 # Turn -fPIC on, in order to use this library in a shared library.
 set_property (TARGET ${target_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -22,5 +19,4 @@ target_include_directories (${target_name} PUBLIC ./inc ${MOSQUITTO_INCLUDE_DIRS
 
 target_sources (${target_name} PRIVATE src/adu_mosquitto_utils.c)
 
-target_link_libraries (${target_name} PRIVATE aduc::c_utils libaducpal ${UUID_LIBRARY}
-                                              ${MOSQUITTO_LIBRARIES})
+target_link_libraries (${target_name} PRIVATE aduc::c_utils libaducpal ${MOSQUITTO_LIBRARIES})

--- a/src/extensions/agent_modules/shared/mosquitto_utils/inc/aduc/adu_mosquitto_utils.h
+++ b/src/extensions/agent_modules/shared/mosquitto_utils/inc/aduc/adu_mosquitto_utils.h
@@ -66,14 +66,6 @@ ADUC_MQTT_DISCONNECTION_CATEGORY CategorizeMQTTDisconnection(int rc);
 char* GenerateCorrelationIdFromTime(time_t t);
 
 /**
- * @brief Generate a correlation ID from a time value with a prefix.
- * @param[in] t The time value to use.
- * @param[in] prefix The prefix to use.
- * @return A string containing the correlation ID. The caller is responsible for free()'ing the returned string.
- */
-char* GenerateCorrelationIdFromTimeWithPrefix(time_t t, const char* prefix);
-
-/**
  * @brief Retrieves the correlation data from MQTT properties.
  *
  * This function attempts to read the correlation data from the provided MQTT properties.
@@ -135,15 +127,5 @@ bool ADU_mosquitto_has_user_property(const mosquitto_property* props, const char
  * @return `true` if the correlation data matches the provided correlation ID; otherwise, `false`.
  */
 bool ADU_are_correlation_ids_matching(const mosquitto_property* props, const char* correlationId);
-
-/**
- * @brief Generate a GUID  7d28dcd5-175c-46ed-b3bb-a557d278da56
- *
- * @param with_hyphens Whether to include hyphens in the GUID.
- * @param buffer Where to store identifier.
- * @param buffer_cch Number of characters in @p buffer.
- *
- */
-bool ADUC_generate_correlation_id(bool with_hyphens, char* buffer, size_t buffer_cch);
 
 #endif

--- a/src/extensions/agent_modules/shared/mosquitto_utils/inc/aduc/adu_mosquitto_utils.h
+++ b/src/extensions/agent_modules/shared/mosquitto_utils/inc/aduc/adu_mosquitto_utils.h
@@ -12,16 +12,6 @@
 #include <mosquitto.h>
 
 /**
- * @brief The length of a correlation ID. (including null terminator)
- */
-#define CORRELATION_ID_LENGTH 37
-
-/**
- * @brief The length of a correlation ID without hyphens. (including null terminator)
- */
-#define CORRELATION_ID_LENGTH_WITHOUT_HYPHENS 33
-
-/**
  * @brief Enumeration representing MQTT disconnection categories.
  */
 typedef enum ADUC_MQTT_DISCONNECTION_CATEGORY_TAG

--- a/src/extensions/agent_modules/shared/mosquitto_utils/src/adu_mosquitto_utils.c
+++ b/src/extensions/agent_modules/shared/mosquitto_utils/src/adu_mosquitto_utils.c
@@ -14,7 +14,6 @@
 #include <aducpal/time.h> // time_t, CLOCK_REALTIME
 #include <mosquitto.h> // mosquitto related functions
 #include <mqtt_protocol.h>
-#include "uuid/uuid.h"
 
 /**
  * @brief Generate a correlation ID from a time value.
@@ -26,16 +25,6 @@ char* GenerateCorrelationIdFromTime(time_t t)
     return ADUC_StringFormat("%ld", t);
 }
 
-/**
- * @brief Generate a correlation ID from a time value with a prefix.
- * @param[in] t The time value to use.
- * @param[in] prefix The prefix to use.
- * @return A string containing the correlation ID. The caller is responsible for free()'ing the returned string.
- */
-char* GenerateCorrelationIdFromTimeWithPrefix(time_t t, const char* prefix)
-{
-    return ADUC_StringFormat("%s-%ld", prefix, t);
-}
 
 /**
  * @brief Retrieves the correlation data from MQTT properties.
@@ -281,50 +270,4 @@ ADUC_MQTT_DISCONNECTION_CATEGORY CategorizeMQTTDisconnection(int rc)
     default:
         return ADUC_MQTT_DISCONNECTION_CATEGORY_OTHER;
     }
-}
-
-/**
- * @brief Generate a GUID  7d28dcd5-175c-46ed-b3bb-a557d278da56
- *
- * @param with_hyphens Whether to include hyphens in the GUID.
- * @param buffer Where to store identifier.
- * @param buffer_cch Number of characters in @p buffer.
- *
- */
-bool ADUC_generate_correlation_id(bool with_hyphens, char* buffer, size_t buffer_cch)
-{
-    uuid_t bin_uuid;
-    char uuid_str[37];  // 36 bytes + NUL
-
-    if (buffer_cch < 33 || (with_hyphens && buffer_cch < 37))
-    {
-        return false;
-    }
-
-    // Generate a UUID
-    uuid_generate(bin_uuid);
-    // Convert the binary UUID to a string
-    uuid_unparse(bin_uuid, uuid_str);
-
-    if (with_hyphens)
-    {
-        if (strcpy(buffer, uuid_str) == NULL)
-        {
-            return false;
-        }
-    }
-    else
-    {
-        int j = 0;
-        for (int i = 0; i < 36; i++)
-        {
-            if (uuid_str[i] != '-')
-            {
-                buffer[j++] = uuid_str[i];
-            }
-        }
-        buffer[j] = '\0';
-    }
-
-    return true;
 }

--- a/src/extensions/agent_modules/shared/state_store/CMakeLists.txt
+++ b/src/extensions/agent_modules/shared/state_store/CMakeLists.txt
@@ -10,7 +10,6 @@ add_library (aduc::${target_name} ALIAS ${target_name})
 
 find_package (Parson REQUIRED)
 
-
 # Turn -fPIC on, in order to use this library in a shared library.
 set_property (TARGET ${target_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -19,11 +18,8 @@ target_include_directories (${target_name} PUBLIC ./inc)
 target_sources (${target_name} PRIVATE src/agent_state_store.c)
 
 target_link_libraries (${target_name}
-    PUBLIC Parson::parson
-    PRIVATE aduc::c_utils
-            aduc::logging
-            libaducpal
-            )
+    PUBLIC aduc::c_utils Parson::parson
+    PRIVATE aduc::logging)
 
 if (ADUC_BUILD_UNIT_TESTS)
     add_subdirectory (tests)

--- a/src/extensions/agent_modules/shared/state_store/src/agent_state_store.c
+++ b/src/extensions/agent_modules/shared/state_store/src/agent_state_store.c
@@ -6,13 +6,11 @@
  * Licensed under the MIT License.
  */
 #include "aduc/agent_state_store.h"
-#include "aduc/logging.h"
-#include "aduc/string_c_utils.h" // IsNuLLOrEmpty
-#include "parson.h"
+#include <aduc/logging.h>
+#include "aduc/string_c_utils.h" // IsNullOrEmpty
 #include <semaphore.h>
 #include <stdlib.h>
 #include <string.h>
-
 #include "stdbool.h" // bool
 
 // Internal state data

--- a/src/utils/d2c_messaging/inc/aduc/d2c_messaging.h
+++ b/src/utils/d2c_messaging/inc/aduc/d2c_messaging.h
@@ -19,7 +19,7 @@ EXTERN_C_BEGIN
 /**
  * @brief The message types currently supported by the Device Update Agent.
  */
-typedef enum _tagADUC_D2C_Message_Type
+typedef enum tagADUC_D2C_Message_Type
 {
     ADUC_D2C_Message_Type_Device_Update_Result = 0, /**< deviceUpdate interface reported property */
     ADUC_D2C_Message_Type_Device_Update_ACK, /**< deviceUpdate interface ACK */
@@ -33,7 +33,7 @@ typedef enum _tagADUC_D2C_Message_Type
     ADUC_D2C_Message_Type_Max
 } ADUC_D2C_Message_Type;
 
-typedef enum _tagADUC_D2C_Message_Status
+typedef enum tagADUC_D2C_Message_Status
 {
     ADUC_D2C_Message_Status_Pending = 0, /**< Waiting to be processed */
     ADUC_D2C_Message_Status_In_Progress, /**< Being processed by the messages processor */
@@ -58,7 +58,7 @@ typedef time_t (*ADUC_D2C_NEXT_RETRY_TIMESTAMP_CALC_FUNC)(
 /**
  * @brief The data structure used for deciding how to handle the response from the cloud.
  */
-typedef struct _tagADUC_D2C_HttpStatus_Retry_Info
+typedef struct tagADUC_D2C_HttpStatus_Retry_Info
 {
     int httpStatusMin; /**< Indicates minimum boundary of the http status code */
     int httpStatusMax; /**< Indicates minimum boundary of the http status code */
@@ -71,7 +71,7 @@ typedef struct _tagADUC_D2C_HttpStatus_Retry_Info
 /**
  * @brief The data structure that contains information about the retry strategy for each message type.
  */
-typedef struct _tagADUC_D2C_RetryStrategy
+typedef struct tagADUC_D2C_RetryStrategy
 {
     ADUC_D2C_HttpStatus_Retry_Info*
         httpStatusRetryInfo; /**< A collection of retry info for each group of of http status codes */
@@ -117,7 +117,7 @@ typedef int (*ADUC_D2C_MESSAGE_TRANSPORT_FUNCTION)(
 /**
  * @brief A device to cloud message data structure.
  */
-typedef struct _tagADUC_D2C_Message
+typedef struct tagADUC_D2C_Message
 {
     void* cloudServiceHandle; /**< The cloud service handle. e.g. ADUC_ClientHandle */
     const char* originalContent; /**< The original content (message) */
@@ -138,7 +138,7 @@ typedef struct _tagADUC_D2C_Message
 /**
  * @brief A data structure that contains information about the message processing job.
  */
-typedef struct _tagADUC_D2C_Message_Processing_Context
+typedef struct tagADUC_D2C_Message_Processing_Context
 {
     ADUC_D2C_Message_Type type; /**< The property type */
 

--- a/src/utils/d2c_messaging/tests/d2c_messaging_ut.cpp
+++ b/src/utils/d2c_messaging/tests/d2c_messaging_ut.cpp
@@ -91,7 +91,7 @@ static ADUC_D2C_RetryStrategy g_defaultRetryStrategy_no_calc_func = {
     /* .initialDelayUnitMilliSecs = */ 1000
 };
 
-typedef struct _tagMockCloudBehavior
+typedef struct tagMockCloudBehavior
 {
     unsigned long delayBeforeResponseMS; // in ms.
     int httpStatus;

--- a/src/utils/retry_utils/inc/aduc/retry_utils.h
+++ b/src/utils/retry_utils/inc/aduc/retry_utils.h
@@ -29,7 +29,7 @@ EXTERN_C_BEGIN
 /**
  * @brief The data structure that contains information about the retry strategy.
  */
-typedef struct _tagADUC_Retry_Params
+typedef struct tagADUC_Retry_Params
 {
     unsigned int maxRetries; /**< Maximum number of retries */
     unsigned int maxDelaySecs; /**< Maximum wait time before retry (in seconds) */
@@ -65,7 +65,7 @@ time_t ADUC_Retry_Delay_Calculator(
     unsigned long maxDelaySecs,
     double maxJitterPercent);
 
-typedef enum ADUC_Failure_Class_tag
+typedef enum tagADUC_Failure_Class
 {
     ADUC_Failure_Class_None,
     ADUC_Failure_Class_Client_Transient,
@@ -79,7 +79,7 @@ typedef enum ADUC_Failure_Class_tag
  */
 time_t ADUC_GetTimeSinceEpochInSeconds();
 
-typedef enum ADUC_Retriable_Operation_State_tag
+typedef enum tagADUC_Retriable_Operation_State
 {
     ADUC_Retriable_Operation_State_Destroyed = -4,
     ADUC_Retriable_Operation_State_Cancelled = -3,
@@ -93,25 +93,26 @@ typedef enum ADUC_Retriable_Operation_State_tag
     ADUC_Retriable_Operation_State_Completed = 5,
 } ADUC_Retriable_Operation_State;
 
-typedef struct ADUC_Retriable_Operation_Context_t
+typedef struct tagADUC_Retriable_Operation_Context ADUC_Retriable_Operation_Context;
+struct tagADUC_Retriable_Operation_Context
 {
     // Operation data
     void* operationName;
     void* data;
 
     // Custom functions
-    void (*dataDestroyFunc)(struct ADUC_Retriable_Operation_Context_t* data);
-    void (*operationDestroyFunc)(struct ADUC_Retriable_Operation_Context_t* context);
-    bool (*doWorkFunc)(struct ADUC_Retriable_Operation_Context_t* context);
-    bool (*cancelFunc)(struct ADUC_Retriable_Operation_Context_t* context);
-    bool (*retryFunc)(struct ADUC_Retriable_Operation_Context_t* context, const ADUC_Retry_Params* retryParams);
-    bool (*completeFunc)(struct ADUC_Retriable_Operation_Context_t* context);
+    void (*dataDestroyFunc)(ADUC_Retriable_Operation_Context* data);
+    void (*operationDestroyFunc)(ADUC_Retriable_Operation_Context* context);
+    bool (*doWorkFunc)(ADUC_Retriable_Operation_Context* context);
+    bool (*cancelFunc)(ADUC_Retriable_Operation_Context* context);
+    bool (*retryFunc)(ADUC_Retriable_Operation_Context* context, const ADUC_Retry_Params* retryParams);
+    bool (*completeFunc)(ADUC_Retriable_Operation_Context* context);
 
     // Callbacks
-    void (*onExpired)(struct ADUC_Retriable_Operation_Context_t* context);
-    void (*onSuccess)(struct ADUC_Retriable_Operation_Context_t* context);
-    void (*onFailure)(struct ADUC_Retriable_Operation_Context_t* context);
-    void (*onRetry)(struct ADUC_Retriable_Operation_Context_t* context);
+    void (*onExpired)(ADUC_Retriable_Operation_Context* context);
+    void (*onSuccess)(ADUC_Retriable_Operation_Context* context);
+    void (*onFailure)(ADUC_Retriable_Operation_Context* context);
+    void (*onRetry)(ADUC_Retriable_Operation_Context* context);
 
     // Configuration
     ADUC_Retry_Params* retryParams; // Array of retry parameters per class of errors.
@@ -137,7 +138,7 @@ typedef struct ADUC_Retriable_Operation_Context_t
     void* lastErrorContext; // Last error context
 
     const void* commChannelHandle; // Handle to the communication channel used for the operation
-} ADUC_Retriable_Operation_Context;
+};
 
 void ADUC_Retriable_Operation_Init(ADUC_Retriable_Operation_Context* context, bool startNow);
 bool ADUC_Retriable_Operation_DoWork(ADUC_Retriable_Operation_Context* context);


### PR DESCRIPTION
- [set state for unenroll, add ifc/enrollutils libs, fix cmake deps](https://github.com/Azure/iot-hub-device-update/commit/eac7dc079f48c8b0873ec17bc67ee901ef7c7489)
  - moved logic out into enrollment utils to unit test it but could not get past a linker error
  - it sets enrolled in state state store regardless of enrolled or not enrolled
- [Remove unused code](https://github.com/Azure/iot-hub-device-update/commit/6bf419b068040120898ac5fc2c439edcb71edb60)
- [consistently use tag prefix for typedef](https://github.com/Azure/iot-hub-device-update/commit/f04303c47909510e4dd6b1e7472f8ffcfbcd83f1)