### PR TITLE
Ban strncpy with compilation error, replaced by ADUC_Safe_StrCopyN

### DIFF
--- a/src/adu-shell/src/main.cpp
+++ b/src/adu-shell/src/main.cpp
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "aduc/aduc_banned.h"
 #include "aduc/c_utils.h"
 #include "aduc/config_utils.h"
 #include "aduc/logging.h"

--- a/src/agent/command_helper/src/command_helper.c
+++ b/src/agent/command_helper/src/command_helper.c
@@ -20,6 +20,10 @@
 #include <string.h> // strlen
 #include <sys/stat.h> // mkfifo
 #include <unistd.h> // sleep
+#include "aduc/string_c_utils.h" // ADUC_Safe_StrCopyN
+
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
 
 #define MAX_COMMAND_ARRAY_SIZE 1 // !< For version 1.0, we're supporting only 1 command.
 #define COMMAND_MAX_LEN 64 // !< Max command length including NULL
@@ -314,6 +318,9 @@ bool SendCommand(const char* command)
 {
     static char buffer[COMMAND_MAX_LEN];
     bool success = false;
+
+    const size_t cmdLen = strlen(command);
+
     int fd = -1;
     if (command == NULL || *command == '\0')
     {
@@ -321,7 +328,7 @@ bool SendCommand(const char* command)
         goto done;
     }
 
-    if (strlen(command) > COMMAND_MAX_LEN - 1)
+    if (cmdLen > COMMAND_MAX_LEN - 1)
     {
         Log_Error("Command is too long (63 characters max).");
         goto done;
@@ -341,7 +348,7 @@ bool SendCommand(const char* command)
     }
 
     // Copy command to buffer and fill the remaining buffer (if any) with additional null bytes.
-    strncpy(buffer, command, sizeof(buffer));
+    ADUC_Safe_StrCopyN(buffer, command, sizeof(buffer), cmdLen);
     ssize_t size = write(fd, buffer, sizeof(buffer));
     if (size != sizeof(buffer))
     {

--- a/src/agent/src/main.c
+++ b/src/agent/src/main.c
@@ -57,6 +57,9 @@
 
 #include "eis_utils.h"
 
+// make this last so that it does not interfere when system headers are included after it
+#include "aduc/aduc_banned.h"
+
 /**
  * @brief Make getopt* stop parsing as soon as non-option argument is encountered.
  * @remark See GETOPT.3 man page for more details.

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.cpp
@@ -16,6 +16,9 @@
 #include <sys/stat.h> // for stat
 #include <vector>
 
+// keep this last to minimize chance to interfere with system header includes.
+#include "aduc/aduc_banned.h"
+
 ADUC_Result Download_curl(
     const ADUC_FileEntity* entity,
     const char* workflowId,

--- a/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
@@ -25,6 +25,9 @@
 #    include <objbase.h>
 #endif
 
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 EXTERN_C_BEGIN
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.cpp
+++ b/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.cpp
@@ -25,6 +25,9 @@
 #    include <algorithm> // std::replace
 #endif
 
+// keep this last to minimize chance to interfere with system header includes.
+#include "aduc/aduc_banned.h"
+
 namespace MSDO = microsoft::deliveryoptimization;
 
 ADUC_Result do_download(

--- a/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/plugin/src/microsoft_delta_download_handler_plugin.EXPORTS.c
+++ b/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/handler/plugin/src/microsoft_delta_download_handler_plugin.EXPORTS.c
@@ -21,6 +21,9 @@
 #include <aduc/logging.h> // ADUC_Logging_*, Log_*
 #include <aduc/types/adu_core.h> // ADUC_Result_*
 
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 /////////////////////////////////////////////////////////////////////////////
 // BEGIN Shared Library Export Functions
 //

--- a/src/extensions/step_handlers/apt_handler/src/apt_handler.cpp
+++ b/src/extensions/step_handlers/apt_handler/src/apt_handler.cpp
@@ -33,6 +33,9 @@
 #include <sstream>
 #include <string>
 
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 namespace adushconst = Adu::Shell::Const;
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/extensions/step_handlers/apt_handler/src/apt_parser.cpp
+++ b/src/extensions/step_handlers/apt_handler/src/apt_parser.cpp
@@ -11,6 +11,9 @@
 #include <parson.h>
 #include <string>
 
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 struct JSONValueDeleter
 {
     void operator()(JSON_Value* value)

--- a/src/extensions/step_handlers/script_handler/src/script_handler.cpp
+++ b/src/extensions/step_handlers/script_handler/src/script_handler.cpp
@@ -22,6 +22,9 @@
 #include <string>
 #include <vector>
 
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 #define HANDLER_PROPERTIES_SCRIPT_FILENAME "scriptFileName"
 #define HANDLER_PROPERTIES_API_VERSION "apiVersion"
 #define HANDLER_ARG_ACTION "--action"

--- a/src/extensions/step_handlers/simulator_handler/src/simulator_handler.cpp
+++ b/src/extensions/step_handlers/simulator_handler/src/simulator_handler.cpp
@@ -5,6 +5,7 @@
  * @copyright Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
  */
+
 #include "aduc/simulator_handler.hpp"
 #include "aduc/logging.h"
 #include "aduc/parser_utils.h" // ADUC_FileEntity_Uninit
@@ -12,6 +13,10 @@
 #include <stdarg.h> // for va_*
 #include <stdlib.h> // for getenv
 #include <string>
+
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 
 #define SIMULATOR_DATA_FILE "du-simulator-data.json"
 

--- a/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
+++ b/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
@@ -40,6 +40,9 @@
 
 #include <aducpal/dirent.h>
 
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 namespace adushconst = Adu::Shell::Const;
 
 EXTERN_C_BEGIN

--- a/src/extensions/step_handlers/swupdate_handler_v2/src/handler_create.cpp
+++ b/src/extensions/step_handlers/swupdate_handler_v2/src/handler_create.cpp
@@ -11,6 +11,9 @@
 #include <aduc/swupdate_handler_v2.hpp>
 #include <exception>
 
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 EXTERN_C_BEGIN
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/extensions/step_handlers/wim_handler/src/wim_handler_1.cpp
+++ b/src/extensions/step_handlers/wim_handler/src/wim_handler_1.cpp
@@ -22,6 +22,10 @@
 #include "aduc/workflow_data_utils.h" // ADUC_WorkflowData
 #include "aduc/workflow_utils.h" // workflow_get_*
 
+
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 EXTERN_C_BEGIN
 
 extern ExtensionManager_Download_Options Default_ExtensionManager_Download_Options;

--- a/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
@@ -24,6 +24,9 @@
 #include <sstream>
 #include <string>
 
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 using ADUC::StringUtils::cstr_wrapper;
 
 #define DEFAULT_REF_STEP_HANDLER "microsoft/steps:1"

--- a/src/inc/aduc/aduc_banned.h
+++ b/src/inc/aduc/aduc_banned.h
@@ -1,0 +1,18 @@
+/**
+ * @file aduc_banned.h
+ * @brief Macro definitions that cause banned functions considered to be
+ * unsafe to result in a compilation error.
+ *
+ * @copyright Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+#ifndef ADUC_BANNED_H
+#define ADUC_BANNED_H
+
+#define DEFINE_BANNED_ALTERNATIVE(BANNED_FUNC, ALT_FUNC) BANNED_FUNC##_is_banned__Please_use_##ALT_FUNC##_instead
+
+#undef strncpy
+#define strncpy(dest,src,n) DEFINE_BANNED_ALTERNATIVE(strncpy, ADUC_Safe_StrCopyN)
+
+#endif

--- a/src/utils/c_utils/CMakeLists.txt
+++ b/src/utils/c_utils/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library (aduc::${target_name} ALIAS ${target_name})
 #
 set_property (TARGET ${target_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_include_directories (${target_name} PUBLIC inc)
+target_include_directories (${target_name} PUBLIC inc ${ADUC_EXPORT_INCLUDES})
 
 target_link_aziotsharedutil (${target_name} PRIVATE)
 

--- a/src/utils/c_utils/inc/aduc/string_c_utils.h
+++ b/src/utils/c_utils/inc/aduc/string_c_utils.h
@@ -20,8 +20,6 @@ char* ADUC_StringUtils_Trim(char* str);
 
 bool ADUC_ParseUpdateType(const char* updateType, char** updateTypeName, unsigned int* updateTypeVersion);
 
-bool ReadDelimitedValueFromFile(const char* fileName, const char* key, char* value, unsigned int valueLen);
-
 bool LoadBufferWithFileContents(const char* filePath, char* strBuffer, const size_t strBuffSize);
 
 bool atoul(const char* str, unsigned long* converted);
@@ -35,6 +33,8 @@ char* ADUC_StringFormat(const char* fmt, ...);
 bool IsNullOrEmpty(const char* str);
 
 bool MallocAndSubstr(char** target, char* source, size_t len);
+
+size_t ADUC_Safe_StrCopyN(char* dest, const char* src, size_t destByteLen, size_t numSrcCharsToCopy);
 
 EXTERN_C_END
 

--- a/src/utils/c_utils/src/string_c_utils.c
+++ b/src/utils/c_utils/src/string_c_utils.c
@@ -19,75 +19,13 @@
 
 #include <aducpal/unistd.h> // open, read, close
 
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 /**
  * @brief Maximum length for the output string of ADUC_StringFormat()
  */
 #define ADUC_STRING_FORMAT_MAX_LENGTH 512
-
-/**
- * @brief Read a value from a delimited file and return the value found.
- * The file is in form "key=value", and keys are case sensitive.
- * Value returned has whitespace trimmed from both ends.
- *
- * @param fileName Filename of delimited file
- * @param key Key to find
- * @param value Value found for @p Key
- * @param valueLen Size of buffer for @p value
- * @return true if value found, false otherwise.
- */
-bool ReadDelimitedValueFromFile(const char* fileName, const char* key, char* value, unsigned int valueLen)
-{
-    bool foundKey = false;
-    char buffer[1024];
-    const size_t bufferLen = ARRAY_SIZE(buffer);
-
-    if (valueLen < 2)
-    {
-        // Need space for at least a character and a null terminator.
-        return false;
-    }
-
-    FILE* fp = fopen(fileName, "r");
-    if (fp == NULL)
-    {
-        return false;
-    }
-
-    while (!foundKey && fgets(buffer, (int)bufferLen, fp) != NULL)
-    {
-        char* delimiter = strchr(buffer, '=');
-        if (delimiter == NULL)
-        {
-            // Ignore lines without delimiters.
-            continue;
-        }
-
-        // Change the delimiter character to a NULL for ease of parsing.
-        *delimiter = '\0';
-
-        ADUC_StringUtils_Trim(buffer);
-        foundKey = (strcmp(buffer, key) == 0);
-        if (!foundKey)
-        {
-            continue;
-        }
-
-        char* foundValue = delimiter + 1;
-        ADUC_StringUtils_Trim(foundValue);
-        strncpy(value, foundValue, valueLen);
-        if (value[valueLen - 1] != '\0')
-        {
-            // strncpy pads the buffer with NULL up to valueLen, so if
-            // that position doesn't have a NULL, the buffer provided was too small.
-            foundKey = false;
-            break;
-        }
-    }
-
-    fclose(fp);
-
-    return foundKey;
-}
 
 /**
  * @brief Function that sets @p strBuffers to the contents of the file at @p filePath if the contents are smaller in size than the buffer
@@ -464,12 +402,39 @@ bool MallocAndSubstr(char** target, char* source, size_t len)
         return false;
     }
     memset(t, 0, (len + 1) * sizeof(*t));
-    if (strncpy(t, source, len) != t)
-    {
-        free(t);
-        return false;
-    }
+    ADUC_Safe_StrCopyN(t, source, len + 1, len);
 
     *target = t;
     return true;
+}
+
+/**
+ * @brief Safely copies a source string to a destination buffer.
+ *
+ * This function is a safer alternative to strncpy. It ensures that the
+ * destination buffer is always null-terminated and won't cause buffer
+ * overflow if src is large enough to cause truncation.
+ *
+ * @param dest The destination buffer.
+ * @param src The source string to be copied.
+ * @param destByteLen The size of the destination buffer in bytes.
+ * @param numSrcCharsToCopy The number of source chars to copy. It will be truncated and null-terminated if >= destByteLen.
+ * @return size_t The number of src chars copied. If < numSrcCharsToCopy, then it was truncated.
+ */
+size_t ADUC_Safe_StrCopyN(char* dest, const char* src, size_t destByteLen, size_t numSrcCharsToCopy)
+{
+    if (dest == NULL || src == NULL || destByteLen == 0)
+    {
+        return 0;
+    }
+
+    if(numSrcCharsToCopy >= destByteLen)
+    {
+        numSrcCharsToCopy = destByteLen - 1;
+    }
+
+    memcpy(dest, src, numSrcCharsToCopy);
+    dest[numSrcCharsToCopy] = '\0';
+
+    return numSrcCharsToCopy;
 }

--- a/src/utils/c_utils/tests/c_utils_ut.cpp
+++ b/src/utils/c_utils/tests/c_utils_ut.cpp
@@ -53,56 +53,6 @@ private:
     char _filePath[ARRAY_SIZE("/tmp/tmpfileXXXXXX")] = "/tmp/tmpfileXXXXXX";
 };
 
-TEST_CASE("ReadDelimitedValueFromFile")
-{
-    const unsigned int valueLen = 20;
-    char value[valueLen];
-
-    SECTION("Valid file")
-    {
-        // clang-format off
-        const std::vector<std::string> content{
-            "Key1=Value1",
-            "NotAKeyValuePair",
-            "Key2=Value2",
-            "=DoesntHaveKey",
-            "TwentyCharacterValue=12345678901234567890",
-            "Key3=Value3",
-            "NineteenCharacterValue=1234567890123456789",
-        };
-        // clang-format on
-        TemporaryTestFile file{ content };
-
-        // Valid keys
-        CHECK(ReadDelimitedValueFromFile(file.Filename(), "Key1", value, valueLen));
-        CHECK(std::strcmp(value, "Value1") == 0);
-        CHECK(ReadDelimitedValueFromFile(file.Filename(), "Key2", value, valueLen));
-        CHECK(std::strcmp(value, "Value2") == 0);
-        CHECK(ReadDelimitedValueFromFile(file.Filename(), "Key3", value, valueLen));
-        CHECK(std::strcmp(value, "Value3") == 0);
-
-        // Long values (around valueLen in size)
-        CHECK(ReadDelimitedValueFromFile(file.Filename(), "NineteenCharacterValue", value, valueLen));
-        CHECK(std::strcmp(value, "1234567890123456789") == 0);
-        CHECK(!ReadDelimitedValueFromFile(file.Filename(), "TwentyCharacterValue", value, valueLen));
-
-        // Invalid key
-        CHECK(!ReadDelimitedValueFromFile(file.Filename(), "NotAKeyValuePair", value, valueLen));
-    }
-
-    SECTION("Missing or empty file")
-    {
-        const std::vector<std::string> content;
-        TemporaryTestFile file{ content };
-
-        // Missing file
-        CHECK(!ReadDelimitedValueFromFile("/tmp/__filenamedoesntexist__", "Key1", value, valueLen));
-
-        // Empty file
-        CHECK(!ReadDelimitedValueFromFile(file.Filename(), "Key1", value, valueLen));
-    }
-}
-
 TEST_CASE("ARRAY_SIZE")
 {
     SECTION("Inferred array size")
@@ -461,5 +411,85 @@ TEST_CASE("ADUC_StringFormat")
         const cstr_wrapper retval{ ADUC_StringFormat(fmt.c_str(), tooLongInput.c_str()) };
 
         CHECK(retval.get() == nullptr);
+    }
+}
+TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
+    char dest[10];
+
+    // Edge cases
+
+    SECTION("Handle NULL source") {
+        memset(dest, 0, sizeof(dest));
+        const size_t num_chars_copied = ADUC_Safe_StrCopyN(dest, NULL, sizeof(dest), 1);
+        CHECK(num_chars_copied == 0);
+    }
+
+    SECTION("Handle NULL destination") {
+        memset(dest, 0, sizeof(dest));
+        const char* src = "test";
+        const size_t num_chars_copied = ADUC_Safe_StrCopyN(NULL, src, sizeof(dest), 4);
+        CHECK(num_chars_copied == 0);
+    }
+
+    SECTION("Handle zero size") {
+        memset(dest, 0, sizeof(dest));
+        const char* src = "test";
+        const size_t num_chars_copied = ADUC_Safe_StrCopyN(dest, src, 0, 4);
+        CHECK(num_chars_copied == 0);
+    }
+
+    // mainline cases
+
+    SECTION("Copy a shorter string") {
+        memset(dest, 0, sizeof(dest));
+        const char* src = "short";
+        const size_t num_chars_copied = ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 5);
+        CHECK(num_chars_copied == 5);
+        CHECK(strcmp(dest, "short") == 0);
+
+    }
+
+    SECTION("Copy a string of exact length") {
+        memset(dest, 0, sizeof(dest));
+        const char* src = "123456789"; // 9 + 1 null-term
+        const size_t num_chars_copied = ADUC_Safe_StrCopyN(dest, src, sizeof(dest), strlen(src));
+        CHECK(num_chars_copied == 9);
+        REQUIRE(strcmp(dest, src) == 0);
+    }
+
+    SECTION("Handle longer source string by truncating") {
+        memset(dest, 0, sizeof(dest));
+        const char* src = "12345678901234"; // 14 + 1
+        const size_t num_chars_copied = ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 14);
+        ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 9);
+        REQUIRE(strcmp(dest, "123456789") == 0);
+    }
+
+    SECTION("Handle subset of longer source string that is still longer than dest") {
+        memset(dest, 0, sizeof(dest));
+        const char* src = "12345678901234"; // 14 + 1
+        const size_t num_chars_copied = ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 11);
+        CHECK(num_chars_copied == 9);
+        REQUIRE(strcmp(dest, "123456789") == 0);
+
+        memset(dest, 0, sizeof(dest));
+        ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 9);
+        REQUIRE(strcmp(dest, "123456789") == 0);
+    }
+
+    SECTION("Handle subset of longer source string, exactly as long as dest buffer - 1") {
+        memset(dest, 0, sizeof(dest));
+        const char* src = "12345678901234"; // 14 + 1
+        const size_t num_chars_copied = ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 9);
+        CHECK(num_chars_copied == 9);
+        REQUIRE(strcmp(dest, "123456789") == 0);
+    }
+
+    SECTION("Handle subset of longer source string, that is less-than dest buffer - 1") {
+        memset(dest, 0, sizeof(dest));
+        const char* src = "12345678901234"; // 14 + 1
+        const size_t num_chars_copied = ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 8);
+        CHECK(num_chars_copied == 8);
+        REQUIRE(strcmp(dest, "12345678") == 0);
     }
 }

--- a/src/utils/c_utils/tests/c_utils_ut.cpp
+++ b/src/utils/c_utils/tests/c_utils_ut.cpp
@@ -461,7 +461,7 @@ TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
         memset(dest, 0, sizeof(dest));
         const char* src = "12345678901234"; // 14 + 1
         const size_t num_chars_copied = ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 14);
-        ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 9);
+        CHECK(num_chars_copied == 9);
         REQUIRE(strcmp(dest, "123456789") == 0);
     }
 

--- a/src/utils/jws_utils/src/jws_utils.c
+++ b/src/utils/jws_utils/src/jws_utils.c
@@ -15,6 +15,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "aduc/string_c_utils.h" // ADUC_Safe_StrCopyN
+
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
+
 //
 // Internal Functions
 //
@@ -141,16 +146,11 @@ static bool ExtractJWSSections(const char* jws, char** header, char** payload, c
         goto done;
     }
 
-    strncpy(*header, jws, headerLen);
-    strncpy(*payload, (headerEnd + 1), payloadLen);
-    strncpy(*signature, (payloadEnd + 1), sigLen);
-
-    (*header)[headerLen] = '\0';
-    (*payload)[payloadLen] = '\0';
-    (*signature)[sigLen] = '\0';
+    ADUC_Safe_StrCopyN(*header, jws, headerLen + 1, headerLen);
+    ADUC_Safe_StrCopyN(*payload, (headerEnd + 1), payloadLen + 1, payloadLen);
+    ADUC_Safe_StrCopyN(*signature, (payloadEnd + 1), sigLen + 1, sigLen);
 
     success = true;
-
 done:
     if (!success)
     {
@@ -218,8 +218,8 @@ static bool ExtractJWSHeader(const char* jws, char** header)
         goto done;
     }
 
-    strncpy(tempHeader, jws, headerLen);
-    tempHeader[headerLen] = '\0';
+    ADUC_Safe_StrCopyN(tempHeader, jws, headerLen + 1, headerLen);
+
     success = true;
 
 done:

--- a/src/utils/permission_utils/tests/permission_utils_ut.cpp
+++ b/src/utils/permission_utils/tests/permission_utils_ut.cpp
@@ -12,11 +12,16 @@
 #include <catch2/catch.hpp>
 #include <stdio.h>
 #include <string.h>
+#include <string>
 
 #include <fstream> // ofstream
 
 #include <aducpal/stdio.h> // remove
 #include <aducpal/sys_stat.h> // S_I*
+#include "aduc/string_c_utils.h" // ADUC_Safe_StrCopyN
+
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
 
 TEST_CASE("PermissionUtils_VerifyFilemodeBit*")
 {
@@ -28,8 +33,9 @@ TEST_CASE("PermissionUtils_VerifyFilemodeBit*")
 #endif
 
     // create temp file with all file permission bits set
-    char tmpfile_path[32];
-    strncpy(tmpfile_path, "/tmp/permissionUtilsUT_XXXXXX", sizeof(tmpfile_path));
+    char tmpfile_path[30];
+    std::string src_str{ "/tmp/permissionUtilsUT_XXXXXX" };
+    ADUC_Safe_StrCopyN(tmpfile_path, src_str.c_str(), sizeof(tmpfile_path), src_str.length());
     ADUC_SystemUtils_MkTemp(tmpfile_path);
     std::ofstream file{ tmpfile_path };
     file.close();

--- a/src/utils/system_utils/src/system_utils.c
+++ b/src/utils/system_utils/src/system_utils.c
@@ -23,9 +23,12 @@
 #include <limits.h> // for PATH_MAX
 #include <stdio.h>
 #include <stdlib.h> // for getenv
-#include <string.h> // for strncpy, strlen
+#include <string.h> // strlen
 #include <sys/stat.h>
 #include <sys/types.h>
+
+// keep this last to avoid interfering with system headers
+#include "aduc/aduc_banned.h"
 
 #ifndef ALL_PERMS
 /**
@@ -216,16 +219,9 @@ int ADUC_SystemUtils_MkDirRecursive(const char* path, uid_t userId, gid_t groupI
     }
 
     char mkdirPath[PATH_MAX + 1];
+    memset(mkdirPath, 0, sizeof(mkdirPath));
     const size_t mkdirPath_cch = ADUC_StrNLen(path, PATH_MAX);
-
-    // Create writable copy of path to iterate over.
-    if (mkdirPath_cch + 1 > ARRAY_SIZE(mkdirPath))
-    {
-        return ENAMETOOLONG;
-    }
-
-    strncpy(mkdirPath, path, mkdirPath_cch);
-    mkdirPath[mkdirPath_cch] = '\0';
+    ADUC_Safe_StrCopyN(mkdirPath, path, sizeof(mkdirPath), mkdirPath_cch);
 
     // Remove any trailing slash.
     if (mkdirPath[mkdirPath_cch - 1] == '/')


### PR DESCRIPTION
- Add aduc_banned.h to strategic executable and module cmake targets' .c/.cpp (cannot add to .h without lots of refactoring to avoid it messing up system headers)
- Make use of strncpy in some impl files result in compiler error
- Replace instances of strncpy with ADUC_Safe_StrCopyN
- Add unit tests for ADUC_Safe_StrCopyN
- Remove unused ReadDelimitedValueFromFile function and tests

Attempting to use strncpy now will result in compilation error that looks like this:
```sh
user/jw-msft/merge-develop-into-rootkey-feature-2023_10_03

/home/jw/src/iot-hub-device-update/src/utils/jws_utils/src/jws_utils.c: In function ‘ExtractJWSSections’:
/home/jw/src/iot-hub-device-update/src/inc/aduc/aduc_banned.h:16:55: error: ‘strncpy_is_banned__Please_use_ADUC_Safe_StrCopyN_instead’ undeclared (first use in this function)
   16 | #define strncpy(dest,src,n) DEFINE_BANNED_ALTERNATIVE(strncpy, ADUC_Safe_StrCopyN)
      |                                                       ^~~~~~~
/home/jw/src/iot-hub-device-update/src/inc/aduc/aduc_banned.h:13:58: note: in definition of macro ‘DEFINE_BANNED_ALTERNATIVE’
   13 | #define DEFINE_BANNED_ALTERNATIVE(BANNED_FUNC, ALT_FUNC) BANNED_FUNC##_is_banned__Please_use_##ALT_FUNC##_instead
      |                                                          ^~~~~~~~~~~
/home/jw/src/iot-hub-device-update/src/utils/jws_utils/src/jws_utils.c:152:5: note: in expansion of macro ‘strncpy’
  152 |     strncpy(*header, jws, headerLen + 1);
      |     ^~~~~~~
/home/jw/src/iot-hub-device-update/src/inc/aduc/aduc_banned.h:16:55: note: each undeclared identifier is reported only once for each function it appears in
   16 | #define strncpy(dest,src,n) DEFINE_BANNED_ALTERNATIVE(strncpy, ADUC_Safe_StrCopyN)
      |                                                       ^~~~~~~
/home/jw/src/iot-hub-device-update/src/inc/aduc/aduc_banned.h:13:58: note: in definition of macro ‘DEFINE_BANNED_ALTERNATIVE’
   13 | #define DEFINE_BANNED_ALTERNATIVE(BANNED_FUNC, ALT_FUNC) BANNED_FUNC##_is_banned__Please_use_##ALT_FUNC##_instead
      |                                                          ^~~~~~~~~~~
/home/jw/src/iot-hub-device-update/src/utils/jws_utils/src/jws_utils.c:152:5: note: in expansion of macro ‘strncpy’
  152 |     strncpy(*header, jws, headerLen + 1);
      |     ^~~~~~~
[77/253] Building CXX object src/utils/permission_utils/tests/CMakeFiles/permission_utils_unit_test.dir/main.cpp.o
ninja: build stopped: subcommand failed.

```