### PR TITLE
Fix #672 error messages on Debian package removal

### DIFF
--- a/packages/debian/postrm
+++ b/packages/debian/postrm
@@ -35,20 +35,30 @@ deregister_eis()
 {
     rm -f "$eis_idservice_dir/$adu_eis_conf_file"
 
-    echo "Remove 'adu' user from 'aziotid' group."
-    gpasswd -d $adu_user aziotid > /dev/null
+    if getent group "aziotid" > /dev/null; then
+        echo "Remove 'adu' user from 'aziotid' group."
+        gpasswd -d $adu_user aziotid > /dev/null
+    fi
 
-    echo "Remove 'adu' user from 'aziotcs' group."
-    gpasswd -d $adu_user aziotcs > /dev/null
+    if getent group "aziotcs" > /dev/null; then
+        echo "Remove 'adu' user from 'aziotcs' group."
+        gpasswd -d $adu_user aziotcs > /dev/null
 
-    echo "Remove 'adu' user from 'aziotks' group."
-    gpasswd -d $adu_user aziotks > /dev/null
+    fi
 
-    echo "Restart IoT Identity Services"
-    systemctl restart aziot-certd
-    systemctl restart aziot-tpmd
-    systemctl restart aziot-keyd
-    systemctl restart aziot-identityd
+    if getent group "aziotks" > /dev/null; then
+        echo "Remove 'adu' user from 'aziotks' group."
+        gpasswd -d $adu_user aziotks > /dev/null
+    fi
+
+    # Deregister our process with EIS
+    if [ -d "$eis_idservice_dir" ]; then
+        echo "Restart IoT Identity Services"
+        systemctl restart aziot-certd
+        systemctl restart aziot-tpmd
+        systemctl restart aziot-keyd
+        systemctl restart aziot-identityd
+    fi
 }
 
 do_remove_tasks() {


### PR DESCRIPTION
Fixes https://github.com/Azure/iot-hub-device-update/issues/672

Errors that will no longer show up in the output:
```sh
Remove 'adu' user from 'aziotid' group.
gpasswd: group 'aziotid' does not exist in /etc/group
Remove 'adu' user from 'aziotcs' group.
gpasswd: group 'aziotcs' does not exist in /etc/group
Remove 'adu' user from 'aziotks' group.
gpasswd: group 'aziotks' does not exist in /etc/group
Restart IoT Identity Services
Failed to restart aziot-certd.service: Unit aziot-certd.service not found.
Failed to restart aziot-tpmd.service: Unit aziot-tpmd.service not found.
Failed to restart aziot-keyd.service: Unit aziot-keyd.service not found.
Failed to restart aziot-identityd.service: Unit aziot-identityd.service not found.
```