### PR TITLE
don't report in progress until processing update after rootkey infra

### DIFF
--- a/src/adu_workflow/src/agent_workflow.c
+++ b/src/adu_workflow/src/agent_workflow.c
@@ -1337,6 +1337,27 @@ void ADUC_Workflow_MethodCall_Idle(ADUC_WorkflowData* workflowData)
 }
 
 /**
+ * @brief Called to do ProcessDeployment.
+ *
+ * @param[in,out] methodCallData The metedata for the method call.
+ * @return Result code.
+ */
+ADUC_Result ADUC_Workflow_MethodCall_ProcessDeployment(ADUC_MethodCall_Data* methodCallData)
+{
+    UNREFERENCED_PARAMETER(methodCallData);
+    Log_Info("Workflow step: ProcessDeployment");
+
+    ADUC_Result result = { ADUC_Result_Success };
+    return result;
+}
+
+void ADUC_Workflow_MethodCall_ProcessDeployment_Complete(ADUC_MethodCall_Data* methodCallData, ADUC_Result result)
+{
+    UNREFERENCED_PARAMETER(methodCallData);
+    UNREFERENCED_PARAMETER(result);
+}
+
+/**
  * @brief Called to do download.
  *
  * @param[in,out] methodCallData The metedata for the method call.

--- a/src/adu_workflow/src/agent_workflow.c
+++ b/src/adu_workflow/src/agent_workflow.c
@@ -243,6 +243,15 @@ typedef struct tagADUC_WorkflowHandlerMapEntry
  *     AutoTransitionApplicableUpdateAction is equal to the current update action of the workflow data.
  */
 const ADUC_WorkflowHandlerMapEntry workflowHandlerMap[] = {
+    { 
+        ADUCITF_WorkflowStep_ProcessDeployment,
+        /* calls operation */                               ADUC_Workflow_MethodCall_ProcessDeployment,
+        /* and on completion calls */                       ADUC_Workflow_MethodCall_ProcessDeployment_Complete,
+        /* on success, transitions to state */              ADUCITF_State_DeploymentInProgress,
+        /* on success auto-transitions to workflow step */  ADUCITF_WorkflowStep_Download,
+        /* on failure, transitions to state */              ADUCITF_State_Failed,
+        /* on failure auto-transitions to workflow step */  ADUCITF_WorkflowStep_Undefined,
+    },
     { ADUCITF_WorkflowStep_Download,
         /* calls operation */                               ADUC_Workflow_MethodCall_Download,
         /* and on completion calls */                       ADUC_Workflow_MethodCall_Download_Complete,

--- a/src/agent/adu_core_interface/src/adu_core_interface.c
+++ b/src/agent/adu_core_interface/src/adu_core_interface.c
@@ -445,13 +445,6 @@ void OrchestratorUpdateCallback(
     {
         Log_Debug("Processing deployment %s ...", workflowId);
 
-        ADUC_Result inProgressResult = { .ResultCode = ADUC_GeneralResult_Success, .ExtendedResultCode = 0 };
-        if (!ReportPreDeploymentProcessingState(
-                propertyValue, ADUCITF_State_DeploymentInProgress, workflowData, inProgressResult))
-        {
-            Log_Warn("Reporting InProgress failed. Continuing processing deployment %s", workflowId);
-        }
-
         // Ensure update to latest rootkey pkg, which is required for validating the update metadata.
         workFolder = workflow_get_root_sandbox_dir(workflowData->WorkflowHandle);
         if (workFolder == NULL)


### PR DESCRIPTION
* rmv oob in-progress reporting when rootkey processed
* add back as 1st state into handler entry state transition table so in-progress report is sent at beginning of update processing