### PR TITLE
Allow multiple agents to connect to a broker

### DIFF
--- a/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/src/adps2_mqtt_client_module.c
+++ b/src/extensions/agent_modules/cloud_communication/adps2_mqtt_client/src/adps2_mqtt_client_module.c
@@ -272,7 +272,7 @@ bool ProcessDeviceRegistrationResponse(
     const char* status = json_object_get_string(json_object(root_value), "status");
     if (status == NULL)
     {
-        Log_Error("Failed to get status from JSON payload");
+        Log_Error("Failed to get 'status' from DPS payload");
         goto done;
     }
 
@@ -287,7 +287,7 @@ bool ProcessDeviceRegistrationResponse(
 
         if (deviceId == NULL)
         {
-            Log_Error("Failed to get deviceId from JSON payload:\n%s", payload);
+            Log_Error("Failed to get 'registrationState.deviceId' from DPS payload:\n%s", payload);
             errorOccurred = true;
         }
         else if (ADUC_StateStore_SetExternalDeviceId(deviceId) != ADUC_STATE_STORE_RESULT_OK)
@@ -301,7 +301,7 @@ bool ProcessDeviceRegistrationResponse(
 
         if (mqttBrokerHostname == NULL)
         {
-            Log_Error("Failed to get MQTT broker hostname from JSON payload");
+            Log_Error("Failed to get 'registrationState.assignedEndpoint.hostName' from DPS payload");
             errorOccurred = true;
         }
         else

--- a/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_mqtt_client_module.c
+++ b/src/extensions/agent_modules/cloud_communication/eg_mqtt_broker_client/src/adu_mqtt_client_module.c
@@ -467,7 +467,7 @@ static bool InitializeModuleInterfaces(ADUC_MQTT_CLIENT_MODULE_STATE* moduleStat
 {
     bool success = false;
 
-    ADUC_COMMUNICATION_CHANNEL_INIT_DATA commInitData = { .sessionId = "adumqttclient",
+    ADUC_COMMUNICATION_CHANNEL_INIT_DATA commInitData = { .sessionId = NULL,
                                                           .ownerModuleContext = moduleState,
                                                           .mqttSettings = &moduleState->mqttSettings,
                                                           .callbacks = &s_duClientCommChannelCallbacks,

--- a/src/extensions/agent_modules/shared/upd_utils/src/adu_upd_utils.c
+++ b/src/extensions/agent_modules/shared/upd_utils/src/adu_upd_utils.c
@@ -131,7 +131,7 @@ void AduUpdUtils_TransitionState(
 
     if (newState == ADU_UPD_STATE_IDLEWAIT)
     {
-        srand(time(NULL));
+        srand((unsigned int)time(NULL));
         int jitter_seconds = (rand() % 121) + 60; // between 1 and 3 minutes of jitter
         time_t now = ADUC_GetTimeSinceEpochInSeconds();
         context->nextExecutionTime = now + context->pollingIntervalInSeconds + jitter_seconds;


### PR DESCRIPTION
- Remove hard-coded clientId for mqtt EG broker connections
- Use state store external deviceId for clientId when connecting to mqtt broker
- Continue using initData->sessionId for DPS mqtt connection
- Fix type issue in AduUpdUtils_TransitionState