### PR TITLE
Re-Enabling native build pipelines for Ubuntu 20.04 and Ubuntu 22.04

### DIFF
--- a/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
+++ b/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
@@ -85,8 +85,8 @@ extends:
         jobs:
           - job: BuildAduAgent_ubuntu2004
             displayName: "Build ADU Agent - Ubuntu 20.04 (amd64)"
-            timeoutInMinutes: 120
-            cancelTimeoutInMinutes: 120
+            timeoutInMinutes: 30
+            cancelTimeoutInMinutes: 30
             pool:
               name: aduc_1es_client_pool
               os: linux
@@ -98,8 +98,8 @@ extends:
 
           - job: BuildAduAgent_ubuntu2204
             displayName: "Build ADU Agent - Ubuntu 22.04 (amd64)"
-            timeoutInMinutes: 120
-            cancelTimeoutInMinutes: 120
+            timeoutInMinutes: 30
+            cancelTimeoutInMinutes: 30
             pool:
               name: aduc_1es_client_pool
               os: linux

--- a/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
+++ b/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
@@ -83,19 +83,6 @@ extends:
     stages:
       - stage: Build
         jobs:
-          - job: BuildAduAgent_ubuntu2204
-            displayName: "Build ADU Agent - Ubuntu 22.04 (amd64)"
-            timeoutInMinutes: 120
-            cancelTimeoutInMinutes: 120
-            pool:
-              name: aduc_1es_client_pool
-              os: linux
-            steps:
-              - template: /azurepipelines/build/templates/adu-docker-build-steps.yml@self
-                parameters:
-                  targetOs: "ubuntu2204"
-                  targetArch: "amd64"
-
           - job: BuildAduAgent_ubuntu2004
             displayName: "Build ADU Agent - Ubuntu 20.04 (amd64)"
             timeoutInMinutes: 120
@@ -104,7 +91,20 @@ extends:
               name: aduc_1es_client_pool
               os: linux
             steps:
-              - template: /azurepipelines/build/templates/adu-docker-build-steps.yml@self
+              - template: /azurepipelines/build/templates/adu-native-build-steps.yml@self
                 parameters:
                   targetOs: "ubuntu2004"
+                  targetArch: "amd64"
+
+          - job: BuildAduAgent_ubuntu2204
+            displayName: "Build ADU Agent - Ubuntu 22.04 (amd64)"
+            timeoutInMinutes: 120
+            cancelTimeoutInMinutes: 120
+            pool:
+              name: aduc_1es_client_pool
+              os: linux
+            steps:
+              - template: /azurepipelines/build/templates/adu-native-build-steps.yml@self
+                parameters:
+                  targetOs: "ubuntu2204"
                   targetArch: "amd64"

--- a/azurepipelines/build/native/adu-ubuntu-arm64-build.yml
+++ b/azurepipelines/build/native/adu-ubuntu-arm64-build.yml
@@ -83,32 +83,6 @@ extends:
     stages:
       - stage: Build
         jobs:
-          - job: BuildAduAgent_ubuntu2204
-            displayName: "Build ADU Agent - Ubuntu 22.04 (arm64)"
-            timeoutInMinutes: 120
-            cancelTimeoutInMinutes: 120
-            pool:
-              name: aduc_1es_client_pool
-              os: linux
-            steps:
-              - template: /azurepipelines/build/templates/adu-docker-build-steps.yml@self
-                parameters:
-                  targetOs: "ubuntu2204"
-                  targetArch: "arm64"
-
-          - job: BuildAduAgent_ubuntu1804
-            displayName: "Build ADU Agent - Ubuntu 18.04 (arm64)"
-            timeoutInMinutes: 120
-            cancelTimeoutInMinutes: 120
-            pool:
-              name: aduc_1es_client_pool
-              os: linux
-            steps:
-              - template: /azurepipelines/build/templates/adu-docker-build-steps.yml@self
-                parameters:
-                  targetOs: "ubuntu1804"
-                  targetArch: "arm64"
-
           - job: BuildAduAgent_ubuntu2004
             displayName: "Build ADU Agent - Ubuntu 20.04 (arm64)"
             timeoutInMinutes: 120
@@ -117,7 +91,20 @@ extends:
               name: aduc_1es_client_pool
               os: linux
             steps:
-              - template: /azurepipelines/build/templates/adu-docker-build-steps.yml@self
+              - template: /azurepipelines/build/templates/adu-native-build-steps.yml@self
                 parameters:
                   targetOs: "ubuntu2004"
+                  targetArch: "arm64"
+
+          - job: BuildAduAgent_ubuntu2204
+            displayName: "Build ADU Agent - Ubuntu 22.04 (arm64)"
+            timeoutInMinutes: 120
+            cancelTimeoutInMinutes: 120
+            pool:
+              name: aduc_1es_client_pool
+              os: linux
+            steps:
+              - template: /azurepipelines/build/templates/adu-native-build-steps.yml@self
+                parameters:
+                  targetOs: "ubuntu2204"
                   targetArch: "arm64"

--- a/azurepipelines/build/templates/adu-native-build-steps.yml
+++ b/azurepipelines/build/templates/adu-native-build-steps.yml
@@ -13,6 +13,13 @@ steps:
             displayName: "Component Detection"
             inputs:
                 sourceScanPath: src
+
+    - task: Bash@3
+      displayName: "Install ADUC dependencies"
+      inputs:
+          targetType: "filePath"
+          filePath: $(Build.SourcesDirectory)/scripts/install-deps.sh
+          arguments: --install-all-deps -f $(Agent.TempDirectory)/adu-deps/
       # Ignore SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
       #   We usually want to return an error code from a specific, previous command
       #   even if popd, pushd, or cd fails.
@@ -20,15 +27,9 @@ steps:
       #   We use 'ret=return' or 'ret=exit' to support dot sourcing.
     - ${{ if eq(parameters.targetArch, 'amd64') }}:
           - bash: |
-                /tmp/deviceupdate-shellcheck --shell=bash $(find -name "*.sh" | grep -v -e '^\.\/out')
+                /tmp/deviceupdate-shellcheck --shell=bash $(find $(Build.SourcesDirectory) -name "*.sh" | grep -v -e '^\.\/out')
                 exit $?
             displayName: "Run ShellCheck"
-    - task: Bash@3
-      displayName: "Install ADUC dependencies"
-      inputs:
-          targetType: "filePath"
-          filePath: $(Build.SourcesDirectory)/scripts/install-deps.sh
-          arguments: --install-all-deps -f $(Build.SourcesDirectory)/adu-deps/
     - task: Bash@3
       displayName: "Build Client, Unit Tests and Packages: linux-MinSizeRel"
       inputs:

--- a/azurepipelines/build/templates/adu-native-build-steps.yml
+++ b/azurepipelines/build/templates/adu-native-build-steps.yml
@@ -13,7 +13,9 @@ steps:
             displayName: "Component Detection"
             inputs:
                 sourceScanPath: src
-
+    - bash: |
+          sudo apt-get install gcc-8
+      displayName: "Adding gcc-8 maybe."
     - task: Bash@3
       displayName: "Install ADUC dependencies"
       inputs:

--- a/azurepipelines/build/templates/adu-native-build-steps.yml
+++ b/azurepipelines/build/templates/adu-native-build-steps.yml
@@ -21,7 +21,7 @@ steps:
           arguments: --install-all-deps -f $(Build.SourcesDirectory)/adu-deps/
     - bash: |
             ls -la $(Build.SourcesDirectory)/adu-deps/
-        displayName: "Checking deps"
+      displayName: "Checking deps"
     - task: Bash@3
       displayName: "Build Client, Unit Tests and Packages: linux-MinSizeRel"
       inputs:

--- a/azurepipelines/build/templates/adu-native-build-steps.yml
+++ b/azurepipelines/build/templates/adu-native-build-steps.yml
@@ -13,16 +13,15 @@ steps:
             displayName: "Component Detection"
             inputs:
                 sourceScanPath: src
-    - bash: |
-          sudo apt-get install gcc-8
-      displayName: "Adding gcc-8 maybe."
     - task: Bash@3
       displayName: "Install ADUC dependencies"
       inputs:
           targetType: "filePath"
           filePath: $(Build.SourcesDirectory)/scripts/install-deps.sh
-          arguments: --install-all-deps
-
+          arguments: --install-all-deps -f $(Build.SourcesDirectory)/adu-deps/
+    - bash: |
+            ls -la $(Build.SourcesDirectory)/adu-deps/
+        displayName: "Checking deps"
     - task: Bash@3
       displayName: "Build Client, Unit Tests and Packages: linux-MinSizeRel"
       inputs:
@@ -45,30 +44,6 @@ steps:
 
     - task: PublishTestResults@2
       displayName: "Publish Unit Test Results: linux-MinSizeRel"
-      condition: succeededOrFailed() # Run this task even if tests fail.
-      inputs:
-          testResultsFormat: cTest
-          testResultsFiles: "Testing/**/*.xml"
-          searchFolder: $(Build.BinariesDirectory)
-          failTaskOnFailedTests: true
-          publishRunAttachments: false # Attachments are not supported for CTest
-
-    - task: Bash@3
-      displayName: "Build Client and Unit Tests: linux-Debug"
-      inputs:
-          targetType: "filePath"
-          filePath: $(Build.SourcesDirectory)/scripts/build.sh
-          arguments: "--clean --build-unit-tests --platform-layer linux --log-lib zlog --static-analysis clang-tidy,cppcheck --out-dir $(Build.BinariesDirectory)"
-
-      # Run all unit tests.
-    - bash: |
-          ctest --repeat until-pass:5 --timeout 300 --force-new-ctest-process -T test -V --output-on-failure
-          exit $?
-      displayName: "Run Unit Tests: linux-Debug"
-      workingDirectory: $(Build.BinariesDirectory)
-
-    - task: PublishTestResults@2
-      displayName: "Publish Unit Test Results: linux-Debug"
       condition: succeededOrFailed() # Run this task even if tests fail.
       inputs:
           testResultsFormat: cTest

--- a/azurepipelines/build/templates/adu-native-build-steps.yml
+++ b/azurepipelines/build/templates/adu-native-build-steps.yml
@@ -13,15 +13,22 @@ steps:
             displayName: "Component Detection"
             inputs:
                 sourceScanPath: src
+      # Ignore SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
+      #   We usually want to return an error code from a specific, previous command
+      #   even if popd, pushd, or cd fails.
+      # Ignore SC2209: Use var=$(command) to assign output (or quote to assign string).
+      #   We use 'ret=return' or 'ret=exit' to support dot sourcing.
+    - ${{ if eq(parameters.targetArch, 'amd64') }}:
+          - bash: |
+                /tmp/deviceupdate-shellcheck --shell=bash $(find -name "*.sh" | grep -v -e '^\.\/out')
+                exit $?
+            displayName: "Run ShellCheck"
     - task: Bash@3
       displayName: "Install ADUC dependencies"
       inputs:
           targetType: "filePath"
           filePath: $(Build.SourcesDirectory)/scripts/install-deps.sh
           arguments: --install-all-deps -f $(Build.SourcesDirectory)/adu-deps/
-    - bash: |
-            ls -la $(Build.SourcesDirectory)/adu-deps/
-      displayName: "Checking deps"
     - task: Bash@3
       displayName: "Build Client, Unit Tests and Packages: linux-MinSizeRel"
       inputs:
@@ -57,17 +64,6 @@ steps:
       inputs:
           artifactName: "adu-client-${{parameters.targetOs}}-${{parameters.targetArch}}"
           targetPath: "$(Build.ArtifactStagingDirectory)"
-
-      # Ignore SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
-      #   We usually want to return an error code from a specific, previous command
-      #   even if popd, pushd, or cd fails.
-      # Ignore SC2209: Use var=$(command) to assign output (or quote to assign string).
-      #   We use 'ret=return' or 'ret=exit' to support dot sourcing.
-    - ${{ if eq(parameters.targetArch, 'amd64') }}:
-          - bash: |
-                /tmp/deviceupdate-shellcheck --shell=bash $(find -name "*.sh" | grep -v -e '^\.\/out')
-                exit $?
-            displayName: "Run ShellCheck"
 
     - ${{ if eq(parameters.targetArch, 'amd64') }}:
           - task: ComponentGovernanceComponentDetection@0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -46,6 +46,12 @@ install_adu=false
 work_folder=/tmp
 cmake_dir_path="${work_folder}/deviceupdate-cmake"
 
+#
+# Export the compiler settings in case VM is wonky
+#
+export CC=/usr/bin/gcc
+export CXX=/usr/bin/g++
+
 print_help() {
     echo "Usage: build.sh [options...]"
     echo "-c, --clean                           Does a clean build."

--- a/scripts/docker/templates/Dockerfile.template
+++ b/scripts/docker/templates/Dockerfile.template
@@ -1,5 +1,6 @@
-
-FROM %%CONTAINER_IMAGE_BASE_IMAGE%%
+# Hardcode the base image to ubuntu:18.04 to avoid the supply chain attack.
+# FROM %%CONTAINER_IMAGE_BASE_IMAGE%%
+FROM "mcr.microsoft.com/mirror/docker/library/ubuntu:18.04"
 
 ADD ./app.tar.gz /
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -917,6 +917,7 @@ if [[ $install_packages_only == "true" ]]; then
     install_catch2=false
 fi
 
+export CC=/usr/bin/gcc
 if [[ $install_packages == "true" ]]; then
     # Check if we need to install any packages
     # before we call apt update.

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -918,6 +918,7 @@ if [[ $install_packages_only == "true" ]]; then
 fi
 
 export CC=/usr/bin/gcc
+export CXX=/usr/bin/g++
 if [[ $install_packages == "true" ]]; then
     # Check if we need to install any packages
     # before we call apt update.

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -488,10 +488,6 @@ do_install_do() {
     $SUDO cmake --build . --target install || return
     popd > /dev/null || return
     popd > /dev/null || return
-
-    if [[ $keep_source_code != "true" ]]; then
-        $SUDO rm -rf $do_dir
-    fi
 }
 
 do_install_azure_storage_sdk() {
@@ -531,10 +527,6 @@ do_install_azure_storage_sdk() {
     $SUDO cmake --build . --target install || return
 
     popd > /dev/null || return
-
-    if [[ $keep_source_code != "true" ]]; then
-        $SUDO rm -rf $azure_storage_sdk_dir || return
-    fi
 }
 
 do_install_cmake_from_source() {


### PR DESCRIPTION
- Fixed native build pipeline issues
- Removed reliance on docker
- Changed dependency installation flow to prep for cache flows.