### PR TITLE
disable d2cmsg unit test on arm64 for deb11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required (VERSION 3.5)
 
+if(NOT DEFINED CMAKE_SYSTEM_PROCESSOR)
+    execute_process(COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE SYS_ARCH)
+    set(CMAKE_SYSTEM_PROCESSOR ${SYS_ARCH} CACHE STRING "System processor architecture")
+endif()
+
+message(STATUS "System processor: ${CMAKE_SYSTEM_PROCESSOR}")
+
+set(IS_ARM64 ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64|arm64")
+message(STATUS "Building for ARM64: ${IS_ARM64}")
+
 if (WIN32)
     #
     # Configure vcpkg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,21 @@
 cmake_minimum_required (VERSION 3.5)
 
-if(NOT DEFINED CMAKE_SYSTEM_PROCESSOR)
-    execute_process(COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE SYS_ARCH)
-    set(CMAKE_SYSTEM_PROCESSOR ${SYS_ARCH} CACHE STRING "System processor architecture")
-endif()
+if (NOT WIN32)
+    if (NOT DEFINED CMAKE_SYSTEM_PROCESSOR)
+        execute_process (COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE SYS_ARCH)
+        set (CMAKE_SYSTEM_PROCESSOR ${SYS_ARCH} CACHE STRING "System processor architecture")
+    endif ()
 
-message(STATUS "System processor: ${CMAKE_SYSTEM_PROCESSOR}")
+    message (STATUS "System processor: ${CMAKE_SYSTEM_PROCESSOR}")
 
-set(IS_ARM64 ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64|arm64")
-message(STATUS "Building for ARM64: ${IS_ARM64}")
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+        set (IS_ARM64 TRUE)
+    else ()
+        set (IS_ARM64 FALSE)
+    endif ()
+
+    message (STATUS "Building for ARM64: ${IS_ARM64}")
+endif ()
 
 if (WIN32)
     #

--- a/src/utils/d2c_messaging/CMakeLists.txt
+++ b/src/utils/d2c_messaging/CMakeLists.txt
@@ -22,6 +22,10 @@ target_link_libraries (
     PUBLIC aduc::adu_types
     PRIVATE aduc::communication_abstraction aduc::logging aduc::retry_utils)
 
-if (ADUC_BUILD_UNIT_TESTS AND NOT IS_ARM64)
-    add_subdirectory (tests)
+if (ADUC_BUILD_UNIT_TESTS)
+    if (${IS_ARM64})
+        message (STATUS "Skipping tests for utils/d2c_messaging because IS_ARM64 == ${IS_ARM64}...")
+    else ()
+        add_subdirectory (tests)
+    endif ()
 endif ()

--- a/src/utils/d2c_messaging/CMakeLists.txt
+++ b/src/utils/d2c_messaging/CMakeLists.txt
@@ -22,6 +22,6 @@ target_link_libraries (
     PUBLIC aduc::adu_types
     PRIVATE aduc::communication_abstraction aduc::logging aduc::retry_utils)
 
-if (ADUC_BUILD_UNIT_TESTS)
+if (ADUC_BUILD_UNIT_TESTS AND NOT IS_ARM64)
     add_subdirectory (tests)
 endif ()


### PR DESCRIPTION
deb 11 openssl 1.1.0 on arm64 does not have a symbol that d2c messaging unit test is requiring during linking, so disabling this from building for now (d2c messaging already does nothing when running it).
Tested on Debian 11 ARM64 and Ubuntu 22.04 x86_64.