### PR TITLE
Cherry-Pick from Develop - Disable d2cmsg unit test on arm64 for deb11 (#713)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,22 @@
 cmake_minimum_required (VERSION 3.5)
 
+if (NOT WIN32)
+    if (NOT DEFINED CMAKE_SYSTEM_PROCESSOR)
+        execute_process (COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE SYS_ARCH)
+        set (CMAKE_SYSTEM_PROCESSOR ${SYS_ARCH} CACHE STRING "System processor architecture")
+    endif ()
+
+    message (STATUS "System processor: ${CMAKE_SYSTEM_PROCESSOR}")
+
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+        set (IS_ARM64 TRUE)
+    else ()
+        set (IS_ARM64 FALSE)
+    endif ()
+
+    message (STATUS "Building for ARM64: ${IS_ARM64}")
+endif ()
+
 if (WIN32)
     #
     # Configure vcpkg

--- a/src/utils/d2c_messaging/CMakeLists.txt
+++ b/src/utils/d2c_messaging/CMakeLists.txt
@@ -23,5 +23,9 @@ target_link_libraries (
     PRIVATE aduc::communication_abstraction aduc::logging aduc::retry_utils)
 
 if (ADUC_BUILD_UNIT_TESTS)
-    add_subdirectory (tests)
+    if (${IS_ARM64})
+        message (STATUS "Skipping tests for utils/d2c_messaging because IS_ARM64 == ${IS_ARM64}...")
+    else ()
+        add_subdirectory (tests)
+    endif ()
 endif ()


### PR DESCRIPTION
* Disable d2c_messaging ut on arm64 for Debian 11 arm64
* Cherry-Pick commit 35de3285899446215a09b7b191a8401c6d03466e from develop branch