### PR TITLE
Update device-update-agent-extended-result-codes.md (#649)

### DIFF
--- a/docs/agent-reference/device-update-agent-extended-result-codes.md
+++ b/docs/agent-reference/device-update-agent-extended-result-codes.md
@@ -29,7 +29,7 @@ The followings are Result Code that visible in the Device or Module Twin:
 | 1101        | ADUC_Result_Restore_Success_Unsupported             |
 | 1102        | ADUC_Result_Restore_InProgress                      |
 
-See [adu_core.h](../../src/adu/types/adu_core.h) for more detail.
+See [adu_core.h](../../src/adu_types/inc/aduc/types/adu_core.h) for more detail.
 
 ## Extended Result Code Structure (32 bits)
 


### PR DESCRIPTION
the link in "see adu_core.h" is wrong

Cherry-pick of main branch commit: https://github.com/Azure/iot-hub-device-update/commit/070b667d52734622817070f75d95978d5602d931
