### PR TITLE
Updated test dependency (catch2 v2.x) and added instruction for optional development tools installation.

### DIFF
--- a/docs/agent-reference/how-to-build-agent-code.md
+++ b/docs/agent-reference/how-to-build-agent-code.md
@@ -58,6 +58,19 @@ dependencies. To see the usage info:
 ./scripts/install-deps.sh -h
 ```
 
+### Install Optional Development Tools
+
+- Install the clang-format package (required for running `scripts/clang-format.sh`):
+```shell
+sudo apt install clang-format
+```
+
+- Install pip3 and cmake-format (required for running `scripts/cmake-format.sh`):
+```shell
+sudo apt install python3-pip
+sudo --set-home pip3 install cmake-format
+```
+
 ### Device Update Linux Build System
 
 The Device Update for IoT Hub reference agent code utilizes CMake for building. An example build script is provided at [scripts/build.sh](../../scripts/build.sh).

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -53,7 +53,7 @@ install_azure_storage_sdk=false
 # ADUC Test Deps
 
 install_catch2=false
-default_catch2_ref=v2.13.9
+default_catch2_ref=v2.x
 catch2_ref=$default_catch2_ref
 install_swupdate=false
 default_swupdate_ref=2021.11


### PR DESCRIPTION
- Update install-deps.sh script to build catch2 v2.x
- Add instruction for installing optional development tools (clang-format, pip3, and cmake-format)