### PR TITLE
Fix an issue in the Script Handler where the primary script file permissions were set incorrectly

### DIFF
--- a/src/adu-shell/src/script_tasks.cpp
+++ b/src/adu-shell/src/script_tasks.cpp
@@ -49,7 +49,7 @@ ADUShellTaskResult Execute(const ADUShell_LaunchArguments& launchArgs)
     bool filePermissionsChanged = false;
     bool statOk = stat(path, &st) == 0;
 
-        // Note: delivery optimization will create the file with do:do ownership
+    // Note: delivery optimization will create the file with do:do ownership
     // Here, we must allow the read access by the owner group and others (S_IRGRP) users (S_IROTH).
     // Otherwise, the script handler will fail to calculate the hash of the script.
     int mode = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH;

--- a/src/adu-shell/src/script_tasks.cpp
+++ b/src/adu-shell/src/script_tasks.cpp
@@ -48,7 +48,12 @@ ADUShellTaskResult Execute(const ADUShell_LaunchArguments& launchArgs)
     struct stat st = {};
     bool filePermissionsChanged = false;
     bool statOk = stat(path, &st) == 0;
-    int mode = S_IRWXU | S_IRGRP | S_IXGRP;
+
+        // Note: delivery optimization will create the file with do:do ownership
+    // Here, we must allow the read access by the owner group and others (S_IRGRP) users (S_IROTH).
+    // Otherwise, the script handler will fail to calculate the hash of the script.
+    int mode = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH;
+
     if (statOk)
     {
         int perms = st.st_mode & ~S_IFMT;


### PR DESCRIPTION
**Cause**

The script_tasks incorrectly removed the read-only access for 'other' user, causing subsequent file hash calculations to fail and triggering multiple re-downloads of the same file.