### PR TITLE
Fix health check permissions failure on Docker

### DIFF
--- a/scripts/docker/templates/setup_container.sh
+++ b/scripts/docker/templates/setup_container.sh
@@ -28,7 +28,7 @@ adu_home_dir=/home/adu
 
 mkdir -p "$adu_conf_dir"
 chown "$adu_user:$adu_group" "$adu_conf_dir"
-chmod u=rwx,g=rx,o=rx "$adu_conf_dir"
+chmod u=rwx,g=rx,o= "$adu_conf_dir"
 chmod u=rw,g=r,o=r "$adu_conf_dir/$adu_conf_file"
 
 chown "$adu_user:$adu_group" "$adu_conf_dir/$adu_diagnostics_conf_file"
@@ -91,7 +91,7 @@ chmod u=rwx,g=rwx,o= "$adu_extensions_sources_dir"
 
 # Set deviceupdate-agent owner and permission
 chown "root:$adu_group" "$adu_shell_dir/$adu_shell_file"
-chmod u=rxs "$adu_shell_dir/$adu_shell_file"
+chmod u=rxs,g=rx "$adu_shell_dir/$adu_shell_file"
 
 #
 # misc for healthcheck

--- a/scripts/docker/templates/setup_container.sh
+++ b/scripts/docker/templates/setup_container.sh
@@ -91,7 +91,7 @@ chmod u=rwx,g=rwx,o= "$adu_extensions_sources_dir"
 
 # Set deviceupdate-agent owner and permission
 chown "root:$adu_group" "$adu_shell_dir/$adu_shell_file"
-chmod u=rxs,g=rx "$adu_shell_dir/$adu_shell_file"
+chmod u=rxs,g=rx,o= "$adu_shell_dir/$adu_shell_file"
 
 #
 # misc for healthcheck


### PR DESCRIPTION
After running `scripts/docker/templates/setup_container.sh` not all permissions align with what health check from ADU needs.

This PR fixes that.
Also changed the script `setup_container.sh` permissions to be executable `chmod +x`

Fix health check failure:
```sh
2025-02-19T18:00:04.4293Z 4616[4616] [E] Lookup failed or '/usr/bin/adu-shell' has incorrect permissions (expected: 04550) [CheckShellBinary:524]
```

Changed:
```sh
chmod u=rxs,g=rx /usr/bin/adu-shell
stat -c '%a' /usr/bin/adu-shell
4550
```


Fix health check failure:
```sh
2025-02-19T17:57:31.5842Z 3919[3919] [E] Lookup failed or '/etc/adu' directory has incorrect permissions (expected: 0750) [CheckConfDirOwnershipAndPermissions:270]
```

Changed:
```sh
chmod u=rwx,g=rx,o= /etc/adu/
stat -c '%a' /etc/adu
750
```