### PR TITLE
Disable fail-fast so we can see result of build in other OS

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   container-job:
     strategy:
+      fail-fast: false
       matrix:
         os: ["debian:12", "debian:11", "debian:10", "ubuntu:22.04", "ubuntu:20.04"]
         arch: [amd64, arm64]


### PR DESCRIPTION
Right now the debian:10 build is broken (see https://github.com/Azure/iot-hub-device-update/pull/757) because it is no longer supported and the repo urls are not available, with the single broken build in Debian 10 we cannot see the result of the build in other OS.

Disable fail-fast to allow the result of Debian 11, 12, Ubuntu 20, 22 to be known.