### PR TITLE
Ensure the downloaded script file has the correct ownership

### DIFF
--- a/src/adu-shell/CMakeLists.txt
+++ b/src/adu-shell/CMakeLists.txt
@@ -45,6 +45,8 @@ target_compile_definitions (
             ADUC_CONF_FOLDER="${ADUC_CONF_FOLDER}"
             ADUC_STEP_HANDLERS="${ADUC_STEP_HANDLERS}"
             ADUSHELL_EFFECTIVE_GROUP_NAME="${ADUSHELL_EFFECTIVE_GROUP_NAME}"
+            ADUC_FILE_USER="${ADUC_FILE_USER}"
+            ADUC_FILE_GROUP="${ADUC_FILE_GROUP}"
             ${adushell_def})
 
 target_link_aziotsharedutil (${target_name} PRIVATE)

--- a/src/adu-shell/inc/adushell.hpp
+++ b/src/adu-shell/inc/adushell.hpp
@@ -37,6 +37,8 @@ typedef struct tagADUShell_LaunchArguments
  * We're using EXIT_SUCCESS (0) for success case and EXIT_FAILURE (1) for general errors.
  */
 #define ADUSHELL_EXIT_UNSUPPORTED 3
+#define ADUSHELL_EXIT_BAD_FILE_PERMS 4
+#define ADUSHELL_EXIT_BAD_FILE_OWNERSHIP 5
 
 /**
  * @brief A result from ADUShell task.

--- a/src/adu-shell/src/script_tasks.cpp
+++ b/src/adu-shell/src/script_tasks.cpp
@@ -51,19 +51,6 @@ ADUShellTaskResult Execute(const ADUShell_LaunchArguments& launchArgs)
     int mode = S_IRWXU | S_IRGRP | S_IXGRP;
     if (statOk)
     {
-        int perms = st.st_mode & ~S_IFMT;
-        if (perms != mode)
-        {
-            // Fix the permissions.
-            if (0 != ADUCPAL_chmod(path, mode))
-            {
-                filePermissionsChanged = true;
-                stat(path, &st);
-                Log_Error(
-                    "Failed to set '%s' file permissions (expected:%d, actual: %d)", path, mode, st.st_mode & ~S_IFMT);
-            }
-        }
-
         // Ensure that the script has the correct ownership.
         struct group* grp = ADUCPAL_getgrnam(ADUC_FILE_GROUP);
         struct passwd* p = ADUCPAL_getpwnam(ADUC_FILE_USER);
@@ -74,12 +61,31 @@ ADUShellTaskResult Execute(const ADUShell_LaunchArguments& launchArgs)
             if (0 != ADUCPAL_chown(path, p->pw_uid, grp->gr_gid))
             {
                 Log_Error("Failed to set '%s' file ownership to %d:%d", path, p->pw_uid, grp->gr_gid);
+                taskResult.SetExitStatus(ADUSHELL_EXIT_BAD_FILE_OWNERSHIP);
+                goto done;
+            }
+        }
+
+        int perms = st.st_mode & ~S_IFMT;
+        if (perms != mode)
+        {
+            // Fix the permissions.
+            if (0 != ADUCPAL_chmod(path, mode))
+            {
+                filePermissionsChanged = true;
+                stat(path, &st);
+                Log_Error(
+                    "Failed to set '%s' file permissions (expected:%d, actual: %d)", path, mode, st.st_mode & ~S_IFMT);
+                taskResult.SetExitStatus(ADUSHELL_EXIT_BAD_FILE_PERMS);
+                goto done;
             }
         }
     }
 
     taskResult.SetExitStatus(ADUC_LaunchChildProcess(launchArgs.targetData, args, taskResult.Output()));
 
+done:
+    // Restore the permissions.
     if (filePermissionsChanged)
     {
         // Restore the permissions.

--- a/src/adu-shell/src/script_tasks.cpp
+++ b/src/adu-shell/src/script_tasks.cpp
@@ -59,8 +59,21 @@ ADUShellTaskResult Execute(const ADUShell_LaunchArguments& launchArgs)
             {
                 filePermissionsChanged = true;
                 stat(path, &st);
-                Log_Warn(
+                Log_Error(
                     "Failed to set '%s' file permissions (expected:%d, actual: %d)", path, mode, st.st_mode & ~S_IFMT);
+            }
+        }
+
+        // Ensure that the script has the correct ownership.
+        struct group* grp = ADUCPAL_getgrnam(ADUC_FILE_GROUP);
+        struct passwd* p = ADUCPAL_getpwnam(ADUC_FILE_USER);
+
+        if (p != NULL && grp != NULL)
+        {
+            // Fix the ownership.
+            if (0 != ADUCPAL_chown(path, p->pw_uid, grp->gr_gid))
+            {
+                Log_Error("Failed to set '%s' file ownership to %d:%d", path, p->pw_uid, grp->gr_gid);
             }
         }
     }


### PR DESCRIPTION
Fix the Script Handler to ensure the script file has the correct ownership.
This to ensure that only 'adu' user and 'adu' group has access to the script file.