### PR TITLE
Adds support for enabling gcov test coverage data collection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,7 +480,7 @@ option (ADUC_TRACE_TARGET_DEPS "Trace target dependencies" OFF)
 option (ADUC_USE_TEST_ROOT_KEYS "Include test root keys" OFF)
 option (ADUC_ENABLE_E2E_TESTING "Enable e2e test pipeline settings" OFF)
 option (ADUC_ENABLE_SRVC_E2E_TESTING "Enable service side test agent settings" OFF)
-
+option (ADUC_ADD_COVERAGE_SYMBOLS "Add coverage symbols to the build" OFF)
 ### End CMake Options
 
 # Construct the absolute path to the adu configuration file.
@@ -520,6 +520,14 @@ if (NOT GENERATE_ERROR_CODE_DEFS_RESULT EQUAL "0")
             "Failed to generate error code definition file using ${ADUC_PATH_TO_ERROR_CODE_GENERATOR_SCRIPT}"
     )
 endif ()
+
+if (ADUC_ADD_COVERAGE_SYMBOLS)
+
+    message(STATUS "Adding coverage symbols to the project.")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
+
+endif()
 
 if (ADUC_BUILD_UNIT_TESTS)
     # Need to be in the root directory to place CTestTestfile.cmake in root

--- a/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
+++ b/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
@@ -95,7 +95,7 @@ extends:
                 parameters:
                   targetOs: "ubuntu2004"
                   targetArch: "amd64"
-
+                  buildType: "Debug"
           - job: BuildAduAgent_ubuntu2204
             displayName: "Build ADU Agent - Ubuntu 22.04 (amd64)"
             timeoutInMinutes: 30
@@ -108,3 +108,4 @@ extends:
                 parameters:
                   targetOs: "ubuntu2204"
                   targetArch: "amd64"
+                  buildType: "Debug"

--- a/azurepipelines/build/native/adu-ubuntu-arm64-build.yml
+++ b/azurepipelines/build/native/adu-ubuntu-arm64-build.yml
@@ -95,6 +95,7 @@ extends:
                 parameters:
                   targetOs: "ubuntu2004"
                   targetArch: "arm64"
+                  buildType: "Debug"
 
           - job: BuildAduAgent_ubuntu2204
             displayName: "Build ADU Agent - Ubuntu 22.04 (arm64)"
@@ -108,3 +109,4 @@ extends:
                 parameters:
                   targetOs: "ubuntu2204"
                   targetArch: "arm64"
+                  buildType: "Debug"

--- a/azurepipelines/build/templates/adu-native-build-steps.yml
+++ b/azurepipelines/build/templates/adu-native-build-steps.yml
@@ -17,20 +17,20 @@ parameters:
       default: false
 steps:
 
-- {{ if eq(parameters.buildWithCoverageSymbols, 'true') }}:
     - task: Bash@3
       displayName: "Build Client, Unit Tests and Packages: linux-${{parameters.buildType}}"
       inputs:
           targetType: "filePath"
           filePath: $(Build.SourcesDirectory)/scripts/build.sh
           arguments: "--clean --type ${{parameters.buildType}} --platform-layer linux --log-lib zlog --build-packages --build-unit-tests --add-coverage-symbols --out-dir $(Build.BinariesDirectory)"
-- {{else}}:
+      condition: eq(parameters['buildWithCoverageSymbols'],true)
     - task: Bash@3
       displayName: "Build Client and Packages: linux-${{parameters.buildType}}"
       inputs:
           targetType: "filePath"
           filePath: $(Build.SourcesDirectory)/scripts/build.sh
           arguments: "--clean --type ${{parameters.buildType}} --platform-layer linux --log-lib zlog --build-packages --out-dir $(Build.BinariesDirectory)"
+      condition: eq(parameters['buildWithCoverageSymbols'],false)
 # End of if-else branch
     - bash: |
           cp $(Build.BinariesDirectory)/*.deb $(Build.ArtifactStagingDirectory)
@@ -38,12 +38,12 @@ steps:
       displayName: "Stage build artifacts (Deb package, agent and docs)"
       condition: ne(variables['Build.Reason'], 'PullRequest')
 
-- {{ if eq(parameters.buildWithCoverageSymbols, 'true') }}:
     # Create the base coverage items
     - script: |
             mkdir -p $(Build.BinariesDirectory)/coverage
             lcov -c -i -d $(Build.BinariesDirectory) -o $(Build.BinariesDirectory)/coverage/base.info
         displayName: "Prepare coverage script"
+      condition: eq(parameters['buildWithCoverageSymbols'],true)
 # End of baseline generation if else
 
 
@@ -54,7 +54,6 @@ steps:
       displayName: "Run Unit Tests: linux-${{parameters.buildType}}"
       workingDirectory: $(Build.BinariesDirectory)
 
-- {{if eq(parameters.buildWithCoverageSymbols, 'true') }}:
     - script: |
           lcov -c -d $(Build.BinariesDirectory) -o $(Build.BinariesDirectory)/coverage/test.info
           lcov -a $(Build.BinariesDirectory)/coverage/base.info -a $(Build.BinariesDirectory)/coverage/test.info -o $(Build.BinariesDirectory)/coverage/coverage.info
@@ -63,6 +62,7 @@ steps:
           lcov -r $(Build.BinariesDirectory)/coverage/coverage.info '*/tests/*' -o $(Build.BinariesDirectory)/coverage/coverage.info
           genhtml $(Build.BinariesDirectory)/coverage/coverage.info --output-directory $(Build.BinariesDirectory)/coverage
       displayName: "Generate Coverage Report"
+      condition: eq(parameters['buildWithCoverageSymbols'],true)
 
     - task: PublishTestResults@2
       displayName: "Publish Unit Test Results: linux-${{parameters.buildType}}"

--- a/azurepipelines/build/templates/adu-native-build-steps.yml
+++ b/azurepipelines/build/templates/adu-native-build-steps.yml
@@ -42,7 +42,7 @@ steps:
     - script: |
             mkdir -p $(Build.BinariesDirectory)/coverage
             lcov -c -i -d $(Build.BinariesDirectory) -o $(Build.BinariesDirectory)/coverage/base.info
-        displayName: "Prepare coverage script"
+      displayName: "Prepare coverage script"
       condition: eq(parameters['buildWithCoverageSymbols'],true)
 # End of baseline generation if else
 

--- a/azurepipelines/build/templates/adu-native-build-steps.yml
+++ b/azurepipelines/build/templates/adu-native-build-steps.yml
@@ -1,57 +1,71 @@
 # Template: Steps to build ADU Agent targeting x86-64 architecture.
 # Consume this steps template in one or more jobs by passing in parameter values.
 
+# Template Functionality
+# Depending on build there are different sections taht will be run and used.
+# If the build type is set to debug the unit tests will be built and the coverage symbols will be
+# added to the build.
 parameters:
     - name: targetOs # example: ubuntu1804
       type: string
     - name: targetArch # example: amd64
       type: string
-
+    - name: buildType # example: Debug, Release, MinSizeRel
+      type: string
+    - name: buildWithCoverageSymbols
+      type: boolean
+      default: false
 steps:
-    - ${{ if eq(parameters.targetArch, 'amd64') }}:
-          - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-            displayName: "Component Detection"
-            inputs:
-                sourceScanPath: src
 
+- {{ if eq(parameters.buildWithCoverageSymbols, 'true') }}:
     - task: Bash@3
-      displayName: "Install ADUC dependencies"
-      inputs:
-          targetType: "filePath"
-          filePath: $(Build.SourcesDirectory)/scripts/install-deps.sh
-          arguments: --install-all-deps -f $(Agent.TempDirectory)/adu-deps/
-      # Ignore SC2164: Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
-      #   We usually want to return an error code from a specific, previous command
-      #   even if popd, pushd, or cd fails.
-      # Ignore SC2209: Use var=$(command) to assign output (or quote to assign string).
-      #   We use 'ret=return' or 'ret=exit' to support dot sourcing.
-    - ${{ if eq(parameters.targetArch, 'amd64') }}:
-          - bash: |
-                /tmp/deviceupdate-shellcheck --shell=bash $(find $(Build.SourcesDirectory) -name "*.sh" | grep -v -e '^\.\/out')
-                exit $?
-            displayName: "Run ShellCheck"
-    - task: Bash@3
-      displayName: "Build Client, Unit Tests and Packages: linux-MinSizeRel"
+      displayName: "Build Client, Unit Tests and Packages: linux-${{parameters.buildType}}"
       inputs:
           targetType: "filePath"
           filePath: $(Build.SourcesDirectory)/scripts/build.sh
-          arguments: "--clean --type MinSizeRel --platform-layer linux --log-lib zlog --build-packages --build-unit-tests --out-dir $(Build.BinariesDirectory)"
-
+          arguments: "--clean --type ${{parameters.buildType}} --platform-layer linux --log-lib zlog --build-packages --build-unit-tests --add-coverage-symbols --out-dir $(Build.BinariesDirectory)"
+- {{else}}:
+    - task: Bash@3
+      displayName: "Build Client and Packages: linux-${{parameters.buildType}}"
+      inputs:
+          targetType: "filePath"
+          filePath: $(Build.SourcesDirectory)/scripts/build.sh
+          arguments: "--clean --type ${{parameters.buildType}} --platform-layer linux --log-lib zlog --build-packages --out-dir $(Build.BinariesDirectory)"
+# End of if-else branch
     - bash: |
           cp $(Build.BinariesDirectory)/*.deb $(Build.ArtifactStagingDirectory)
           cp $(Build.BinariesDirectory)/bin/AducIotAgent $(Build.ArtifactStagingDirectory)/AducIotAgent
       displayName: "Stage build artifacts (Deb package, agent and docs)"
       condition: ne(variables['Build.Reason'], 'PullRequest')
 
+- {{ if eq(parameters.buildWithCoverageSymbols, 'true') }}:
+    # Create the base coverage items
+    - script: |
+            mkdir -p $(Build.BinariesDirectory)/coverage
+            lcov -c -i -d $(Build.BinariesDirectory) -o $(Build.BinariesDirectory)/coverage/base.info
+        displayName: "Prepare coverage script"
+# End of baseline generation if else
+
+
       # Run all unit tests.
     - bash: |
           ctest --repeat until-pass:5 --timeout 300 --force-new-ctest-process -T test -V --output-on-failure
           exit $?
-      displayName: "Run Unit Tests: linux-MinSizeRel"
+      displayName: "Run Unit Tests: linux-${{parameters.buildType}}"
       workingDirectory: $(Build.BinariesDirectory)
 
+- {{if eq(parameters.buildWithCoverageSymbols, 'true') }}:
+    - script: |
+          lcov -c -d $(Build.BinariesDirectory) -o $(Build.BinariesDirectory)/coverage/test.info
+          lcov -a $(Build.BinariesDirectory)/coverage/base.info -a $(Build.BinariesDirectory)/coverage/test.info -o $(Build.BinariesDirectory)/coverage/coverage.info
+          lcov -r $(Build.BinariesDirectory)/coverage/coverage.info '/usr/*' -o $(Build.BinariesDirectory)/coverage/coverage.info
+          lcov -r $(Build.BinariesDirectory)/coverage/coverage.info '/opt/*' -o $(Build.BinariesDirectory)/coverage/coverage.info
+          lcov -r $(Build.BinariesDirectory)/coverage/coverage.info '*/tests/*' -o $(Build.BinariesDirectory)/coverage/coverage.info
+          genhtml $(Build.BinariesDirectory)/coverage/coverage.info --output-directory $(Build.BinariesDirectory)/coverage
+      displayName: "Generate Coverage Report"
+
     - task: PublishTestResults@2
-      displayName: "Publish Unit Test Results: linux-MinSizeRel"
+      displayName: "Publish Unit Test Results: linux-${{parameters.buildType}}"
       condition: succeededOrFailed() # Run this task even if tests fail.
       inputs:
           testResultsFormat: cTest

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,6 +45,7 @@ install_prefix=/usr/local
 install_adu=false
 work_folder=/tmp
 cmake_dir_path="${work_folder}/deviceupdate-cmake"
+add_coverage_symbols=false
 
 #
 # Export the compiler settings in case VM is wonky
@@ -89,6 +90,8 @@ print_help() {
     echo ""
     echo "--cmake-path                          Override the cmake path such that CMake binary is at <cmake-path>/bin/cmake"
     echo ""
+    echo "--add-coverage-symbols                Includes the gcov coverage data within gcov for the build. Will increase the executable size."
+    echo "                                      You can run the ADU agent or any of the unit tests (if built with -u) to generate the coverage data with gcov."
     echo "--openssl-path                        Override the openssl path"
     echo ""
     echo "--major-version                       Major version of ADU"
@@ -289,6 +292,9 @@ while [[ $1 != "" ]]; do
         fi
         log_lib=$1
         ;;
+    --add-coverage-symbols)
+        add_coverage_symbols=true
+        ;;
     -l | --log-dir)
         shift
         if [[ -z $1 || $1 == -* ]]; then
@@ -423,11 +429,17 @@ CMAKE_OPTIONS=(
 if [[ $major_version != "" ]]; then
     CMAKE_OPTIONS+=("-DADUC_VERSION_MAJOR=$major_version")
 fi
+
 if [[ $minor_version != "" ]]; then
     CMAKE_OPTIONS+=("-DADUC_VERSION_MINOR=$minor_version")
 fi
+
 if [[ $patch_version != "" ]]; then
     CMAKE_OPTIONS+=("-DADUC_VERSION_PATCH=$patch_version")
+fi
+
+if [[ $add_coverage_symbols == "true" ]]; then
+    CMAKE_OPTIONS+=("-DADUC_ADD_COVERAGE_SYMBOLS=ON")
 fi
 
 for i in "${static_analysis_tools[@]}"; do


### PR DESCRIPTION
- Adds flags for gcov coverage data integraton and collection
- Moves some of the Microsoft specific SDL work out to a ADO repo (ADUGen1Build.UbuntuAMD64) instead of invoking directly within the pipeline
- Cleans up some of the install deps flags
