### PR TITLE
Remove broken Debian 10 build, reached end of life in June 30, 2024

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,11 +6,8 @@ jobs:
   container-job:
     strategy:
       matrix:
-        os: ["debian:12", "debian:11", "debian:10", "ubuntu:22.04", "ubuntu:20.04"]
+        os: ["debian:12", "debian:11", "ubuntu:22.04", "ubuntu:20.04"]
         arch: [amd64, arm64]
-        exclude:
-          - os: "debian:10"
-            arch: arm64
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-latest' }}
     container:
       image: ${{ matrix.os }}


### PR DESCRIPTION
Fix broken builds in GitHub

```sh
Ign:1 http://deb.debian.org/debian buster InRelease
Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
Ign:3 http://deb.debian.org/debian buster-updates InRelease
Err:4 http://deb.debian.org/debian buster Release
  404  Not Found [IP: 146.75.30.132 80]
Err:5 http://deb.debian.org/debian-security buster/updates Release
  404  Not Found [IP: 146.75.30.132 80]
Err:6 http://deb.debian.org/debian buster-updates Release
  404  Not Found [IP: 146.75.30.132 80]
Reading package lists...
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
Error: Process completed with exit code 100.
```

Debian 10 no longer supported, details https://wiki.debian.org/LTS/Buster
