### PR TITLE
Fix potential double free issue in FileInfoUtils_FillFileInfoWithNewestFilesInDir

### DIFF
--- a/src/diagnostics_component/utils/file_info_utils/src/file_info_utils.c
+++ b/src/diagnostics_component/utils/file_info_utils/src/file_info_utils.c
@@ -168,13 +168,11 @@ done:
 
     if (!succeeded)
     {
+        // Free all the file names, if allocated.
         for (int i = 0; i < logFileSize; ++i)
         {
-            FileInfo logFileEntry = logFiles[i];
-
-            free(logFileEntry.fileName);
-
-            memset(&logFileEntry, 0, sizeof(FileInfo));
+            free(logFiles[i].fileName);
+            memset(&logFiles[i], 0, sizeof(FileInfo));
         }
     }
 


### PR DESCRIPTION
Fix an issue in the `FileInfoUtils_FillFileInfoWithNewestFilesInDir()` function where, if an error occurs after the `FileInfo` structure has been partially populated, the cleanup code incorrectly handles the `fileName` fields. Specifically, the cleanup code frees the fileName fields but does not properly reset these fields in the input array.