### PR TITLE
change reporting schema workflowId at top-level

### DIFF
--- a/src/adu_types/inc/aduc/types/update_content.h
+++ b/src/adu_types/inc/aduc/types/update_content.h
@@ -20,16 +20,6 @@ EXTERN_C_BEGIN
 #define ADUCITF_FIELDNAME_STATE "state"
 
 /**
- * @brief JSON field name for Action property
- */
-#define ADUCITF_FIELDNAME_ACTION "action"
-
-/**
- * @brief JSON field name for Id property
- */
-#define ADUCITF_FIELDNAME_ID "id"
-
-/**
  * @brief JSON field name for RetryTimestamp property
  */
 #define ADUCITF_FIELDNAME_RETRYTIMESTAMP "retryTimestamp"
@@ -80,12 +70,12 @@ EXTERN_C_BEGIN
 #define ADUCITF_FIELDNAME_INSTALLEDCRITERIA "installedCriteria"
 
 /**
- * @brief JSON field name for workflow property.
+ * @brief JSON field name for workflowId reporting property.
  */
-#define ADUCITF_FIELDNAME_WORKFLOW "workflow"
+#define ADUCITF_FIELDNAME_WORKFLOWID "workflowId"
 
 /**
- * @brief JSON field name for installedUpdateId property.
+ * @brief JSON field name for installedUpdateId reporting property.
  */
 #define ADUCITF_FIELDNAME_INSTALLEDUPDATEID "installedUpdateId"
 

--- a/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/CMakeLists.txt
+++ b/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/CMakeLists.txt
@@ -21,6 +21,6 @@ target_link_libraries (
             aduc::logging
             aduc::mosquitto_utils
             aduc::retry_utils
-            Parson::parson)
+            Parson::parson
+            libaducpal)
 
-add_subdirectory (tests)

--- a/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/tests/adps2mqtt_client_module_ft.cpp
+++ b/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/tests/adps2mqtt_client_module_ft.cpp
@@ -11,13 +11,14 @@
 #include "aduc/logging.h"
 #include "aduc/system_utils.h"
 #include "du_agent_sdk/agent_module_interface.h"
+#include <aducpal/stdlib.h> // ADUCPAL_setenv
 
 #include <aducpal/unistd.h>
 #include <signal.h>
 
 static void set_test_config_folder()
 {
-    setenv(ADUC_CONFIG_FOLDER_ENV, "/tmp/adu/testdata/adps2mqtt-client-module-test-data", 1);
+    ADUCPAL_setenv(ADUC_CONFIG_FOLDER_ENV, "/tmp/adu/testdata/adps2mqtt-client-module-test-data", 1);
 }
 
 bool keep_running_ft = true;

--- a/src/utils/config_utils/src/config_utils.c
+++ b/src/utils/config_utils/src/config_utils.c
@@ -781,7 +781,7 @@ bool ADUC_AgentInfo_ConnectionData_GetStringField(const ADUC_AgentInfo* agent, c
         if (agent->connectionDataJson == NULL
             || !ADUC_JSON_GetStringField(agent->connectionDataJson, fieldName, value))
         {
-            Log_Error("GetStringField");
+            Log_Error("GetStringField: '%s'", fieldName);
             goto done;
         }
     }


### PR DESCRIPTION
- Change "workflow": { "id": <string>, "action": <number> } to "workflowId": <string> at top-level
- Use ADUCPAL_setenv instead of setenv
- Trace fieldName in error trace of ADUC_AgentInfo_ConnectionData_GetStringField 