### PR TITLE
Update build pipeline to run every 2 weeks and change build timeout to 120 minutes to accommodate CodeQL processing overhead.

### DIFF
--- a/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
+++ b/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
@@ -85,8 +85,8 @@ extends:
         jobs:
           - job: BuildAduAgent_ubuntu2004
             displayName: "Build ADU Agent - Ubuntu 20.04 (amd64)"
-            timeoutInMinutes: 30
-            cancelTimeoutInMinutes: 30
+            timeoutInMinutes: 120
+            cancelTimeoutInMinutes: 120
             pool:
               name: aduc_1es_client_pool
               os: linux
@@ -98,8 +98,8 @@ extends:
 
           - job: BuildAduAgent_ubuntu2204
             displayName: "Build ADU Agent - Ubuntu 22.04 (amd64)"
-            timeoutInMinutes: 30
-            cancelTimeoutInMinutes: 30
+            timeoutInMinutes: 120
+            cancelTimeoutInMinutes: 120
             pool:
               name: aduc_1es_client_pool
               os: linux

--- a/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
+++ b/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
@@ -40,6 +40,14 @@ trigger:
             - docker/*
             - scripts/*
 
+schedules:
+  - cron: "0 0 */14 * *"  # This cron expression schedules the pipeline to run every 14 days
+    displayName: "Every 2 weeks"
+    branches:
+      include:
+        - develop
+    always: true
+    
 pr:
     branches:
         include:


### PR DESCRIPTION
When CodeQL generating a new snapshot, the build process will take longer than expected due to the CodeQL processing overhead. This changes the build timeout to 120 minutes to accommodate the additional time needed for periodic CodeQL processing time.