### PR TITLE
Add devcontainer with Debian 11.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+#ARG VARIANT=bookworm
+ARG VARIANT=bullseye
+FROM --platform=amd64 mcr.microsoft.com/devcontainers/base:${VARIANT}
+
+WORKDIR /iot-hub-device-update
+
+COPY ./scripts/install-deps.sh /iot-hub-device-update/
+
+# Needed for `--install-githooks` option as part of `-a`
+COPY ../.git ./.git
+
+RUN apt-get update
+
+RUN /bin/bash install-deps.sh -a
+
+# To build in the container run
+#./scripts/build.sh -c -u --build-packages 
+
+# To install
+# cd out && sudo cmake --build . --target install
+
+#RUN /bin/bash /install-deps.sh --install-aduc-deps --install-do --install-cmake --install-shellcheck --work-folder /iot-hub-device-update
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"build": { "dockerfile": "Dockerfile", "context": ".." },
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-vscode.cpptools",
+				"ms-vscode.cmake-tools",
+				"ms-python.python"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root",
+
+	// "containerUser": "root"
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,41 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(gdb) Launch AducIotAgent",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/out/bin/AducIotAgent",
+            "args": ["-l","0","-e"],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        { // From https://github.com/microsoft/vscode-cmake-tools/blob/main/docs/debug-launch.md#gdb-1
+            "name": "(ctest) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            // Resolved by CMake Tools:
+            "cwd": "${cmake.testWorkingDirectory}",
+            "program": "${cmake.testProgram}",
+            "args": [ "${cmake.testArgs}"],
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "cmake.debugConfig": {
+        "args": ["-l0","-e", "h"]
+    },
+    "cmake.buildDirectory": "${workspaceFolder}/out",
+    "cmake.cmakePath": "/tmp/deviceupdate-cmake/bin/cmake",
+    "cmake.cpackPath": "/tmp/deviceupdate-cmake/bin/cpack",
+    "cmake.ctestPath": "/tmp/deviceupdate-cmake/bin/ctest",
+}


### PR DESCRIPTION
Are you interested in having a devcontainer in this repo?

A devcontainer is quite useful for building, running the tests and also debugging.

<img width="1686" height="421" alt="image" src="https://github.com/user-attachments/assets/04e0ab28-9096-4096-89b4-2ef5baf423ef" />

<img width="2124" height="283" alt="image" src="https://github.com/user-attachments/assets/9dcd9636-f5f3-4712-afd9-ff33680879d5" />
