### PR TITLE
Added exit handler to ensure no double free in workflow_get_workfolder when parent workfolder is used

### DIFF
--- a/src/utils/workflow_utils/src/workflow_utils.c
+++ b/src/utils/workflow_utils/src/workflow_utils.c
@@ -1887,8 +1887,15 @@ char* workflow_get_root_sandbox_dir(const ADUC_WorkflowHandle handle)
 
 done:
 
-    free(tempRet);
-    free(pwf);
+    if (tempRet == pwf)
+    {
+        free(tempRet);
+    }
+    else
+    {
+        free(tempRet);
+        free(pwf);
+    }
 
     return ret;
 }

--- a/src/utils/workflow_utils/src/workflow_utils.c
+++ b/src/utils/workflow_utils/src/workflow_utils.c
@@ -1868,6 +1868,7 @@ char* workflow_get_root_sandbox_dir(const ADUC_WorkflowHandle handle)
         }
 
         tempRet = pwf;
+        pwf = NULL;
         Log_Debug("Using parent workfolder: '%s'", pwf);
     }
     else
@@ -1887,15 +1888,8 @@ char* workflow_get_root_sandbox_dir(const ADUC_WorkflowHandle handle)
 
 done:
 
-    if (tempRet == pwf)
-    {
-        free(tempRet);
-    }
-    else
-    {
-        free(tempRet);
-        free(pwf);
-    }
+    free(tempRet);
+    free(pwf);
 
     return ret;
 }

--- a/src/utils/workflow_utils/src/workflow_utils.c
+++ b/src/utils/workflow_utils/src/workflow_utils.c
@@ -1869,7 +1869,7 @@ char* workflow_get_root_sandbox_dir(const ADUC_WorkflowHandle handle)
 
         tempRet = pwf;
         pwf = NULL;
-        Log_Debug("Using parent workfolder: '%s'", pwf);
+        Log_Debug("Using parent workfolder: '%s'", tempRet);
     }
     else
     {


### PR DESCRIPTION
Repro information and log output in bug here: https://microsoft.visualstudio.com/OS/_workitems/edit/48256773