### PR TITLE
Fix builds failing for catch2 v3.8 by using specified cmake version

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -66,6 +66,7 @@ cmake_force_source=false
 cmake_prefix="$work_folder"
 cmake_installer_dir=""
 cmake_dir_symlink="/tmp/deviceupdate-cmake"
+cmake_bin="cmake"
 
 install_shellcheck=false
 supported_shellcheck_version='0.8.0'
@@ -280,9 +281,9 @@ do_install_catch2() {
     mkdir cmake || return
     pushd cmake > /dev/null || return
 
-    CC="$catch2_cc" CXX="$catch2_cxx" cmake .. || return
-    CC="$catch2_cc" CXX="$catch2_cxx" cmake --build . || return
-    $SUDO cmake --build . --target install || return
+    CC="$catch2_cc" CXX="$catch2_cxx" "$cmake_bin" .. || return
+    CC="$catch2_cc" CXX="$catch2_cxx" "$cmake_bin" --build . || return
+    $SUDO "$cmake_bin" --build . --target install || return
     popd > /dev/null || return
     popd > /dev/null || return
 
@@ -958,6 +959,7 @@ if [[ $install_cmake == "true" ]]; then
             fi
         fi
     fi
+    cmake_bin="${cmake_dir_symlink}/bin/cmake"
 fi
 
 # Install git hooks if requested.

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -639,7 +639,7 @@ do_install_shellcheck() {
     fi
 
     if [[ $shellcheck_version == "$supported_shellcheck_version" ]]; then
-        echo "${work_folder}/deviceupdate-shellcheck at version ${supported_cmake_version} already exists. Skipping install..."
+        echo "${work_folder}/deviceupdate-shellcheck at version ${shellcheck_version} already exists. Skipping install..."
         return 0
     fi
 


### PR DESCRIPTION
Fix 
```sh
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  CMake 3.16 or higher is required.  You are running version 3.13.4
```

As mentioned on https://github.com/Azure/iot-hub-device-update/pull/689#issuecomment-2687481888

The combination of PR [Migrate catch2 v2 to v3 #683](https://github.com/Azure/iot-hub-device-update/pull/683) and [Public GitHub Actions for build and test #689](https://github.com/Azure/iot-hub-device-update/pull/689) sees that Debian 10 is using the system version of cmake 3.13.4 that is lower than the required by catch2 v3.8, which is cmake 3.16 https://github.com/catchorg/Catch2/blob/v3.8.0/CMakeLists.txt#L1


Tested on
https://github.com/AndreRicardo-Zoetis/iot-hub-device-update/actions/runs/13564853498/job/37915573097

Also tested locally with 
```sh
scripts/install-deps.sh --install-aduc-deps --install-do --install-shellcheck
```
`--install-aduc-deps` sets `install_catch2=true`, so it also calls the install catch2.

PS: also fixed what I believe is a typo on the name of a variable for shellcheck version.