### PR TITLE
Fix 15 IMPORTANT Severity CODEQL cmp narrow with wide in loop condition

### DIFF
--- a/src/diagnostics_component/utils/file_info_utils/src/file_info_utils.c
+++ b/src/diagnostics_component/utils/file_info_utils/src/file_info_utils.c
@@ -169,7 +169,7 @@ done:
     if (!succeeded)
     {
         // Free all the file names, if allocated.
-        for (int i = 0; i < logFileSize; ++i)
+        for (size_t i = 0; i < logFileSize; ++i)
         {
             free(logFiles[i].fileName);
             memset(&logFiles[i], 0, sizeof(FileInfo));

--- a/src/diagnostics_component/utils/file_upload_utils/src/blob_storage_helper.cpp
+++ b/src/diagnostics_component/utils/file_upload_utils/src/blob_storage_helper.cpp
@@ -76,7 +76,7 @@ bool AzureBlobStorageHelper::UploadFilesToContainer(
     }
 
     size_t fileNameSize = VECTOR_size(fileNames);
-    for (unsigned int i = 0; i < fileNameSize; ++i)
+    for (size_t i = 0; i < fileNameSize; ++i)
     {
         auto fileNameHandle = static_cast<const STRING_HANDLE*>(VECTOR_element(fileNames, i));
         const char* fileName = STRING_c_str(*fileNameHandle);

--- a/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/source_update_cache/src/source_update_cache_utils.c
+++ b/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler/source_update_cache/src/source_update_cache_utils.c
@@ -46,7 +46,7 @@ static STRING_HANDLE encodeBase64ForFilePath(const char* unencoded)
     // For '+', '/', and '=', encode using '_' followed by 2-digit hex ascii code.
 
     lengthUnencoded = strlen(unencoded);
-    for (int index = 0; index < lengthUnencoded; ++index)
+    for (size_t index = 0; index < lengthUnencoded; ++index)
     {
         switch (unencoded[index])
         {

--- a/src/extensions/step_handlers/script_handler/src/script_handler.cpp
+++ b/src/extensions/step_handlers/script_handler/src/script_handler.cpp
@@ -366,7 +366,7 @@ ADUC_Result ScriptHandlerImpl::PrepareScriptArguments(
 
     Log_Info("Parsing script arguments: %s", arguments);
     argumentList = ADUC::StringUtils::Split(fileArgs, ' ');
-    for (int i = 0; i < argumentList.size(); i++)
+    for (size_t i = 0; i < argumentList.size(); i++)
     {
         const std::string argument = argumentList[i];
         if (!argument.empty())

--- a/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
+++ b/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
@@ -738,7 +738,7 @@ ADUC_Result SWUpdateHandlerImpl::PrepareCommandArguments(
 
     Log_Info("Parsing handlerProperties.arguments: %s", arguments);
     argumentList = ADUC::StringUtils::Split(fileArgs, ' ');
-    for (int i = 0; i < argumentList.size(); i++)
+    for (size_t i = 0; i < argumentList.size(); i++)
     {
         const std::string argument = argumentList[i];
         if (!argument.empty())

--- a/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
+++ b/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
@@ -350,7 +350,7 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
 
     result = { ADUC_Result_Download_Success };
 
-    for (int i = 0; i < fileCount; i++)
+    for (size_t i = 0; i < fileCount; i++)
     {
         Log_Info("Downloading file #%d", i);
 

--- a/src/utils/c_utils/src/string_c_utils.c
+++ b/src/utils/c_utils/src/string_c_utils.c
@@ -427,7 +427,7 @@ char* ADUC_StringUtils_Map(const char* src, int (*mapFn)(int))
         return NULL;
     }
 
-    for (int i = 0; i <= len; ++i)
+    for (size_t i = 0; i <= len; ++i)
     {
         int ret = mapFn(src[i]);
 

--- a/src/utils/d2c_messaging/src/d2c_messaging.c
+++ b/src/utils/d2c_messaging/src/d2c_messaging.c
@@ -271,7 +271,7 @@ static void DefaultIoTHubSendReportedStateCompletedCallback(int http_status_code
         goto done;
     }
 
-    for (int i = 0; i < message_processing_context->retryStrategy->httpStatusRetryInfoSize; i++)
+    for (size_t i = 0; i < message_processing_context->retryStrategy->httpStatusRetryInfoSize; i++)
     {
         ADUC_D2C_HttpStatus_Retry_Info* info = &message_processing_context->retryStrategy->httpStatusRetryInfo[i];
 

--- a/src/utils/hash_utils/src/hash_utils.c
+++ b/src/utils/hash_utils/src/hash_utils.c
@@ -104,7 +104,7 @@ static bool ADUC_HashUtils_GetIndexStrongestValidHash(
     int strongestIndex = -1; // Assume hashes array is not sorted by strength ordering.
     SHAversion curBestAlg = SHA1;
 
-    for (int i = 0; i < hashCount; ++i)
+    for (size_t i = 0; i < hashCount; ++i)
     {
         SHAversion algVersion = SHA1;
         char* hashType = ADUC_HashUtils_GetHashType(hashes, hashCount, (size_t)i);

--- a/src/utils/path_utils/src/path_utils.c
+++ b/src/utils/path_utils/src/path_utils.c
@@ -35,7 +35,7 @@ STRING_HANDLE PathUtils_SanitizePathSegment(const char* unsanitized)
         return NULL;
     }
 
-    for (int i = 0; i < strlen(unsanitized); ++i)
+    for (size_t i = 0; i < strlen(unsanitized); ++i)
     {
         char c = unsanitized[i];
 

--- a/src/utils/root_key_utils/src/root_key_util.c
+++ b/src/utils/root_key_utils/src/root_key_util.c
@@ -217,7 +217,7 @@ bool RootKeyUtility_GetHardcodedKeysAsAducRootKeys(VECTOR_HANDLE* aducRootKeyVec
 
     const size_t rsaKeyListSize = RootKeyList_numHardcodedKeys();
 
-    for (int i = 0; i < rsaKeyListSize; ++i)
+    for (size_t i = 0; i < rsaKeyListSize; ++i)
     {
         RSARootKey key = rsaKeyList[i];
 

--- a/src/utils/workflow_utils/src/workflow_utils.c
+++ b/src/utils/workflow_utils/src/workflow_utils.c
@@ -266,7 +266,7 @@ static bool ADUC_RelatedFile_Init(
         goto done;
     }
 
-    for (int i = 0; i < hashCount; ++i)
+    for (size_t i = 0; i < hashCount; ++i)
     {
         if (!ADUC_Hash_Init(&tempHashArray[i], hashes[i].value, hashes[i].type))
         {

--- a/src/utils/workflow_utils/src/workflow_utils.c
+++ b/src/utils/workflow_utils/src/workflow_utils.c
@@ -365,7 +365,7 @@ static bool workflow_init_update_file_inodes(ADUC_Workflow* wf)
         return false;
     }
 
-    for (int i = 0; i < count; ++i)
+    for (size_t i = 0; i < count; ++i)
     {
         wf->UpdateFileInodes[i] = ADUC_INODE_SENTINEL_VALUE;
     }

--- a/src/utils/workflow_utils/src/workflow_utils.c
+++ b/src/utils/workflow_utils/src/workflow_utils.c
@@ -281,7 +281,7 @@ static bool ADUC_RelatedFile_Init(
         goto done;
     }
 
-    for (int i = 0; i < propertiesCount; ++i)
+    for (size_t i = 0; i < propertiesCount; ++i)
     {
         if (!ADUC_Property_Init(&tempPropertiesArray[i], properties[i].Name, properties[i].Value))
         {


### PR DESCRIPTION
Fixes all 15 the `IMPORTANT` severity CODEQL security issues with following Query Name:
`"Comparison of narrow type with wide type in loop condition"`