### PR TITLE
Debian 12: add debian:12 to docker-build.yml

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,7 @@ jobs:
   container-job:
     strategy:
       matrix:
-        os: ["debian:11", "debian:10", "ubuntu:22.04", "ubuntu:20.04"]
+        os: ["debian:12", "debian:11", "debian:10", "ubuntu:22.04", "ubuntu:20.04"]
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.os }}


### PR DESCRIPTION
Add "debian:12" in docker-build.yml as requested in https://github.com/Azure/iot-hub-device-update/pull/707#issuecomment-2706286959 by [AndreRicardo-Zoetis](https://github.com/AndreRicardo-Zoetis).