### PR TITLE
Factor out req-resp internal mgmt impls

### DIFF
--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/CMakeLists.txt
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/CMakeLists.txt
@@ -9,7 +9,9 @@ find_package (azure_c_shared_utility REQUIRED)
 find_package (Parson REQUIRED)
 
 target_sources (${target_name} PRIVATE src/adu_agent_info_management.c
+                                       src/adu_agent_info_management_internal.c
                                        src/adu_enrollment_management.c
+                                       src/adu_enrollment_management_internal.c
                                        src/adu_mqtt_client_module.c
                                        src/adu_updates_management.c
                                        src/agentinfo_request_operation.c

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/inc/aduc/agent_module_interface_internal.h
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/inc/aduc/agent_module_interface_internal.h
@@ -4,10 +4,10 @@
 #include <du_agent_sdk/agent_module_interface.h> // ADUC_AGENT_CONTRACT_INFO
 
 //
-// The per topic module interface declaration expansions
+// The per operation module interface declaration expansions
 //
 
-// Enrollment topic
+// Enrollment request and response management
 
 const ADUC_AGENT_CONTRACT_INFO* ADUC_Enrollment_Management_GetContractInfo(ADUC_AGENT_MODULE_HANDLE handle);
 int ADUC_Enrollment_Management_Initialize(ADUC_AGENT_MODULE_HANDLE handle, void* initData);
@@ -15,7 +15,7 @@ int ADUC_Enrollment_Management_Deinitialize(ADUC_AGENT_MODULE_HANDLE handle);
 int ADUC_Enrollment_Management_DoWork(ADUC_AGENT_MODULE_HANDLE handle);
 void ADUC_Enrollment_Management_Destroy(ADUC_AGENT_MODULE_HANDLE handle);
 
-// AgentInfo topic
+// AgentInfo request and response management
 
 const ADUC_AGENT_CONTRACT_INFO* ADUC_AgentInfo_Management_GetContractInfo(ADUC_AGENT_MODULE_HANDLE handle);
 int ADUC_AgentInfo_Management_Initialize(ADUC_AGENT_MODULE_HANDLE handle, void* initData);
@@ -23,7 +23,7 @@ int ADUC_AgentInfo_Management_Deinitialize(ADUC_AGENT_MODULE_HANDLE handle);
 int ADUC_AgentInfo_Management_DoWork(ADUC_AGENT_MODULE_HANDLE handle);
 void ADUC_AgentInfo_Management_Destroy(ADUC_AGENT_MODULE_HANDLE handle);
 
-// Update topic
+// Update request and response management
 
 // const ADUC_AGENT_CONTRACT_INFO* ADUC_Update_Management_GetContractInfo(ADUC_AGENT_MODULE_HANDLE handle);
 // int ADUC_Update_Management_Initialize(ADUC_AGENT_MODULE_HANDLE handle, void* initData);
@@ -31,7 +31,7 @@ void ADUC_AgentInfo_Management_Destroy(ADUC_AGENT_MODULE_HANDLE handle);
 // int ADUC_Update_Management_DoWork(ADUC_AGENT_MODULE_HANDLE handle);
 // void ADUC_Update_Management_Destroy(ADUC_AGENT_MODULE_HANDLE handle);
 
-// UpdateResults topic
+// UpdateResults request and response management
 
 // const ADUC_AGENT_CONTRACT_INFO* ADUC_UpdateResults_Management_GetContractInfo(ADUC_AGENT_MODULE_HANDLE handle);
 // int ADUC_UpdateResults_Management_Initialize(ADUC_AGENT_MODULE_HANDLE handle, void* initData);

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_agent_info_management.c
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_agent_info_management.c
@@ -15,6 +15,7 @@
 #include <aduc/adu_mqtt_common.h>
 #include <aduc/adu_mqtt_protocol.h>
 #include <aduc/adu_types.h>
+#include <aduc/agent_module_interface_internal.h>
 #include <aduc/agent_state_store.h>
 #include <aduc/config_utils.h>
 #include <aduc/agentinfo_request_operation.h>
@@ -33,77 +34,6 @@
 // clang-format off
 #include <aduc/aduc_banned.h> // must be after other includes
 // clang-format on
-
-/**
- * @brief Gets the extension contract info.
- * @param handle The handle to the module. This is the same handle that was returned by the Create function.
- * @return ADUC_AGENT_CONTRACT_INFO The extension contract info.
- */
-const ADUC_AGENT_CONTRACT_INFO* ADUC_AgentInfo_Management_GetContractInfo(ADUC_AGENT_MODULE_HANDLE handle)
-{
-    static ADUC_AGENT_CONTRACT_INFO s_moduleContractInfo = {
-        "Microsoft", "Device Update AgentInfo Module", 1, "Microsoft/DUAgentInfoModule:1"
-    };
-
-    IGNORED_PARAMETER(handle);
-    return &s_moduleContractInfo;
-}
-
-/**
- * @brief Initialize the agentinfo management.
- * @param handle The agent module handle.
- * @param initData The initialization data.
- * @return 0 on successful initialization; -1, otherwise.
- */
-int ADUC_AgentInfo_Management_Initialize(ADUC_AGENT_MODULE_HANDLE handle, void* initData)
-{
-    IGNORED_PARAMETER(initData);
-    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
-    if (context == NULL)
-    {
-        Log_Error("Failed to get operation context");
-        return -1;
-    }
-
-    return 0;
-}
-
-/**
- * @brief Deinitialize the agentinfo management.
- * @param handle The module handle.
- * @return int 0 on success.
- */
-int ADUC_AgentInfo_Management_Deinitialize(ADUC_AGENT_MODULE_HANDLE handle)
-{
-    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
-    if (context == NULL)
-    {
-        Log_Error("Failed to get operation context");
-        return false;
-    }
-    context->cancelFunc(context);
-    return 0;
-}
-
-/**
- * @brief AgentInfo mangement do work function.
- *
- * @param handle The module handle.
- * @return int 0 on success.
- */
-int ADUC_AgentInfo_Management_DoWork(ADUC_AGENT_MODULE_HANDLE handle)
-{
-    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
-    if (context == NULL)
-    {
-        Log_Error("Failed to get operation context");
-        return -1;
-    }
-
-    context->doWorkFunc(context);
-
-    return 0;
-}
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_agent_info_management_internal.c
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_agent_info_management_internal.c
@@ -1,0 +1,88 @@
+
+#include "aduc/agent_module_interface_internal.h"
+
+#include <aduc/adu_mqtt_common.h> // OperationContextFromAgentModuleHandle
+#include <aduc/logging.h>
+#include <aduc/retry_utils.h> // ADUC_Retriable_Operation_Context
+#include <du_agent_sdk/agent_common.h> // IGNORED_PARAMETER
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// BEGIN - AGENT_MODULE_INTERFACE_INTERNAL_H interface implementation
+//
+
+/**
+ * @brief Gets the extension contract info.
+ * @param handle The handle to the module. This is the same handle that was returned by the Create function.
+ * @return ADUC_AGENT_CONTRACT_INFO The extension contract info.
+ */
+const ADUC_AGENT_CONTRACT_INFO* ADUC_AgentInfo_Management_GetContractInfo(ADUC_AGENT_MODULE_HANDLE handle)
+{
+    static ADUC_AGENT_CONTRACT_INFO s_moduleContractInfo = {
+        "Microsoft", "Device Update AgentInfo Module", 1, "Microsoft/DUAgentInfoModule:1"
+    };
+
+    IGNORED_PARAMETER(handle);
+    return &s_moduleContractInfo;
+}
+
+/**
+ * @brief Initialize the agentinfo management.
+ * @param handle The agent module handle.
+ * @param initData The initialization data.
+ * @return 0 on successful initialization; -1, otherwise.
+ */
+int ADUC_AgentInfo_Management_Initialize(ADUC_AGENT_MODULE_HANDLE handle, void* initData)
+{
+    IGNORED_PARAMETER(initData);
+    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
+    if (context == NULL)
+    {
+        Log_Error("Failed to get operation context");
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Deinitialize the agentinfo management.
+ * @param handle The module handle.
+ * @return int 0 on success.
+ */
+int ADUC_AgentInfo_Management_Deinitialize(ADUC_AGENT_MODULE_HANDLE handle)
+{
+    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
+    if (context == NULL)
+    {
+        Log_Error("Failed to get operation context");
+        return false;
+    }
+    context->cancelFunc(context);
+    return 0;
+}
+
+/**
+ * @brief AgentInfo mangement do work function.
+ *
+ * @param handle The module handle.
+ * @return int 0 on success.
+ */
+int ADUC_AgentInfo_Management_DoWork(ADUC_AGENT_MODULE_HANDLE handle)
+{
+    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
+    if (context == NULL)
+    {
+        Log_Error("Failed to get operation context");
+        return -1;
+    }
+
+    context->doWorkFunc(context);
+
+    return 0;
+}
+
+//
+// END - AGENT_MODULE_INTERFACE_INTERNAL_H implementation
+//
+/////////////////////////////////////////////////////////////////////////////

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management.c
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management.c
@@ -15,6 +15,7 @@
 #include <aduc/adu_mqtt_common.h>
 #include <aduc/adu_mqtt_protocol.h>
 #include <aduc/adu_types.h>
+#include <aduc/agent_module_interface_internal.h>
 #include <aduc/agent_state_store.h>
 #include <aduc/config_utils.h>
 #include <aduc/enrollment_request_operation.h>
@@ -33,77 +34,6 @@
 // clang-format off
 #include <aduc/aduc_banned.h> // must be after other includes
 // clang-format on
-
-/**
- * @brief Gets the extension contract info.
- * @param handle The handle to the module. This is the same handle that was returned by the Create function.
- * @return ADUC_AGENT_CONTRACT_INFO The extension contract info.
- */
-const ADUC_AGENT_CONTRACT_INFO* ADUC_Enrollment_Management_GetContractInfo(ADUC_AGENT_MODULE_HANDLE handle)
-{
-    static ADUC_AGENT_CONTRACT_INFO s_moduleContractInfo = {
-        "Microsoft", "Device Update Enrollment Module", 1, "Microsoft/DUEnrollmentModule:1"
-    };
-
-    IGNORED_PARAMETER(handle);
-    return &s_moduleContractInfo;
-}
-
-/**
- * @brief Initialize the enrollment management.
- * @param handle The agent module handle.
- * @param initData The initialization data.
- * @return 0 on successful initialization; -1, otherwise.
- */
-int ADUC_Enrollment_Management_Initialize(ADUC_AGENT_MODULE_HANDLE handle, void* initData)
-{
-    IGNORED_PARAMETER(initData);
-    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
-    if (context == NULL)
-    {
-        Log_Error("Failed to get operation context");
-        return -1;
-    }
-
-    return 0;
-}
-
-/**
- * @brief Deinitialize the enrollment management.
- * @param handle The module handle.
- * @return int 0 on success.
- */
-int ADUC_Enrollment_Management_Deinitialize(ADUC_AGENT_MODULE_HANDLE handle)
-{
-    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
-    if (context == NULL)
-    {
-        Log_Error("Failed to get operation context");
-        return false;
-    }
-    context->cancelFunc(context);
-    return 0;
-}
-
-/**
- * @brief Enrollment mangement do work function.
- *
- * @param handle The module handle.
- * @return int 0 on success.
- */
-int ADUC_Enrollment_Management_DoWork(ADUC_AGENT_MODULE_HANDLE handle)
-{
-    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
-    if (context == NULL)
-    {
-        Log_Error("Failed to get operation context");
-        return -1;
-    }
-
-    context->doWorkFunc(context);
-
-    return 0;
-}
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -237,7 +167,6 @@ void OnMessage_enr_resp(
 done:
     free(scopeId);
 }
-
 
 //
 // END - ADU_ENROLLMENT_MANAGEMENT.H Public Interface

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management_internal.c
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_enrollment_management_internal.c
@@ -1,0 +1,87 @@
+#include "aduc/agent_module_interface_internal.h"
+
+#include <aduc/adu_mqtt_common.h> // OperationContextFromAgentModuleHandle
+#include <aduc/logging.h>
+#include <aduc/retry_utils.h> // ADUC_Retriable_Operation_Context
+#include <du_agent_sdk/agent_common.h> // IGNORED_PARAMETER
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// BEGIN - AGENT_MODULE_INTERFACE_INTERNAL_H interface implementation
+//
+
+/**
+ * @brief Gets the extension contract info.
+ * @param handle The handle to the module. This is the same handle that was returned by the Create function.
+ * @return ADUC_AGENT_CONTRACT_INFO The extension contract info.
+ */
+const ADUC_AGENT_CONTRACT_INFO* ADUC_Enrollment_Management_GetContractInfo(ADUC_AGENT_MODULE_HANDLE handle)
+{
+    static ADUC_AGENT_CONTRACT_INFO s_moduleContractInfo = {
+        "Microsoft", "Device Update Enrollment Module", 1, "Microsoft/DUEnrollmentModule:1"
+    };
+
+    IGNORED_PARAMETER(handle);
+    return &s_moduleContractInfo;
+}
+
+/**
+ * @brief Initialize the enrollment management.
+ * @param handle The agent module handle.
+ * @param initData The initialization data.
+ * @return 0 on successful initialization; -1, otherwise.
+ */
+int ADUC_Enrollment_Management_Initialize(ADUC_AGENT_MODULE_HANDLE handle, void* initData)
+{
+    IGNORED_PARAMETER(initData);
+    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
+    if (context == NULL)
+    {
+        Log_Error("Failed to get operation context");
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Deinitialize the enrollment management.
+ * @param handle The module handle.
+ * @return int 0 on success.
+ */
+int ADUC_Enrollment_Management_Deinitialize(ADUC_AGENT_MODULE_HANDLE handle)
+{
+    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
+    if (context == NULL)
+    {
+        Log_Error("Failed to get operation context");
+        return false;
+    }
+    context->cancelFunc(context);
+    return 0;
+}
+
+/**
+ * @brief Enrollment mangement do work function.
+ *
+ * @param handle The module handle.
+ * @return int 0 on success.
+ */
+int ADUC_Enrollment_Management_DoWork(ADUC_AGENT_MODULE_HANDLE handle)
+{
+    ADUC_Retriable_Operation_Context* context = OperationContextFromAgentModuleHandle(handle);
+    if (context == NULL)
+    {
+        Log_Error("Failed to get operation context");
+        return -1;
+    }
+
+    context->doWorkFunc(context);
+
+    return 0;
+}
+
+//
+// END - AGENT_MODULE_INTERFACE_INTERNAL_H implementation
+//
+/////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
A wholesale copy of per-operation internal interface impls declared in [agent_module_interface_internal.h](https://github.com/Azure/iot-hub-device-update/compare/topic/v2-pr-fb...user/jw-msft/v2-internalmgmt?expand=1#diff-83350046f6ab4ac3afc6988cc6917424e53b8dd28719445692eb92aeafa86234) from `adu_<operation>_management.c` into respective `adu_<operation>_management_internal.c`
