### PR TITLE
Allow use of curl to download rootkey pkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,14 @@ cmake_minimum_required (VERSION 3.5)
 
 if (NOT WIN32)
     if (NOT DEFINED CMAKE_SYSTEM_PROCESSOR)
-        execute_process (COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE SYS_ARCH)
-        set (CMAKE_SYSTEM_PROCESSOR ${SYS_ARCH} CACHE STRING "System processor architecture")
+        execute_process (
+            COMMAND uname -m
+            COMMAND tr -d '\n'
+            OUTPUT_VARIABLE SYS_ARCH)
+        set (
+            CMAKE_SYSTEM_PROCESSOR
+            ${SYS_ARCH}
+            CACHE STRING "System processor architecture")
     endif ()
 
     message (STATUS "System processor: ${CMAKE_SYSTEM_PROCESSOR}")
@@ -254,6 +260,10 @@ set (
         "An override URL to use for the public rootkey package. Leave empty to use the URL provided in the C2D message."
 )
 
+if (ADUC_ROOTKEY_PKG_DOWNLOAD_WITH_CURL)
+    set (ROOTKEY_PKG_DOWNLOAD_USE_CURL 1)
+endif ()
+
 #
 # Starting from version 0.8.1, Device Update Agent must support only one version of the update manifest
 # based on the base dtmi model that the Agent announces when connecting to the IoT Hub.
@@ -497,6 +507,8 @@ option (ADUC_TRACE_TARGET_DEPS "Trace target dependencies" OFF)
 option (ADUC_USE_TEST_ROOT_KEYS "Include test root keys" OFF)
 option (ADUC_ENABLE_E2E_TESTING "Enable e2e test pipeline settings" OFF)
 option (ADUC_ENABLE_SRVC_E2E_TESTING "Enable service side test agent settings" OFF)
+option (ADUC_ROOTKEY_PKG_DOWNLOAD_WITH_CURL
+        "Use Curl to download the Rootkey Package instead of DeliveryOptimization agent" OFF)
 
 ### End CMake Options
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Device Update for IoT Hub features provide a powerful and flexible experience, i
 
 * [Device Update for IoT Hub](https://aka.ms/iot-hub-device-update-docs)
 * [Getting Started with Device Update Agent](./docs/agent-reference)
+* More details on building the agent here: [How to build agent code](./docs/agent-reference/how-to-build-agent-code.md)
 
 ## Quick Start
 

--- a/docs/agent-reference/how-to-build-agent-code.md
+++ b/docs/agent-reference/how-to-build-agent-code.md
@@ -39,7 +39,7 @@ enabled, use a personal access token (PAT) as the password.
 
 To install all dependencies run:
 
-```shell
+```sh
 ./scripts/install-deps.sh -a
 ```
 
@@ -47,26 +47,28 @@ To install all dependencies run:
 
 To install only the dependencies necessary for the agent:
 
-```shell
+```sh
 ./scripts/install-deps.sh --install-aduc-deps --install-packages --install-do
 ```
 
 `install-deps.sh` also provides several options for installing individual
 dependencies. To see the usage info:
 
-```shell
+```sh
 ./scripts/install-deps.sh -h
 ```
 
 ### Install Optional Development Tools
 
 - Install the clang-format package (required for running `scripts/clang-format.sh`):
-```shell
+
+```sh
 sudo apt install clang-format
 ```
 
 - Install pip3 and cmake-format (required for running `scripts/cmake-format.sh`):
-```shell
+
+```sh
 sudo apt install python3-pip
 sudo --set-home pip3 install cmake-format
 ```
@@ -79,13 +81,13 @@ The Device Update for IoT Hub reference agent code utilizes CMake for building. 
 
 To build the reference agent with the default parameters:
 
-```shell
+```sh
 ./scripts/build.sh -c
 ```
 
 To see additional build options with build.sh:
 
-```shell
+```sh
 build.sh -h
 ```
 
@@ -93,7 +95,7 @@ build.sh -h
 
 To build and run the unit tests:
 
-```shell
+```sh
 ./scripts/build.sh -c -u
 pushd out
 ctest # or ninja test
@@ -101,7 +103,7 @@ ctest # or ninja test
 
 For more test run options:
 
-```shell
+```sh
 ctest -h
 ```
 
@@ -127,7 +129,7 @@ No suppression file is currently used, so the goal is for all the unit tests to 
 
 To build the debian package (will be output to the `out` directory):
 
-```shell
+```sh
 ./scripts/build.sh --build-packages
 ```
 
@@ -137,7 +139,7 @@ Alternatively, you can build using CMake directly. Set the required product valu
 for ADUC_DEVICEINFO_MANUFACTURER and ADUC_DEVICEINFO_MODEL in the top-level
 [CMakeLists.txt](../../CMakeLists.txt) before building. Optional CMake values can be found there as well.
 
-```shell
+```sh
 mkdir -p build && pushd build
 cmake ..
 cmake --build .
@@ -146,7 +148,7 @@ popd > /dev/null
 
 or using Ninja
 
-```shell
+```sh
 mkdir -p build && pushd build
 cmake -G Ninja ..
 ninja
@@ -155,10 +157,28 @@ popd > /dev/null
 
 You can do incremental builds with Ninja:
 
-```shell
+```sh
 pushd out && ninja
 popd
 ```
+
+### Use Curl for RootKey Package Download instead of Delivery Optimization Agent (DO)
+
+One can already configure the agent to use curl to download update payload content (by registering curl content downloader extension, `/var/lib/adu/extensions/sources/libcurl_content_downloader.so`).
+
+However, to switch to curl for downloading the RootKey Package (infrastructure file for update signature verification), one must currently rebuild the agent from sources by providing the `--rootkeypkg-curl` parameter to [build.sh](../../scripts/build.sh).
+
+For example:
+
+```sh
+./scripts/build.sh -c --rootkeypkg-curl
+```
+
+Notes:
+
+- Just as with update payload downloads, using curl for downloads will require `/usr/bin/curl` to be available on the device that has the AducIotAgent binary.
+
+- curl will be invoked with the following cmd-line: `/usr/bin/curl -L -C - -o /path/to/output/file`
 
 ### Build Options for MQTT and MQTT over WebSockets IotHub Transport Providers
 
@@ -168,7 +188,7 @@ By Default, both mqtt and mqtt/WebSockets will be linked into the AducIotAgent b
 
 Here is the default in top-level `CMakeLists.txt`:
 
-```shell
+```sh
 set (
     ADUC_IOT_HUB_PROTOCOL
     "IotHub_Protocol_from_Config"
@@ -201,7 +221,7 @@ If using only `MQTT`, then choosing `MQTT` for `ADUC_IOT_HUB_PROTOCOL` in the to
 
 To link in only MQTT transport provider, set this in the top-level `CMakeLists.txt`:
 
-```shell
+```sh
 set (
     ADUC_IOT_HUB_PROTOCOL
     "MQTT"
@@ -214,7 +234,7 @@ set (
 
 After enabling WebSockets above using install-deps.sh so that it builds libiothub_client_mqtt_ws_transport.a static library, modify the top-level CMakeLists.txt to use MQTT_over_WebSockets:
 
-```shell
+```sh
 set (
     ADUC_IOT_HUB_PROTOCOL
     "MQTT_over_WebSockets"
@@ -228,14 +248,14 @@ Using `"MQTT"` will use SecureMQTT over port `8883`.
 
 Please note that, by default, both MQTT (`libiothub_client_mqtt_transport.a`) and MQTT over WebSockets(`libiothub_client_mqtt_ws_transport.a`) static libraries are built by `install-deps.sh` via the `use_mqtt` and `use_wsio` -D configs.
 
-```shell
+```sh
 # Verify mqtt transport static lib exists
 $ locate libiothub_client_mqtt_transport.a | \
     grep '/usr/local/lib/'
 /usr/local/lib/libiothub_client_mqtt_transport.a
 ```
 
-```shell
+```sh
 # Verify mqtt over websockets static lib exists
 $ locate libiothub_client_mqtt_ws_transport.a | \
     grep '/usr/local/lib/'
@@ -246,13 +266,13 @@ $ locate libiothub_client_mqtt_ws_transport.a | \
 
 ### Install the Device Update Agent after building
 
-```shell
+```sh
 sudo cmake --build out --target install
 ```
 
 or using Ninja
 
-```shell
+```sh
 pushd out > /dev/null
 sudo ninja install
 popd > /dev/null
@@ -264,7 +284,7 @@ popd > /dev/null
 
 After building the Debian package using `build.sh --build-packages`, do:
 
-```shell
+```sh
 sudo apt install ./out/{PKG_NAME}.deb
 ```
 
@@ -276,7 +296,7 @@ Run Device Update Agent by following these [instructions](./how-to-run-agent.md)
 
 If using MQTT, run the following netstat command to verify that it is connecting to the remote MQTT port of 8883:
 
-```shell
+```sh
 $ sudo ./out/bin/AducIotClient -l0 -e > /dev/null 2>&1 &
 $ sudo netstat -pantu | grep Adu
 tcp        0      0 <LOCAL IP ADDR>:<LOCAL PORT>       <REMOTE IP ADDR>:8883         ESTABLISHED <PID>/./out/bin/Aduc
@@ -288,7 +308,7 @@ $ fg
 
 If using MQTT over WebSockets, run the following netstat command to verify that it is connecting to the remote WebSockets port of 443:
 
-```shell
+```sh
 $ sudo ./out/bin/AducIotClient -l0 -e > /dev/null 2>&1 &
 $ sudo netstat -pantu | grep Adu
 tcp        0      0 <LOCAL IP ADDR>:<LOCAL PORT>       <REMOTE IP ADDR>:443         ESTABLISHED <PID>/./out/bin/Aduc

--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -43,7 +43,7 @@ set (CPACK_DEBIAN_PACKAGE_SECTION "admin")
 # If remove deliveryoptimization-agent from dependencies, preinst script must be updated accordingly.
 
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps
-set (CPACK_DEBIAN_PACKAGE_DEPENDS "deliveryoptimization-agent (>= 1.0.0), libdeliveryoptimization (>= 1.0.0), libcurl4-openssl-dev")
+set (CPACK_DEBIAN_PACKAGE_DEPENDS "deliveryoptimization-agent (>= 1.0.0), libdeliveryoptimization (>= 1.0.0), curl")
 set (CPACK_DEBIAN_PACKAGE_SUGGESTS "deliveryoptimization-plugin-apt")
 
 # Use dpkg-shlibdeps to generate better package dependency list.

--- a/src/agent/adu_core_interface/src/adu_core_interface.c
+++ b/src/agent/adu_core_interface/src/adu_core_interface.c
@@ -18,7 +18,6 @@
 #include "aduc/logging.h"
 #include "aduc/reporting_utils.h"
 #include "aduc/rootkey_workflow.h"
-#include "aduc/rootkeypackage_do_download.h"
 #include "aduc/rootkeypackage_types.h"
 #include "aduc/rootkeypackage_utils.h"
 #include "aduc/string_c_utils.h"

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.cpp
@@ -111,8 +111,9 @@ ADUC_Result Download_curl(
     // -L (or --location). Handle 3xx redirects. See https://curl.se/docs/manpage.html#-L
     args.emplace_back("-L");
 
-    // -C (or --continue-at). The ' -' after allows auto-resuming the transfer. See https://curl.se/docs/manpage.html#-C
-    args.emplace_back("-C -");
+    // -C (or --continue-at). The hyphen after, i.e. '-C -', allows auto-resuming the transfer. See https://curl.se/docs/manpage.html#-C
+    args.emplace_back("-C");
+    args.emplace_back("-");
 
     // -o (or --output). Output to file instead of stdout. See https://curl.se/docs/manpage.html#-o
     // NOTE: -O (or --remote-name) is not needed as we already have an /absolute/ file path.

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.cpp
@@ -108,9 +108,18 @@ ADUC_Result Download_curl(
         entity->DownloadUri,
         fullFilePath.str().c_str());
 
+    // -L (or --location). Handle 3xx redirects. See https://curl.se/docs/manpage.html#-L
+    args.emplace_back("-L");
+
+    // -C (or --continue-at). The ' -' after allows auto-resuming the transfer. See https://curl.se/docs/manpage.html#-C
+    args.emplace_back("-C -");
+
+    // -o (or --output). Output to file instead of stdout. See https://curl.se/docs/manpage.html#-o
+    // NOTE: -O (or --remote-name) is not needed as we already have an /absolute/ file path.
     args.emplace_back("-o");
     args.emplace_back(fullFilePath.str().c_str());
-    args.emplace_back("-O");
+
+    // Finally, tack the url onto the end
     args.emplace_back(entity->DownloadUri);
 
     exitCode = ADUC_LaunchChildProcess("/usr/bin/curl", args, output);

--- a/src/rootkey_workflow/CMakeLists.txt
+++ b/src/rootkey_workflow/CMakeLists.txt
@@ -23,6 +23,12 @@ target_compile_definitions (
             ADUC_ROOTKEY_STORE_PATH="${ADUC_ROOTKEY_STORE_PATH}"
             ADUC_ROOTKEY_PKG_URL_OVERRIDE="${ADUC_ROOTKEY_PKG_URL_OVERRIDE}")
 
+if (ROOTKEY_PKG_DOWNLOAD_USE_CURL)
+    target_compile_definitions (${target_name} PRIVATE ROOTKEY_PKG_DOWNLOAD_USE_CURL=1)
+else ()
+    target_compile_definitions (${target_name} PRIVATE ROOTKEY_PKG_DOWNLOAD_USE_CURL=0)
+endif ()
+
 include (CMakePrintHelpers)
 cmake_print_variables (ADUC_ENABLE_E2E_TESTING)
 if (ADUC_ENABLE_E2E_TESTING)

--- a/src/rootkey_workflow/src/rootkey_workflow.c
+++ b/src/rootkey_workflow/src/rootkey_workflow.c
@@ -9,7 +9,6 @@
 #include "aduc/rootkey_workflow.h"
 
 #include <aduc/logging.h>
-#include <aduc/rootkeypackage_do_download.h>
 #include <aduc/rootkeypackage_download.h>
 #include <aduc/rootkeypackage_parse.h>
 #include <aduc/rootkeypackage_utils.h>
@@ -19,6 +18,12 @@
 #include <azure_c_shared_utility/strings.h>
 #include <parson.h>
 #include <root_key_util.h>
+
+#if ROOTKEY_PKG_DOWNLOAD_USE_CURL == 1
+#    include <aduc/rootkeypackage_curl_download.h>
+#else
+#    include <aduc/rootkeypackage_do_download.h>
+#endif
 
 #include <stdlib.h>
 
@@ -44,8 +49,13 @@ ADUC_Result RootKeyWorkflow_UpdateRootKeys(const char* workflowId, const char* w
     memset(&rootKeyPackage, 0, sizeof(ADUC_RootKeyPackage));
 
     ADUC_RootKeyPkgDownloaderInfo rootkey_downloader_info = {
-        .name = "DO", // DeliveryOptimization
+#if ROOTKEY_PKG_DOWNLOAD_USE_CURL == 1
+        .name = "Curl",
+        .downloadFn = DownloadRootKeyPkg_Curl,
+#else
+        .name = "DO",
         .downloadFn = DownloadRootKeyPkg_DO,
+#endif
         .downloadBaseDir = workFolder,
     };
 

--- a/src/utils/rootkeypackage_utils/CMakeLists.txt
+++ b/src/utils/rootkeypackage_utils/CMakeLists.txt
@@ -9,12 +9,16 @@ find_package (Parson REQUIRED)
 add_library (${target_name} STATIC)
 add_library (aduc::${target_name} ALIAS ${target_name})
 
-
 set_property (TARGET ${target_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_sources (
-    ${target_name} PRIVATE src/rootkeypackage_download.c src/rootkeypackage_parse.c
-                           src/rootkeypackage_utils.c src/rootkeypackage_do_download.cpp)
+target_sources (${target_name} PRIVATE src/rootkeypackage_download.c src/rootkeypackage_parse.c
+                                       src/rootkeypackage_utils.c)
+
+if (ROOTKEY_PKG_DOWNLOAD_USE_CURL)
+    target_sources (${target_name} PRIVATE src/rootkeypackage_curl_download.cpp)
+else ()
+    target_sources (${target_name} PRIVATE src/rootkeypackage_do_download.cpp)
+endif ()
 
 target_include_directories (${target_name} PUBLIC inc ${ADUC_EXPORT_INCLUDES})
 
@@ -25,6 +29,10 @@ target_link_libraries (
     ${target_name}
     PUBLIC aduc::c_utils aduc::hash_utils libaducpal
     PRIVATE aduc::crypto_utils aduc::logging aduc::system_utils aduc::url_utils Parson::parson)
+
+if (ROOTKEY_PKG_DOWNLOAD_USE_CURL)
+    target_link_libraries (${target_name} PRIVATE aduc::process_utils)
+endif ()
 
 target_compile_definitions (
     ${target_name} PRIVATE ADUC_ROOTKEY_PKG_URL_OVERRIDE="${ADUC_ROOTKEY_PKG_URL_OVERRIDE}")

--- a/src/utils/rootkeypackage_utils/inc/aduc/rootkeypackage_curl_download.h
+++ b/src/utils/rootkeypackage_utils/inc/aduc/rootkeypackage_curl_download.h
@@ -1,0 +1,22 @@
+
+/**
+ * @file rootkeypackage_curl_download.h
+ * @brief The root key package curl download header.
+ *
+ * @copyright Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+#ifndef ROOTKEYPACKAGE_CURL_DOWNLOAD_H
+#define ROOTKEYPACKAGE_CURL_DOWNLOAD_H
+
+#include <aduc/c_utils.h>
+#include <aduc/result.h>
+
+EXTERN_C_BEGIN
+
+ADUC_Result DownloadRootKeyPkg_Curl(const char* url, const char* targetFilePath);
+
+EXTERN_C_END
+
+#endif // ROOTKEYPACKAGE_CURL_DOWNLOAD_H

--- a/src/utils/rootkeypackage_utils/src/rootkeypackage_curl_download.cpp
+++ b/src/utils/rootkeypackage_utils/src/rootkeypackage_curl_download.cpp
@@ -49,7 +49,7 @@ ADUC_Result DownloadRootKeyPkg_Curl(const char* url, const char* targetFilePath)
             }
             joined_args += arg;
         }
-        Log_Info("Using cmdline: /usr/bin/curl '%s' ...", joined_args.c_str());
+        Log_Info("Using cmdline: /usr/bin/curl %s", joined_args.c_str());
 
         std::string output;
         int exitCode = ADUC_LaunchChildProcess("/usr/bin/curl", args, output);

--- a/src/utils/rootkeypackage_utils/src/rootkeypackage_curl_download.cpp
+++ b/src/utils/rootkeypackage_utils/src/rootkeypackage_curl_download.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file rootkeypackage_curl_download.cpp
+ * @brief Implements curl download of root key packages.
+ *
+ * @copyright Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+#include <aduc/types/adu_core.h>
+#include <aduc/logging.h>
+#include "aduc/process_utils.hpp" // for ADUC_LaunchChildProcess
+#include <aduc/result.h>
+
+#include <string>
+#include <vector>
+
+EXTERN_C_BEGIN
+
+ADUC_Result DownloadRootKeyPkg_Curl(const char* url, const char* targetFilePath)
+{
+    ADUC_Result result = { ADUC_GeneralResult_Failure, 0 };
+
+    Log_Info("Downloading File '%s' to '%s'", url, targetFilePath);
+
+    try
+    {
+        std::vector<std::string> args;
+
+        // -L (or --location). Handle 3xx redirects. See https://curl.se/docs/manpage.html#-L
+        args.emplace_back("-L");
+
+        // -C (or --continue-at). With hyphen after, e.g. '-C -', enables auto-resuming transfers. See https://curl.se/docs/manpage.html#-C
+        args.emplace_back("-C");
+        args.emplace_back("-");
+
+        // -o (or --output). Output to file instead of stdout. See https://curl.se/docs/manpage.html#-o
+        // NOTE: -O (or --remote-name) is not needed as we already have an /absolute/ file path.
+        args.emplace_back("-o");
+        args.emplace_back(targetFilePath);
+
+        // Finally, tack the url onto the end
+        args.emplace_back(url);
+
+        std::string joined_args;
+        for (const auto& arg : args)
+        {
+            if (!joined_args.empty()) {
+                joined_args += " ";
+            }
+            joined_args += arg;
+        }
+        Log_Info("Using cmdline: /usr/bin/curl '%s' ...", joined_args.c_str());
+
+        std::string output;
+        int exitCode = ADUC_LaunchChildProcess("/usr/bin/curl", args, output);
+        if (exitCode == 0)
+        {
+            result.ResultCode = ADUC_Result_Download_Success;
+            Log_Info("Download output:: \n%s", output.c_str());
+        }
+        else
+        {
+            result.ResultCode = ADUC_Result_Failure;
+            result.ExtendedResultCode = ADUC_ERROR_CURL_DOWNLOADER_EXTERNAL_FAILURE(exitCode);
+        }
+    }
+    catch (...)
+    {
+        result.ExtendedResultCode = ADUC_ERC_UTILITIES_ROOTKEYUTIL_ROOTKEYPACKAGE_DOWNLOAD_EXCEPTION;
+    }
+
+    Log_Info("RootKey Package Download with Curl - rc: %d, erc: 0x%08x", result.ResultCode, result.ExtendedResultCode);
+
+    return result;
+}
+
+EXTERN_C_END

--- a/src/utils/rootkeypackage_utils/src/rootkeypackage_do_download.cpp
+++ b/src/utils/rootkeypackage_utils/src/rootkeypackage_do_download.cpp
@@ -1,6 +1,6 @@
 /**
  * @file rootkeypackage_do_download.cpp
- * @brief Implements delivery optimization download.
+ * @brief Implements delivery optimization download of rootkey packages.
  *
  * @copyright Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
@@ -48,7 +48,7 @@ ADUC_Result DownloadRootKeyPkg_DO(const char* url, const char* targetFilePath)
         result.ExtendedResultCode = ADUC_ERC_UTILITIES_ROOTKEYUTIL_ROOTKEYPACKAGE_DOWNLOAD_EXCEPTION;
     }
 
-    Log_Info("Download rc: %d, erc: 0x%08x", result.ResultCode, result.ExtendedResultCode);
+    Log_Info("RootKey Package Download with DO - rc: %d, erc: 0x%08x", result.ResultCode, result.ExtendedResultCode);
 
     return result;
 }

--- a/src/utils/rootkeypackage_utils/src/rootkeypackage_download.c
+++ b/src/utils/rootkeypackage_utils/src/rootkeypackage_download.c
@@ -7,7 +7,6 @@
  */
 
 #include "aduc/rootkeypackage_download.h"
-#include "aduc/rootkeypackage_do_download.h"
 #include "aduc/rootkeypackage_utils.h"
 #include <aduc/logging.h>
 #include <aduc/string_c_utils.h>

--- a/src/utils/rootkeypackage_utils/tests/testapp/CMakeLists.txt
+++ b/src/utils/rootkeypackage_utils/tests/testapp/CMakeLists.txt
@@ -10,3 +10,9 @@ target_sources (${target_name} PRIVATE src/main.cpp)
 
 target_link_aziotsharedutil (${target_name} INTERFACE)
 target_link_libraries (${target_name} PRIVATE aduc::rootkeypackage_utils aduc::test_utils)
+
+if (ROOTKEY_PKG_DOWNLOAD_USE_CURL)
+    target_compile_definitions (${target_name} PRIVATE ROOTKEY_PKG_DOWNLOAD_USE_CURL=1)
+else ()
+    target_compile_definitions (${target_name} PRIVATE ROOTKEY_PKG_DOWNLOAD_USE_CURL=0)
+endif ()

--- a/src/utils/rootkeypackage_utils/tests/testapp/src/main.cpp
+++ b/src/utils/rootkeypackage_utils/tests/testapp/src/main.cpp
@@ -7,10 +7,15 @@
  */
 #include <aduc/c_utils.h>
 #include <aduc/file_test_utils.hpp>
-#include <aduc/rootkeypackage_do_download.h>
 #include <aduc/rootkeypackage_utils.h>
 #include <azure_c_shared_utility/strings.h>
 #include <string>
+
+#if ROOTKEY_PKG_DOWNLOAD_USE_CURL == 1
+#    include <aduc/rootkeypackage_curl_download.h>
+#else
+#    include <aduc/rootkeypackage_do_download.h>
+#endif
 
 #define ROOTKEY_PKG_URL "http://localhost:8083/rootkey.json"
 #define WORKFLOW_ID "7cf7241f-9ede-3e37-ca72-a7593bd7fc0f"
@@ -29,8 +34,13 @@ int main(int argc, char** argv)
     ADUC_RootKeyPackage rootKeyPackage{};
 
     ADUC_RootKeyPkgDownloaderInfo downloaderInfo{
+#if ROOTKEY_PKG_DOWNLOAD_USE_CURL == 1
+        "Curl",
+        DownloadRootKeyPkg_Curl,
+#else
         "DO",
         DownloadRootKeyPkg_DO,
+#endif
         "/tmp/deviceupdate/rootkey_download_test_app",
     };
 

--- a/tools/download_file/main.cpp
+++ b/tools/download_file/main.cpp
@@ -9,7 +9,7 @@
 #include <string.h>
 
 //fwd-decl
-ADUC_Result DownloadRootKeyPkg_DO(const char* url, const char* targetFilePath);
+ADUC_Result DownloadRootKeyPkg_Test_DO(const char* url, const char* targetFilePath);
 
 //decls
 typedef int32_t ADUC_Result_t;
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
 
     if (g_SimMode == SimMode_DOWNLOAD_ROOTKEY_PKG)
     {
-        result = DownloadRootKeyPkg_DO(g_arg_url, g_arg_out_filepath);
+        result = DownloadRootKeyPkg_Test_DO(g_arg_url, g_arg_out_filepath);
     }
     else if (g_SimMode == SimMode_DOWNLOAD_UPDATE_PAYLOAD)
     {
@@ -132,7 +132,7 @@ int main(int argc, char** argv)
 }
 
 // Ported from src/utils/rootkeypackage_utils/src/rootkeypackage_do_download.cpp
-ADUC_Result DownloadRootKeyPkg_DO(const char* url, const char* targetFilePath)
+ADUC_Result DownloadRootKeyPkg_Test_DO(const char* url, const char* targetFilePath)
 {
     ADUC_Result result = {};
 


### PR DESCRIPTION
- Add ADUC_ROOTKEY_PKG_DOWNLOAD_WITH_CURL option in CMakelist.txt that sets compiler definition ROOTKEY_PKG_DOWNLOAD_USE_CURL to 1
- Add --rootkeypkg-curl option to build.sh that sets -DADUC_ROOTKEY_PKG_DOWNLOAD_WITH_CURL=true
- Add DownloadRootKeyPkg_Curl
- Conditionally compile `DownloadRootKeyPkg_Curl` or `DownloadRootKeyPkg_DO` based on ROOTKEY_PKG_DOWNLOAD_USE_CURL CompilerDefinition
- Remove `-O` (`--remote-name`) from Curl Content Downloader since -o is absolute file path to avoid `"Warning: Got more output options than URLs"`
- Add `-L` (`--location`) to curl cmd-line to handle 3xx redirects
- Add `-C -` to direct curl to auto-resume downloads
- Update tools and tests accordingly

Addresses these 2 github issues:
- https://github.com/Azure/iot-hub-device-update/issues/711
- https://github.com/Azure/iot-hub-device-update/issues/715