### PR TITLE
curl rootkey download feedback

### DIFF
--- a/src/agent/command_helper/src/command_helper.c
+++ b/src/agent/command_helper/src/command_helper.c
@@ -274,19 +274,23 @@ static void* ADUC_CommandListenerThread(void* unused)
                     continue;
                 }
 
-                char* safeCommandLine = (char*)malloc(readSize + 1);
-                if (safeCommandLine != NULL)
+                if (readSize > 0)
                 {
-                    memcpy(safeCommandLine, commandLine, readSize);
-                    safeCommandLine[readSize] = '\0';
-
-                    if (strncmp(safeCommandLine, g_commands[i]->commandText, readSize) == 0)
+                    size_t safeReadSize = (size_t)readSize;
+                    char* safeCommandLine = (char*)malloc(safeReadSize + 1);
+                    if (safeCommandLine != NULL)
                     {
-                        matchedCommand = g_commands[i];
+                        memcpy(safeCommandLine, commandLine, readSize);
+                        safeCommandLine[readSize] = '\0';
+
+                        if (strncmp(safeCommandLine, g_commands[i]->commandText, safeReadSize) == 0)
+                        {
+                            matchedCommand = g_commands[i];
+                            free(safeCommandLine);
+                            break;
+                        }
                         free(safeCommandLine);
-                        break;
                     }
-                    free(safeCommandLine);
                 }
             }
         }

--- a/src/utils/rootkeypackage_utils/src/rootkeypackage_curl_download.cpp
+++ b/src/utils/rootkeypackage_utils/src/rootkeypackage_curl_download.cpp
@@ -62,6 +62,7 @@ ADUC_Result DownloadRootKeyPkg_Curl(const char* url, const char* targetFilePath)
         {
             result.ResultCode = ADUC_Result_Failure;
             result.ExtendedResultCode = ADUC_ERROR_CURL_DOWNLOADER_EXTERNAL_FAILURE(exitCode);
+            Log_Error("Curl process error, exitCode: %d\nDownload output: \n%s\n", exitCode, output.c_str());
         }
     }
     catch (...)

--- a/src/utils/rootkeypackage_utils/src/rootkeypackage_curl_download.cpp
+++ b/src/utils/rootkeypackage_utils/src/rootkeypackage_curl_download.cpp
@@ -38,6 +38,9 @@ ADUC_Result DownloadRootKeyPkg_Curl(const char* url, const char* targetFilePath)
         args.emplace_back("-o");
         args.emplace_back(targetFilePath);
 
+        args.emplace_back("-m"); // -m, --max-time <seconds>
+        args.emplace_back("3600"); // 1 hour
+
         // Finally, tack the url onto the end
         args.emplace_back(url);
 


### PR DESCRIPTION
from here:
https://github.com/Azure/iot-hub-device-update/issues/715#issuecomment-2755316108

Changes
- [trace exitCode and output on curl failure](https://github.com/Azure/iot-hub-device-update/commit/d38075601c0b83103b1a9749b648340189c593f4)
- [add max time to align with DO download](https://github.com/Azure/iot-hub-device-update/commit/7a1f5050257158df1cb6ccfb06490f8e3c4e9ee4)
- [cast ssize_t to size_t after >0 check](https://github.com/Azure/iot-hub-device-update/pull/736/commits/786d8fd82ff569de36681cdab46be5b4935dc9b4)
