### PR TITLE
Adding pip authenticate to pipelines

### DIFF
--- a/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
+++ b/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
@@ -64,7 +64,6 @@ extends:
                 displayName: 'Pip Authenticate'
                 inputs:
                   artifactFeeds: 'adu-linux-client/ADUTestFeed'
-                  onlyExtraIndex: true
               - task: PowerShell@2
                 displayName: "Build Client + UTs - amd64_debug"
                 inputs:

--- a/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
+++ b/azurepipelines/build/native/adu-windows-msvc2022-amd64-build.yml
@@ -60,6 +60,11 @@ extends:
               name: 1es_hosted_pool_windows
               os: windows
             steps:
+              - task: PipAuthenticate@1
+                displayName: 'Pip Authenticate'
+                inputs:
+                  artifactFeeds: 'adu-linux-client/ADUTestFeed'
+                  onlyExtraIndex: true
               - task: PowerShell@2
                 displayName: "Build Client + UTs - amd64_debug"
                 inputs:

--- a/azurepipelines/e2e_test/templates/e2e_test_run.yaml
+++ b/azurepipelines/e2e_test/templates/e2e_test_run.yaml
@@ -11,7 +11,6 @@ steps:
       displayName: 'Pip Authenticate'
       inputs:
           artifactFeeds: 'adu-linux-client/ADUTestFeed'
-          onlyExtraIndex: true
 
     - script: |
           mkdir testresults

--- a/azurepipelines/e2e_test/templates/e2e_test_run.yaml
+++ b/azurepipelines/e2e_test/templates/e2e_test_run.yaml
@@ -7,6 +7,12 @@ parameters:
       type: string
 
 steps:
+    - task: PipAuthenticate@1
+      displayName: 'Pip Authenticate'
+      inputs:
+          artifactFeeds: 'adu-linux-client/ADUTestFeed'
+          onlyExtraIndex: true
+
     - script: |
           mkdir testresults
       displayName: Creating the test results directory

--- a/azurepipelines/e2e_test/templates/e2e_vm_setup.yaml
+++ b/azurepipelines/e2e_test/templates/e2e_vm_setup.yaml
@@ -30,7 +30,6 @@ steps:
       displayName: 'Pip Authenticate'
       inputs:
           artifactFeeds: 'adu-linux-client/ADUTestFeed'
-          onlyExtraIndex: true
 
     - task: DownloadPipelineArtifact@2
       displayName: "Download DeviceUpdate Package from pipeline"

--- a/azurepipelines/e2e_test/templates/e2e_vm_setup.yaml
+++ b/azurepipelines/e2e_test/templates/e2e_vm_setup.yaml
@@ -26,6 +26,12 @@ parameters:
     - name: provisioning_type
       type: string
 steps:
+    - task: PipAuthenticate@1
+      displayName: 'Pip Authenticate'
+      inputs:
+          artifactFeeds: 'adu-linux-client/ADUTestFeed'
+          onlyExtraIndex: true
+
     - task: DownloadPipelineArtifact@2
       displayName: "Download DeviceUpdate Package from pipeline"
       inputs:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -467,6 +467,7 @@ for i in "${static_analysis_tools[@]}"; do
 
         if ! [ -x "$(command -v cpplint)" ]; then
             error "Can't run static analysis - cpplint is not installed. Try: pip install --system cpplint"
+            error "If you are running a build on the pipelines you MUST use PipAuthenticate@1 with the proper config"
             $ret 1
         fi
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -87,7 +87,7 @@ catch2_cc=""
 catch2_cxx=""
 
 # Dependencies packages
-aduc_packages=('git' 'make' 'build-essential' 'cmake' 'ninja-build' 'libcurl4-openssl-dev' 'libssl-dev' 'uuid-dev' 'python2.7' 'lsb-release' 'curl' 'wget' 'pkg-config' 'libxml2-dev')
+aduc_packages=('git' 'make' 'build-essential' 'cmake' 'ninja-build' 'libcurl4-openssl-dev' 'libssl-dev' 'uuid-dev' 'lsb-release' 'curl' 'wget' 'pkg-config' 'libxml2-dev')
 static_analysis_packages=('clang' 'clang-tidy' 'cppcheck')
 compiler_packages=('gcc' 'g++')
 


### PR DESCRIPTION
- Adds the PipAuthenticate@1 function for the checkout of the PIP artifacts to be used for various builds. 
- Removed unnecessary dependence on python2.7 which can cause flags
- Updated error warnings in install-deps.sh and install-deps.ps1 to use PipAuthenticate when working in pipelines or creating release artifacts