### PR TITLE
Fix extension_utils.c: json file generation in Register[Handler]Extension

### DIFF
--- a/src/utils/extension_utils/src/extension_utils.c
+++ b/src/utils/extension_utils/src/extension_utils.c
@@ -274,7 +274,7 @@ static bool RegisterHandlerExtension(
     content = STRING_construct_sprintf(
         "{\n"
         "   \"fileName\":\"%s\",\n"
-        "   \"sizeInBytes\":%d,\n"
+        "   \"sizeInBytes\":%lld,\n"
         "   \"hashes\": {\n"
         "        \"sha256\":\"%s\"\n"
         "   },\n"
@@ -493,7 +493,7 @@ bool RegisterExtension(const char* extensionDir, const char* extensionFilePath)
     content = STRING_construct_sprintf(
         "{\n"
         "   \"fileName\":\"%s\",\n"
-        "   \"sizeInBytes\":%d,\n"
+        "   \"sizeInBytes\":%lld,\n"
         "   \"hashes\": {\n"
         "        \"sha256\":\"%s\"\n"
         "   }\n"


### PR DESCRIPTION
STRING_construct_sprintf() is erroneously called with format specifier "%d" for fileSize being a "long long [int]". Depending on the architecture this can lead to subsequent arguments getting misinterpreted during vsnprintf() invocation in this function. Found that bug on arm32 architecture (i.MX6).