### PR TITLE
handle nodeployment case

### DIFF
--- a/src/agent/adu_core_interface/src/adu_core_interface.c
+++ b/src/agent/adu_core_interface/src/adu_core_interface.c
@@ -380,6 +380,23 @@ void OrchestratorUpdateCallback(
         goto done;
     }
 
+    // If there is no deployment for the device group or the device connected
+    // within an interval before the update was deployed, then a C2D message
+    // with update action of cancel and an internal workflowId of
+    // "nodeployment" will be sent.
+    //
+    // It is an indicator that no deployment exists for the device group or
+    // that a new deployment has been deployed recently and should be flowing
+    // down the pipe soon.
+    //
+    // Instead of processing a cancel, just ignore this and wait for normal
+    // cancellation to occur once a "process deployment" action flows down.
+    if (updateAction == ADUCITF_UpdateAction_Cancel && (0 == strcmp(workflowId, "nodeployment")))
+    {
+        Log_Info("Received deployment delay period NOOP cancel. Will wait for update deployment to be pushed...");
+        goto done;
+    }
+
     if (updateAction == ADUCITF_UpdateAction_ProcessDeployment && !IsNullOrEmpty(workflowId))
     {
         Log_Debug("Processing deployment %s ...", workflowId);

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required (VERSION 3.5)
 
+add_subdirectory (auto_utils)
 add_subdirectory (c_utils)
 add_subdirectory (config_utils)
 add_subdirectory (contract_utils)

--- a/src/utils/auto_utils/CMakeLists.txt
+++ b/src/utils/auto_utils/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+set (target_name auto_utils)
+
+add_library (${target_name} INTERFACE)
+add_library (aduc::${target_name} ALIAS ${target_name})
+
+target_include_directories (${target_name} INTERFACE inc)
+
+#
+# Turn -fPIC on, in order to use this library in another shared library.
+#
+set_property (TARGET ${target_name} PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/utils/auto_utils/inc/aduc/defer.hpp
+++ b/src/utils/auto_utils/inc/aduc/defer.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <functional>
+
+namespace aduc
+{
+/**
+ * @brief Unconditionally execute a function at scope exit.
+ *
+ */
+class Defer
+{
+    std::function<void()> scope_exit_fn;
+
+public:
+    explicit Defer(std::function<void()>&& fn) : scope_exit_fn(std::move(fn))
+    {
+    }
+
+    ~Defer()
+    {
+        scope_exit_fn();
+    }
+};
+
+} // namespace aduc

--- a/src/utils/workflow_utils/src/workflow_utils.c
+++ b/src/utils/workflow_utils/src/workflow_utils.c
@@ -733,6 +733,8 @@ ADUC_Result workflow_parse_peek_unprotected_workflow_properties(
     char* tmpWorkflowId = NULL;
     char* tmpRootKeyPkgUrl = NULL;
 
+    bool is_nodeployment_delay_period = false;
+
     if (json_object_dothas_value(updateActionJsonObj, ADUCITF_FIELDNAME_WORKFLOW_DOT_ACTION))
     {
         updateAction = json_object_dotget_number(updateActionJsonObj, ADUCITF_FIELDNAME_WORKFLOW_DOT_ACTION);
@@ -754,6 +756,11 @@ ADUC_Result workflow_parse_peek_unprotected_workflow_properties(
             goto done;
         }
 
+        if (0 == strcmp(workflowId, "nodeployment"))
+        {
+            is_nodeployment_delay_period = true;
+        }
+
         tmpWorkflowId = workflow_copy_string(workflowId);
         if (tmpWorkflowId == NULL)
         {
@@ -762,7 +769,7 @@ ADUC_Result workflow_parse_peek_unprotected_workflow_properties(
         }
     }
 
-    if (outRootKeyPkgUrl_optional != NULL)
+    if (outRootKeyPkgUrl_optional != NULL && !is_nodeployment_delay_period)
     {
         rootkeyPkgUrl = json_object_dotget_string(updateActionJsonObj, ADUCITF_FIELDNAME_ROOTKEY_PACKAGE_URL);
         if (IsNullOrEmpty(rootkeyPkgUrl))
@@ -785,7 +792,7 @@ ADUC_Result workflow_parse_peek_unprotected_workflow_properties(
         *outWorkflowUpdateAction = updateAction;
     }
 
-    if (outWorkflowId_optional != NULL && workflowId != NULL)
+    if (outWorkflowId_optional != NULL && tmpWorkflowId != NULL)
     {
         *outWorkflowId_optional = tmpWorkflowId;
         tmpWorkflowId = NULL;

--- a/src/utils/workflow_utils/tests/CMakeLists.txt
+++ b/src/utils/workflow_utils/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ disablertti ()
 find_package (Catch2 REQUIRED)
 find_package (Parson REQUIRED)
 
-add_executable (${PROJECT_NAME} ${sources} "")
+add_executable (${PROJECT_NAME} ${sources})
 
 target_sources (${PROJECT_NAME} PRIVATE main.cpp workflow_utils_ut.cpp
                                         workflow_get_update_file_ut.cpp)
@@ -19,6 +19,8 @@ target_include_directories (${PROJECT_NAME} PUBLIC inc ${ADUC_EXPORT_INCLUDES})
 
 target_link_libraries (${PROJECT_NAME} PRIVATE Catch2::Catch2WithMain aduc::parser_utils aduc::string_utils
                                                aduc::test_utils aduc::workflow_utils Catch2::Catch2 aduc::root_key_utils umock_c)
+
+target_link_libraries (${PROJECT_NAME} PRIVATE aduc::auto_utils)
 
 target_link_aziotsharedutil (${PROJECT_NAME} PRIVATE)
 


### PR DESCRIPTION
- Skip rootkeypackage url parse if "nodeployment" internal workflowId is received.
- Handle "nodeployment" case in OrchestratorUpdateCallback
- Add workflow parse unit test for "nodeployment" case
- Add defer.hpp for adding defer statements that execute on exit of current scope
- Addresses github issue #694