### PR TITLE
Align ADUC_Safe_StrCopyN arg order to StringCchCopyNA

### DIFF
--- a/src/agent/command_helper/src/command_helper.c
+++ b/src/agent/command_helper/src/command_helper.c
@@ -353,7 +353,7 @@ bool SendCommand(const char* command)
     }
 
     // Copy command to buffer and fill the remaining buffer (if any) with additional null bytes.
-    if (!ADUC_Safe_StrCopyN(buffer, command, sizeof(buffer), cmdLen))
+    if (!ADUC_Safe_StrCopyN(buffer, sizeof(buffer), command, cmdLen))
     {
         goto done;
     }

--- a/src/agent/command_helper/src/command_helper.c
+++ b/src/agent/command_helper/src/command_helper.c
@@ -10,6 +10,7 @@
 #include "aduc/logging.h"
 #include "aduc/permission_utils.h"
 
+#include "aduc/string_c_utils.h" // ADUC_Safe_StrCopyN
 #include <aducpal/unistd.h> // sleep
 #include <errno.h>
 #include <fcntl.h>
@@ -20,7 +21,6 @@
 #include <stdlib.h> // free
 #include <string.h> // strlen
 #include <sys/stat.h> // mkfifo
-#include "aduc/string_c_utils.h" // ADUC_Safe_StrCopyN
 
 // keep this last to avoid interfering with system headers
 #include "aduc/aduc_banned.h"

--- a/src/extensions/agent_modules/shared/agentinfo_utils/src/adu_agentinfo_utils.c
+++ b/src/extensions/agent_modules/shared/agentinfo_utils/src/adu_agentinfo_utils.c
@@ -111,10 +111,10 @@ bool AgentInfoData_SetCorrelationId(ADUC_AgentInfo_Request_Operation_Data* agent
     }
 
     if (!ADUC_Safe_StrCopyN(
-        agentInfoData->ainfoReqMessageContext.correlationId,
-        ARRAY_SIZE(agentInfoData->ainfoReqMessageContext.correlationId),
-        correlationId,
-        strlen(correlationId)))
+            agentInfoData->ainfoReqMessageContext.correlationId,
+            ARRAY_SIZE(agentInfoData->ainfoReqMessageContext.correlationId),
+            correlationId,
+            strlen(correlationId)))
     {
         Log_Error("copy failed");
         return false;

--- a/src/extensions/agent_modules/shared/agentinfo_utils/src/adu_agentinfo_utils.c
+++ b/src/extensions/agent_modules/shared/agentinfo_utils/src/adu_agentinfo_utils.c
@@ -111,10 +111,10 @@ bool AgentInfoData_SetCorrelationId(ADUC_AgentInfo_Request_Operation_Data* agent
     }
 
     if (!ADUC_Safe_StrCopyN(
-            agentInfoData->ainfoReqMessageContext.correlationId,
-            correlationId,
-            ARRAY_SIZE(agentInfoData->ainfoReqMessageContext.correlationId),
-            strlen(correlationId)))
+        agentInfoData->ainfoReqMessageContext.correlationId,
+        ARRAY_SIZE(agentInfoData->ainfoReqMessageContext.correlationId),
+        correlationId,
+        strlen(correlationId)))
     {
         Log_Error("copy failed");
         return false;

--- a/src/extensions/agent_modules/shared/enrollment_utils/src/adu_enrollment_utils.c
+++ b/src/extensions/agent_modules/shared/enrollment_utils/src/adu_enrollment_utils.c
@@ -126,10 +126,10 @@ bool EnrollmentData_SetCorrelationId(ADUC_Enrollment_Request_Operation_Data* enr
     }
 
     if (!ADUC_Safe_StrCopyN(
-        enrollmentData->enrReqMessageContext.correlationId,
-        ARRAY_SIZE(enrollmentData->enrReqMessageContext.correlationId),
-        correlationId,
-        strlen(correlationId)))
+            enrollmentData->enrReqMessageContext.correlationId,
+            ARRAY_SIZE(enrollmentData->enrReqMessageContext.correlationId),
+            correlationId,
+            strlen(correlationId)))
     {
         Log_Error("copy failed");
         return false;

--- a/src/extensions/agent_modules/shared/enrollment_utils/src/adu_enrollment_utils.c
+++ b/src/extensions/agent_modules/shared/enrollment_utils/src/adu_enrollment_utils.c
@@ -127,8 +127,8 @@ bool EnrollmentData_SetCorrelationId(ADUC_Enrollment_Request_Operation_Data* enr
 
     if (!ADUC_Safe_StrCopyN(
         enrollmentData->enrReqMessageContext.correlationId,
-        correlationId,
         ARRAY_SIZE(enrollmentData->enrReqMessageContext.correlationId),
+        correlationId,
         strlen(correlationId)))
     {
         Log_Error("copy failed");

--- a/src/extensions/agent_modules/shared/state_store/src/agent_state_store.c
+++ b/src/extensions/agent_modules/shared/state_store/src/agent_state_store.c
@@ -310,8 +310,9 @@ ADUC_STATE_STORE_RESULT ADUC_StateStore_SetTopicSubscribedStatus(const char* top
 
     if (subscribed)
     {
-        *state_topic_target = (char*)calloc(topic_len + 1, sizeof(char));
-        if (!ADUC_Safe_StrCopyN(*state_topic_target, topic, topic_len + 1, topic_len))
+        const size_t TopicByteLenPlusNullTerm = topic_len + 1;
+        *state_topic_target = (char*)calloc(TopicByteLenPlusNullTerm, sizeof(char));
+        if (!ADUC_Safe_StrCopyN(*state_topic_target /* dest */, TopicByteLenPlusNullTerm /* destByteLen */, topic /* src */, topic_len /* srcByteLen */))
         {
             result = ADUC_STATE_STORE_RESULT_ERROR_MAX_TOPIC_BYTE_LENGTH_EXCEEDED;
             goto done;

--- a/src/extensions/agent_modules/shared/state_store/src/agent_state_store.c
+++ b/src/extensions/agent_modules/shared/state_store/src/agent_state_store.c
@@ -312,7 +312,11 @@ ADUC_STATE_STORE_RESULT ADUC_StateStore_SetTopicSubscribedStatus(const char* top
     {
         const size_t TopicByteLenPlusNullTerm = topic_len + 1;
         *state_topic_target = (char*)calloc(TopicByteLenPlusNullTerm, sizeof(char));
-        if (!ADUC_Safe_StrCopyN(*state_topic_target /* dest */, TopicByteLenPlusNullTerm /* destByteLen */, topic /* src */, topic_len /* srcByteLen */))
+        if (!ADUC_Safe_StrCopyN(
+                *state_topic_target /* dest */,
+                TopicByteLenPlusNullTerm /* destByteLen */,
+                topic /* src */,
+                topic_len /* srcByteLen */))
         {
             result = ADUC_STATE_STORE_RESULT_ERROR_MAX_TOPIC_BYTE_LENGTH_EXCEEDED;
             goto done;

--- a/src/extensions/agent_modules/shared/upd_utils/src/adu_upd_utils.c
+++ b/src/extensions/agent_modules/shared/upd_utils/src/adu_upd_utils.c
@@ -106,10 +106,10 @@ bool UpdateData_SetCorrelationId(ADUC_Update_Request_Operation_Data* updateData,
     }
 
     if (!ADUC_Safe_StrCopyN(
-        updateData->updReqMessageContext.correlationId,
-        ARRAY_SIZE(updateData->updReqMessageContext.correlationId),
-        correlationId,
-        strlen(correlationId)))
+            updateData->updReqMessageContext.correlationId,
+            ARRAY_SIZE(updateData->updReqMessageContext.correlationId),
+            correlationId,
+            strlen(correlationId)))
     {
         Log_Error("copy failed");
         return false;

--- a/src/extensions/agent_modules/shared/upd_utils/src/adu_upd_utils.c
+++ b/src/extensions/agent_modules/shared/upd_utils/src/adu_upd_utils.c
@@ -106,10 +106,10 @@ bool UpdateData_SetCorrelationId(ADUC_Update_Request_Operation_Data* updateData,
     }
 
     if (!ADUC_Safe_StrCopyN(
-            updateData->updReqMessageContext.correlationId,
-            correlationId,
-            ARRAY_SIZE(updateData->updReqMessageContext.correlationId),
-            strlen(correlationId)))
+        updateData->updReqMessageContext.correlationId,
+        ARRAY_SIZE(updateData->updReqMessageContext.correlationId),
+        correlationId,
+        strlen(correlationId)))
     {
         Log_Error("copy failed");
         return false;

--- a/src/utils/c_utils/inc/aduc/string_c_utils.h
+++ b/src/utils/c_utils/inc/aduc/string_c_utils.h
@@ -34,9 +34,9 @@ bool IsNullOrEmpty(const char* str);
 
 bool MallocAndSubstr(char** target, const char* source, size_t len);
 
-bool ADUC_Safe_StrCopyN(char* dest, const char* src, size_t destByteLen, size_t numSrcCharsToCopy);
+bool ADUC_Safe_StrCopyN(char* dest, size_t destByteLen, const char* src, size_t srcByteLen);
 
-bool ADUC_AllocAndStrCopyN(char** dest, const char* src, size_t srcLen);
+bool ADUC_AllocAndStrCopyN(char** dest, const char* src, size_t srcByteLen);
 
 EXTERN_C_END
 

--- a/src/utils/c_utils/src/string_c_utils.c
+++ b/src/utils/c_utils/src/string_c_utils.c
@@ -476,7 +476,8 @@ bool ADUC_AllocAndStrCopyN(char** dest, const char* src, size_t srcByteLen)
         goto done;
     }
 
-    if (!ADUC_Safe_StrCopyN(tmpDest, SrcByteLenNullTerm * sizeof(char) /* destByteLen */, src, srcByteLen /* srcByteLen */))
+    if (!ADUC_Safe_StrCopyN(
+            tmpDest, SrcByteLenNullTerm * sizeof(char) /* destByteLen */, src, srcByteLen /* srcByteLen */))
     {
         goto done;
     }

--- a/src/utils/c_utils/src/string_c_utils.c
+++ b/src/utils/c_utils/src/string_c_utils.c
@@ -384,8 +384,8 @@ bool IsNullOrEmpty(const char* str)
  * @brief Allocates memory for @p target and copy @p len characters of @p source into @p target buffer.
  *
  * @param[out] target Output string
- * @param source Source string
  * @param len Length of string to copy.
+ * @param source Source string
  * @return bool Returns true is success.
  */
 bool MallocAndSubstr(char** target, const char* source, size_t len)
@@ -396,16 +396,15 @@ bool MallocAndSubstr(char** target, const char* source, size_t len)
     }
     *target = NULL;
 
-    char* t = malloc((len + 1) * sizeof(*t));
+    const size_t LenPlusNullTerm = len + 1;
 
+    char* t = calloc(LenPlusNullTerm, sizeof(*t));
     if (t == NULL)
     {
         return false;
     }
 
-    memset(t, 0, (len + 1) * sizeof(*t));
-
-    if (!ADUC_Safe_StrCopyN(t, source, len + 1, len))
+    if (!ADUC_Safe_StrCopyN(t, LenPlusNullTerm, source, len /* srcByteLen */))
     {
         free(t);
         return false;
@@ -423,63 +422,61 @@ bool MallocAndSubstr(char** target, const char* source, size_t len)
  * overflow if src is large enough to cause truncation.
  *
  * @param dest The destination buffer.
+ * @param destByteLen The size in bytes of the destination buffer capacity that also accounts for a null-terminator. e.g. pass ARRAY_SIZE(dest), or 42, for char dest[42].
  * @param src The source string to be copied.
- * @param destByteLen The size of the destination buffer in bytes, including plus 1 for the null terminator.
- * @param numSrcCharsToCopy The number of source chars to copy. It will be truncated and null-terminated if >= destByteLen.
+ * @param srcByteLen The number of source bytes to copy.
  * @return true on success.
  */
-bool ADUC_Safe_StrCopyN(char* dest, const char* src, size_t destByteLen, size_t numSrcCharsToCopy)
+bool ADUC_Safe_StrCopyN(char* dest, size_t destByteLen, const char* src, size_t srcByteLen)
 {
-    size_t srcLen = 0;
-
     if (dest == NULL || src == NULL || destByteLen == 0)
     {
         return false;
     }
     *dest = '\0';
 
-    if (numSrcCharsToCopy >= destByteLen)
+    if (srcByteLen >= destByteLen)
     {
         return false;
     }
 
-    srcLen = ADUC_StrNLen(src, numSrcCharsToCopy);
-    if (numSrcCharsToCopy > srcLen)
+    if (srcByteLen > ADUC_StrNLen(src, srcByteLen))
     {
         return false;
     }
 
-    memcpy(dest, src, numSrcCharsToCopy);
-    dest[numSrcCharsToCopy] = '\0';
+    memcpy(dest, src, srcByteLen);
+    dest[srcByteLen] = '\0';
 
     return true;
 }
 
 /**
-* @brief Allocate a new str that is a copy of the src string with given max number of char.
+* @brief Allocate a new str that is a copy of the src string up to the given byte length.
 * @param dest The addr of ptr that will point to newly allocated string copy.
 * @param src The source string.
-* @param srcLen The char length of source string (not including null terminator)
+* @param srcByteLen The byte length of source string (not including null terminator).
+* @remark The caller must take into account character encoding, e.g. utf-8 characters can have up to 4 bytes per character for some unicode codepoints.
 * @return true on success
 */
-bool ADUC_AllocAndStrCopyN(char** dest, const char* src, size_t srcLen)
+bool ADUC_AllocAndStrCopyN(char** dest, const char* src, size_t srcByteLen)
 {
     bool res = false;
     char* tmpDest = NULL;
+    const size_t SrcByteLenNullTerm = srcByteLen + 1;
 
-    if (dest == NULL || src == NULL || srcLen == 0)
+    if (dest == NULL || src == NULL || srcByteLen == 0 || SrcByteLenNullTerm == 0)
     {
         return false;
     }
 
-    tmpDest = calloc(srcLen + 1, sizeof(char)); // incl. null term
+    tmpDest = calloc(SrcByteLenNullTerm, sizeof(char));
     if (tmpDest == NULL)
     {
         goto done;
     }
 
-    if (!ADUC_Safe_StrCopyN(
-            tmpDest, src, (srcLen + 1) * sizeof(char) /* destByteLen */, srcLen /* numSrcCharsToCopy */))
+    if (!ADUC_Safe_StrCopyN(tmpDest, SrcByteLenNullTerm * sizeof(char) /* destByteLen */, src, srcByteLen /* srcByteLen */))
     {
         goto done;
     }

--- a/src/utils/c_utils/tests/c_utils_ut.cpp
+++ b/src/utils/c_utils/tests/c_utils_ut.cpp
@@ -424,7 +424,8 @@ TEST_CASE("ADUC_StringFormat")
     }
 }
 
-TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
+TEST_CASE("ADUC_Safe_StrCopyN properly copies strings")
+{
     char dest[10] = "foo";
 
     const auto reset_dest = [&dest] {
@@ -434,20 +435,23 @@ TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
 
     // Edge cases
 
-    SECTION("Handle NULL source") {
+    SECTION("Handle NULL source")
+    {
         reset_dest();
         REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, sizeof(dest), NULL, 0));
         CHECK_THAT(dest, Equals("f")); // did not write to dest when NULL arg
     }
 
-    SECTION("Handle NULL destination") {
+    SECTION("Handle NULL destination")
+    {
         reset_dest();
         const char* src = "test";
         REQUIRE_FALSE(ADUC_Safe_StrCopyN(NULL, sizeof(dest), src, 4));
         CHECK_THAT(dest, Equals("f")); // did not write to dest when NULL arg
     }
 
-    SECTION("Handle zero size") {
+    SECTION("Handle zero size")
+    {
         reset_dest();
         const char* src = "test";
         REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, 0 /* destByteLen */, src, 4 /* srcByteLen */));
@@ -456,21 +460,24 @@ TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
 
     // mainline cases
 
-    SECTION("src chars to cpy < dest capacity should succeed") {
+    SECTION("src chars to cpy < dest capacity should succeed")
+    {
         reset_dest();
         const char* src = "short";
         REQUIRE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 5));
         CHECK_THAT(dest, Equals("short"));
     }
 
-    SECTION("Error when truncation would be needed") {
+    SECTION("Error when truncation would be needed")
+    {
         reset_dest();
         const char* src = "12345678901234"; // 14 + 1
         REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 14));
         CHECK_THAT(dest, Equals(""));
     }
 
-    SECTION("Handle subset of longer source string that is still longer than dest") {
+    SECTION("Handle subset of longer source string that is still longer than dest")
+    {
         reset_dest();
         const char* src = "12345678901234"; // 14 + 1
         REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 11));
@@ -481,14 +488,16 @@ TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
         CHECK_THAT(dest, Equals("123456789"));
     }
 
-    SECTION("Handle subset of longer source string, exactly as long as dest buffer - 1") {
+    SECTION("Handle subset of longer source string, exactly as long as dest buffer - 1")
+    {
         reset_dest();
         const char* src = "12345678901234"; // 14 + 1
         REQUIRE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 9));
         CHECK_THAT(dest, Equals("123456789"));
     }
 
-    SECTION("Handle subset of longer source string, that is less-than dest buffer - 1") {
+    SECTION("Handle subset of longer source string, that is less-than dest buffer - 1")
+    {
         reset_dest();
         const char* src = "12345678901234"; // 14 + 1
         REQUIRE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 8));

--- a/src/utils/c_utils/tests/c_utils_ut.cpp
+++ b/src/utils/c_utils/tests/c_utils_ut.cpp
@@ -436,21 +436,21 @@ TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
 
     SECTION("Handle NULL source") {
         reset_dest();
-        REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, NULL, sizeof(dest), 0));
+        REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, sizeof(dest), NULL, 0));
         CHECK_THAT(dest, Equals("f")); // did not write to dest when NULL arg
     }
 
     SECTION("Handle NULL destination") {
         reset_dest();
         const char* src = "test";
-        REQUIRE_FALSE(ADUC_Safe_StrCopyN(NULL, src, sizeof(dest), 4));
+        REQUIRE_FALSE(ADUC_Safe_StrCopyN(NULL, sizeof(dest), src, 4));
         CHECK_THAT(dest, Equals("f")); // did not write to dest when NULL arg
     }
 
     SECTION("Handle zero size") {
         reset_dest();
         const char* src = "test";
-        REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, src, 0 /* destByteLen */, 4 /* numSrcCharsToCopy */));
+        REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, 0 /* destByteLen */, src, 4 /* srcByteLen */));
         CHECK_THAT(dest, Equals("f")); // did not write to dest when told dest len is 0
     }
 
@@ -459,39 +459,39 @@ TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
     SECTION("src chars to cpy < dest capacity should succeed") {
         reset_dest();
         const char* src = "short";
-        REQUIRE(ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 5));
+        REQUIRE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 5));
         CHECK_THAT(dest, Equals("short"));
     }
 
     SECTION("Error when truncation would be needed") {
         reset_dest();
         const char* src = "12345678901234"; // 14 + 1
-        REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 14));
+        REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 14));
         CHECK_THAT(dest, Equals(""));
     }
 
     SECTION("Handle subset of longer source string that is still longer than dest") {
         reset_dest();
         const char* src = "12345678901234"; // 14 + 1
-        REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 11));
+        REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 11));
         CHECK_THAT(dest, Equals(""));
 
         reset_dest();
-        REQUIRE(ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 9));
+        REQUIRE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 9));
         CHECK_THAT(dest, Equals("123456789"));
     }
 
     SECTION("Handle subset of longer source string, exactly as long as dest buffer - 1") {
         reset_dest();
         const char* src = "12345678901234"; // 14 + 1
-        REQUIRE(ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 9));
+        REQUIRE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 9));
         CHECK_THAT(dest, Equals("123456789"));
     }
 
     SECTION("Handle subset of longer source string, that is less-than dest buffer - 1") {
         reset_dest();
         const char* src = "12345678901234"; // 14 + 1
-        REQUIRE(ADUC_Safe_StrCopyN(dest, src, sizeof(dest), 8));
+        REQUIRE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, 8));
         CHECK_THAT(dest, Equals("12345678"));
     }
 
@@ -499,7 +499,7 @@ TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
     {
         reset_dest();
         const char* src = "123";
-        REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, src, sizeof(dest), strlen(src) + 1));
+        REQUIRE_FALSE(ADUC_Safe_StrCopyN(dest, sizeof(dest), src, strlen(src) + 1));
         CHECK_THAT(dest, Equals(""));
     }
 
@@ -509,7 +509,7 @@ TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
         memset(&target[0], 0, 4);
 
         const char* src = "🦆"; // 4-byte utf-8 sequence, so target must be size 5 for nul-term.
-        REQUIRE(ADUC_Safe_StrCopyN(target, src, sizeof(target), strlen(src)));
+        REQUIRE(ADUC_Safe_StrCopyN(target, sizeof(target), src, strlen(src)));
         CHECK_THAT(target, Equals("🦆"));
     }
 
@@ -519,7 +519,7 @@ TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
         memset(&target[0], 0, 4);
 
         const char* src = "🦆"; // 4-byte utf-8 sequence, so target must be size 5 for nul-term.
-        REQUIRE_FALSE(ADUC_Safe_StrCopyN(target, src, sizeof(target), strlen(src)));
+        REQUIRE_FALSE(ADUC_Safe_StrCopyN(target, sizeof(target), src, strlen(src)));
         CHECK_THAT(target, Equals(""));
     }
 
@@ -529,7 +529,7 @@ TEST_CASE("ADUC_Safe_StrCopyN properly copies strings") {
         memset(target, 0, 4);
 
         const char* src = "1234";
-        REQUIRE_FALSE(ADUC_Safe_StrCopyN(target, src, sizeof(target), strlen(src)));
+        REQUIRE_FALSE(ADUC_Safe_StrCopyN(target, sizeof(target), src, strlen(src)));
         CHECK_THAT(target, Equals(""));
     }
 }

--- a/src/utils/jws_utils/src/jws_utils.c
+++ b/src/utils/jws_utils/src/jws_utils.c
@@ -7,6 +7,7 @@
  */
 
 #include "jws_utils.h"
+#include "aduc/string_c_utils.h" // ADUC_Safe_StrCopyN
 #include "base64_utils.h"
 #include "crypto_lib.h"
 #include <azure_c_shared_utility/azure_base64.h>
@@ -15,7 +16,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "aduc/string_c_utils.h" // ADUC_Safe_StrCopyN
 
 // keep this last to avoid interfering with system headers
 #include "aduc/aduc_banned.h"
@@ -137,7 +137,7 @@ static bool ExtractJWSSections(const char* jws, char** header, char** payload, c
 
     size_t sigLen = jwsLen - payloadLen - headerLen - 2; // 2 is for the periods
 
-     // target buffer capacities in bytes
+    // target buffer capacities in bytes
     const size_t HdrCapBytes = headerLen + 1;
     const size_t PayloadCapBytes = payloadLen + 1;
     const size_t SigCapBytes = sigLen + 1;
@@ -151,17 +151,23 @@ static bool ExtractJWSSections(const char* jws, char** header, char** payload, c
         goto done;
     }
 
-    if (!ADUC_Safe_StrCopyN(*header /* dest */, HdrCapBytes /* destByteLen */, jws /* src */, headerLen /* srcByteLen */))
+    if (!ADUC_Safe_StrCopyN(
+            *header /* dest */, HdrCapBytes /* destByteLen */, jws /* src */, headerLen /* srcByteLen */))
     {
         goto done;
     }
 
-    if (!ADUC_Safe_StrCopyN(*payload /* dest */, PayloadCapBytes /* destByteLen */, (headerEnd + 1) /* src */, payloadLen /* srcByteLen */))
+    if (!ADUC_Safe_StrCopyN(
+            *payload /* dest */,
+            PayloadCapBytes /* destByteLen */,
+            (headerEnd + 1) /* src */,
+            payloadLen /* srcByteLen */))
     {
         goto done;
     }
 
-    if (!ADUC_Safe_StrCopyN(*signature /* dest */, SigCapBytes /* destByteLen */, (payloadEnd + 1) /* src */, sigLen /* srcByteLen */))
+    if (!ADUC_Safe_StrCopyN(
+            *signature /* dest */, SigCapBytes /* destByteLen */, (payloadEnd + 1) /* src */, sigLen /* srcByteLen */))
     {
         goto done;
     }
@@ -234,7 +240,8 @@ static bool ExtractJWSHeader(const char* jws, char** header)
         goto done;
     }
 
-    if (!ADUC_Safe_StrCopyN(tempHeader /* dest */, headerLen + 1 /* destByteLen */, jws /* src */, headerLen /* srcByteLen */))
+    if (!ADUC_Safe_StrCopyN(
+            tempHeader /* dest */, headerLen + 1 /* destByteLen */, jws /* src */, headerLen /* srcByteLen */))
     {
         goto done;
     }

--- a/src/utils/jws_utils/src/jws_utils.c
+++ b/src/utils/jws_utils/src/jws_utils.c
@@ -137,26 +137,31 @@ static bool ExtractJWSSections(const char* jws, char** header, char** payload, c
 
     size_t sigLen = jwsLen - payloadLen - headerLen - 2; // 2 is for the periods
 
-    *header = (char*)malloc(headerLen + 1);
-    *payload = (char*)malloc(payloadLen + 1);
-    *signature = (char*)malloc(sigLen + 1);
+     // target buffer capacities in bytes
+    const size_t HdrCapBytes = headerLen + 1;
+    const size_t PayloadCapBytes = payloadLen + 1;
+    const size_t SigCapBytes = sigLen + 1;
+
+    *header = (char*)malloc(HdrCapBytes);
+    *payload = (char*)malloc(PayloadCapBytes);
+    *signature = (char*)malloc(SigCapBytes);
 
     if (*header == NULL || *payload == NULL || *signature == NULL)
     {
         goto done;
     }
 
-    if (!ADUC_Safe_StrCopyN(*header, jws, headerLen + 1, headerLen))
+    if (!ADUC_Safe_StrCopyN(*header /* dest */, HdrCapBytes /* destByteLen */, jws /* src */, headerLen /* srcByteLen */))
     {
         goto done;
     }
 
-    if (!ADUC_Safe_StrCopyN(*payload, (headerEnd + 1), payloadLen + 1, payloadLen))
+    if (!ADUC_Safe_StrCopyN(*payload /* dest */, PayloadCapBytes /* destByteLen */, (headerEnd + 1) /* src */, payloadLen /* srcByteLen */))
     {
         goto done;
     }
 
-    if (!ADUC_Safe_StrCopyN(*signature, (payloadEnd + 1), sigLen + 1, sigLen))
+    if (!ADUC_Safe_StrCopyN(*signature /* dest */, SigCapBytes /* destByteLen */, (payloadEnd + 1) /* src */, sigLen /* srcByteLen */))
     {
         goto done;
     }
@@ -229,7 +234,7 @@ static bool ExtractJWSHeader(const char* jws, char** header)
         goto done;
     }
 
-    if (!ADUC_Safe_StrCopyN(tempHeader, jws, headerLen + 1, headerLen))
+    if (!ADUC_Safe_StrCopyN(tempHeader /* dest */, headerLen + 1 /* destByteLen */, jws /* src */, headerLen /* srcByteLen */))
     {
         goto done;
     }

--- a/src/utils/permission_utils/tests/permission_utils_ut.cpp
+++ b/src/utils/permission_utils/tests/permission_utils_ut.cpp
@@ -35,7 +35,7 @@ TEST_CASE("PermissionUtils_VerifyFilemodeBit*")
     // create temp file with all file permission bits set
     char tmpfile_path[30];
     std::string src_str{ "/tmp/permissionUtilsUT_XXXXXX" };
-    REQUIRE(ADUC_Safe_StrCopyN(tmpfile_path, src_str.c_str(), sizeof(tmpfile_path), src_str.length()));
+    REQUIRE(ADUC_Safe_StrCopyN(tmpfile_path, sizeof(tmpfile_path), src_str.c_str(), src_str.length()));
     ADUC_SystemUtils_MkTemp(tmpfile_path);
     std::ofstream file{ tmpfile_path };
     file.close();

--- a/src/utils/permission_utils/tests/permission_utils_ut.cpp
+++ b/src/utils/permission_utils/tests/permission_utils_ut.cpp
@@ -16,9 +16,9 @@
 
 #include <fstream> // ofstream
 
+#include "aduc/string_c_utils.h" // ADUC_Safe_StrCopyN
 #include <aducpal/stdio.h> // remove
 #include <aducpal/sys_stat.h> // S_I*
-#include "aduc/string_c_utils.h" // ADUC_Safe_StrCopyN
 
 // keep this last to avoid interfering with system headers
 #include "aduc/aduc_banned.h"

--- a/src/utils/system_utils/src/system_utils.c
+++ b/src/utils/system_utils/src/system_utils.c
@@ -221,7 +221,8 @@ int ADUC_SystemUtils_MkDirRecursive(const char* path, uid_t userId, gid_t groupI
     char mkdirPath[PATH_MAX + 1];
     memset(mkdirPath, 0, sizeof(mkdirPath));
     const size_t mkdirPath_cch = ADUC_StrNLen(path, PATH_MAX);
-    if (!ADUC_Safe_StrCopyN(mkdirPath /* dest */, sizeof(mkdirPath) /* destByteLen */, path /* src */, mkdirPath_cch /* srcByteLen */))
+    if (!ADUC_Safe_StrCopyN(
+            mkdirPath /* dest */, sizeof(mkdirPath) /* destByteLen */, path /* src */, mkdirPath_cch /* srcByteLen */))
     {
         return EINVAL;
     }

--- a/src/utils/system_utils/src/system_utils.c
+++ b/src/utils/system_utils/src/system_utils.c
@@ -221,7 +221,7 @@ int ADUC_SystemUtils_MkDirRecursive(const char* path, uid_t userId, gid_t groupI
     char mkdirPath[PATH_MAX + 1];
     memset(mkdirPath, 0, sizeof(mkdirPath));
     const size_t mkdirPath_cch = ADUC_StrNLen(path, PATH_MAX);
-    if (!ADUC_Safe_StrCopyN(mkdirPath, path, sizeof(mkdirPath), mkdirPath_cch))
+    if (!ADUC_Safe_StrCopyN(mkdirPath /* dest */, sizeof(mkdirPath) /* destByteLen */, path /* src */, mkdirPath_cch /* srcByteLen */))
     {
         return EINVAL;
     }


### PR DESCRIPTION
- [align ADUC_Safe_StrCopyN arg order to StringCchCopyNA](https://github.com/Azure/iot-hub-device-update/commit/0325d011c553598a254ea4dbf606999c42c44935)
- [clang-format](https://github.com/Azure/iot-hub-device-update/commit/883cd019a08c9067783acc13ac6dc5725ea226e6)
- Make arg naming consistent: dest, destByteLen, src, srcByteLen
