### PR TITLE
Fix crash when fmt specifier exists in scriptOutput string

### DIFF
--- a/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
+++ b/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
@@ -260,7 +260,7 @@ ADUC_Result SWUpdateHandler_PerformAction(
 
     if (!scriptOutput.empty())
     {
-        Log_Info(scriptOutput.c_str());
+        Log_Info("%s\n", scriptOutput.c_str());
     }
 
     // Parse result file.


### PR DESCRIPTION
if something like `%s` exists in the script output, it can crash because there was no format specifier (so the string value itself is the format string).