### PR TITLE
Fix all known SDK stability issues on RPI4

### DIFF
--- a/src/agent/api/src/apisvc.c
+++ b/src/agent/api/src/apisvc.c
@@ -198,6 +198,7 @@ static void* aduc_apisvc_thread_proc(void* arg)
     int rdfifo = -1;
     int writefifo = -1;
     int open_read_retries = 0, open_write_retries = 0;
+    ssize_t sent = 0;
 
     ADUC_Logging_Init(ADUC_LOG_DEBUG, "aducapi");
 
@@ -244,7 +245,7 @@ static void* aduc_apisvc_thread_proc(void* arg)
 
     while (g_api_svc_thread_running)
     {
-        ssize_t n;
+        ssize_t n = 0;
         ApiWireRequestMsg msg = { 0 };
 
         open_write_retries = 0;
@@ -359,6 +360,12 @@ static void* aduc_apisvc_thread_proc(void* arg)
             {
                 Log_Info("Sent %d bytes for GETSTATE response status: %d", sent, status);
             }
+        }
+
+        if (sent > 0)
+        {
+            fsync(writefifo); // attempt to flush to the pipe before closing
+            usleep(50000); // 50 msec delay to allow client to read before closing the fifo
         }
 
         // Close this side of the response FIFO after handling the request

--- a/src/agent/api/src/apisvc.c
+++ b/src/agent/api/src/apisvc.c
@@ -247,6 +247,7 @@ static void* aduc_apisvc_thread_proc(void* arg)
     {
         ssize_t n = 0;
         ApiWireRequestMsg msg = { 0 };
+        int resp_fifo_keepalive = -1;
 
         open_write_retries = 0;
 
@@ -295,6 +296,18 @@ static void* aduc_apisvc_thread_proc(void* arg)
         while (writefifo == -1 && g_api_svc_thread_running && open_write_retries < 30)
         {
             ++open_write_retries;
+
+            // First, open for read to prevent EOF on client side (keep-alive descriptor)
+            if (resp_fifo_keepalive == -1)
+            {
+                resp_fifo_keepalive = open(msg.data, O_RDONLY | O_NONBLOCK);
+                if (resp_fifo_keepalive < 0)
+                {
+                    Log_Debug("Failed to open resp fifo '%s' for keep-alive read: %d", msg.data, errno);
+                }
+            }
+
+            // Now open for write
             writefifo = open(msg.data, O_WRONLY | O_NONBLOCK);
             if (writefifo < 0)
             {
@@ -309,13 +322,24 @@ static void* aduc_apisvc_thread_proc(void* arg)
         }
         if (!g_api_svc_thread_running)
         {
+            // Cleanup before breaking
+            if (resp_fifo_keepalive != -1)
+            {
+                close(resp_fifo_keepalive);
+                resp_fifo_keepalive = -1;
+            }
             break;
         }
 
         if (writefifo == -1)
         {
             Log_Error("Failed to open response fifo for write after %d retries", open_write_retries);
-            // Don't set extended result code here - just skip this request and continue
+            // Cleanup and skip this request
+            if (resp_fifo_keepalive != -1)
+            {
+                close(resp_fifo_keepalive);
+                resp_fifo_keepalive = -1;
+            }
             usleep(OnErrorDelayMicrosecs);
             continue;
         }
@@ -330,6 +354,11 @@ static void* aduc_apisvc_thread_proc(void* arg)
             {
                 close(writefifo);
                 writefifo = -1;
+            }
+            if (resp_fifo_keepalive != -1)
+            {
+                close(resp_fifo_keepalive);
+                resp_fifo_keepalive = -1;
             }
             usleep(OnErrorDelayMicrosecs);
             continue;
@@ -373,6 +402,13 @@ static void* aduc_apisvc_thread_proc(void* arg)
         {
             close(writefifo);
             writefifo = -1;
+        }
+
+        // Close keep-alive descriptor last to prevent EOF
+        if (resp_fifo_keepalive != -1)
+        {
+            close(resp_fifo_keepalive);
+            resp_fifo_keepalive = -1;
         }
     }
 

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -10,17 +10,26 @@ add_library (aduc::sdk ALIAS ${target_name})
 
 target_sources(${target_name} PRIVATE src/aducsdk.c)
 
+# Include apiproto source directly to avoid logging dependency
+# We compile it with ADUC_APIPROTO_NO_LOGGING to disable logging
+target_sources(${target_name} PRIVATE ${CMAKE_SOURCE_DIR}/src/utils/apiproto_utils/src/apiproto.c)
+
 target_include_directories (${target_name}
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
         $<INSTALL_INTERFACE:include>
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/utils/apiproto_utils/inc
+        ${CMAKE_SOURCE_DIR}/src/utils/c_utils/inc
 )
 
-target_link_libraries(${target_name} PRIVATE aduc::apiproto_utils)
+# Link only c_utils, not apiproto_utils (we compile apiproto.c directly)
+target_link_libraries(${target_name} PRIVATE aduc::c_utils)
 
 target_compile_definitions (
     ${target_name} PRIVATE ADUC_API_DEFAULT_FIFO_PATH="${ADUC_API_DEFAULT_FIFO_PATH}"
-                           ADUC_DATA_FOLDER="${ADUC_DATA_FOLDER}")
+                           ADUC_DATA_FOLDER="${ADUC_DATA_FOLDER}"
+                           ADUC_APIPROTO_NO_LOGGING=1)
 
 include(GNUInstallDirs)
 

--- a/src/sdk/src/aducsdk.c
+++ b/src/sdk/src/aducsdk.c
@@ -6,6 +6,11 @@
  * Licensed under the MIT License.
  */
 
+// Define _GNU_SOURCE before any includes to get secure_getenv() on glibc systems
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <aduc/aducsdk.h>
 #include <aduc/apiproto.h>
 
@@ -110,6 +115,11 @@ ADUC_ServiceStatus GetAduServiceStatus(void)
     ApiWireRequestMsg req = { 0 };
     ApiWireResponseMsg resp = { 0 };
 
+    // Use secure_getenv() to prevent privilege escalation attacks when running with elevated privileges
+    // secure_getenv() returns NULL if the program is setuid/setgid, preventing environment tampering
+    const char* debug_env = secure_getenv("ADUC_SDK_DEBUG");
+    const bool debug_enabled = (debug_env != NULL && debug_env[0] != '\0');
+
     if (!verify_fifo_security(reqFifoPath))
     {
         return ADUC_ServiceStatus_ERROR_AgentServiceNotRunning;
@@ -169,23 +179,76 @@ ADUC_ServiceStatus GetAduServiceStatus(void)
     req = (ApiWireRequestMsg){ .ver = 1, .type = ApiRequestType_GETSTATE, .len = (uint16_t)respPathLen };
     memcpy(req.data, respFifoPath, respPathLen);
 
-    respFifo = open(respFifoPath, O_RDONLY | O_NONBLOCK); // open resp fifo first for read
+    // Open response FIFO for read first (before sending request)
+    // This must be done BEFORE sending the request to avoid deadlock and EOF issues
+    int open_retries = 0;
+    const int MAX_OPEN_RETRIES = 3;
+    while (respFifo == -1 && open_retries < MAX_OPEN_RETRIES)
+    {
+        respFifo = open(respFifoPath, O_RDONLY | O_NONBLOCK);
+        if (respFifo == -1)
+        {
+            if (debug_enabled)
+            {
+                fprintf(stderr, "[ADUC SDK] Failed to open response FIFO '%s' for read (attempt %d/%d): errno=%d (%s)\n",
+                        respFifoPath, open_retries + 1, MAX_OPEN_RETRIES, errno, strerror(errno));
+            }
+            open_retries++;
+            if (open_retries < MAX_OPEN_RETRIES)
+            {
+                usleep(50000); // 50ms retry delay
+            }
+        }
+    }
+
     if (respFifo == -1)
     {
+        // This is semi-catastrophic - we just created this FIFO and can't open it
+        if (debug_enabled)
+        {
+            fprintf(stderr, "[ADUC SDK] CRITICAL: Cannot open response FIFO after %d attempts\n", MAX_OPEN_RETRIES);
+        }
         result = ADUC_ServiceStatus_ERROR_AgentServiceSdkOpenRespFifoFailed;
         goto cleanup;
+    }
+
+    if (debug_enabled)
+    {
+        fprintf(stderr, "[ADUC SDK] Response FIFO opened successfully: fd=%d\n", respFifo);
+    }
+
+    // Send request to service
+    if (debug_enabled)
+    {
+        fprintf(stderr, "[ADUC SDK] Sending GETSTATE request to service...\n");
     }
 
     n = msg_send_req(reqFifo, &req);
     if (n != (ssize_t)(3 * sizeof(uint16_t) + respPathLen))
     {
+        if (debug_enabled)
+        {
+            fprintf(stderr, "[ADUC SDK] Failed to send request: sent %zd bytes, expected %zu\n",
+                    n, (size_t)(3 * sizeof(uint16_t) + respPathLen));
+        }
         result = ADUC_ServiceStatus_ERROR_AgentServiceBrokenPipe;
         goto cleanup;
     }
 
+    if (debug_enabled)
+    {
+        fprintf(stderr, "[ADUC SDK] Request sent successfully (%zd bytes), waiting for response...\n", n);
+    }
+
+    // Wait for response from service
     n = msg_recv_resp(respFifo, &resp);
     if (n != sizeof(resp))
     {
+        if (debug_enabled)
+        {
+            fprintf(stderr, "[ADUC SDK] Failed to receive response: got %zd bytes, expected %zu\n",
+                    n, sizeof(resp));
+        }
         if (n == -1)
         {
             result = ADUC_ServiceStatus_ERROR_RecvMsgFailed;
@@ -198,6 +261,12 @@ ADUC_ServiceStatus GetAduServiceStatus(void)
     }
 
     result = (ADUC_ServiceStatus)(resp.ret_val);
+
+    if (debug_enabled)
+    {
+        fprintf(stderr, "[ADUC SDK] Response received successfully: code=%u, ret_val=%u (%s)\n",
+                resp.code, resp.ret_val, ADUC_ServiceStatusToString(result));
+    }
 
 cleanup:
     if (reqFifo != -1)

--- a/src/utils/apiproto_utils/src/apiproto.c
+++ b/src/utils/apiproto_utils/src/apiproto.c
@@ -81,7 +81,7 @@ static ssize_t _wait_until_bytes_avail_for_read(int fd)
         FD_ZERO(&read_fds);
         FD_SET(fd, &read_fds);
         sel_timeout.tv_sec = 0;
-        sel_timeout.tv_usec = 150000; // 150 ms in microseconds
+        sel_timeout.tv_usec = 500000; // 500 ms in microseconds (increased for ARM systems)
 
         rdy = select(fd + 1, &read_fds, NULL, NULL, &sel_timeout);
         if (rdy > 0 && FD_ISSET(fd, &read_fds))
@@ -214,13 +214,28 @@ ssize_t msg_send_resp(int fd, const ApiWireResponseMsg* msg)
 {
     char write_buf[RESP_MSG_READ_BUF_SIZE] = { 0 };
     ssize_t bytes_written = -1;
+    int retries = 0;
+    const int MAX_WRITE_RETRIES = 10;
 
     uint16_t v = htons(msg->code);
     memcpy(write_buf, &v, sizeof(uint16_t));
     v = htons(msg->ret_val);
     memcpy(write_buf + sizeof(uint16_t), &v, sizeof(uint16_t));
 
+retry_write:
     bytes_written = write(fd, write_buf, sizeof(write_buf));
+    if (bytes_written < 0)
+    {
+        if ((errno == EAGAIN || errno == EWOULDBLOCK) && retries < MAX_WRITE_RETRIES)
+        {
+            retries++;
+            usleep(10000); // 10ms
+            goto retry_write;
+        }
+        Log_Error("msg_send_resp: write error: %d (%s)", errno, strerror(errno));
+        return -1;
+    }
+
     if (bytes_written != sizeof(write_buf))
     {
         Log_Error("msg_send_resp: wrote %zd, expected %zu", bytes_written, sizeof(write_buf));
@@ -232,22 +247,42 @@ ssize_t msg_send_resp(int fd, const ApiWireResponseMsg* msg)
 
 ssize_t msg_recv_resp(int fd, ApiWireResponseMsg* out_msg)
 {
-    ssize_t total_bytes_read = 0, bytes_read = -1, wait_res = -1;
+    ssize_t total_bytes_read = 0, bytes_read = -1;
     uint16_t msg_code = 0, msg_ret_val = 0;
     char read_buf[RESP_MSG_READ_BUF_SIZE] = { 0 };
+    int retries = 0;
+    const int MAX_RETRIES = 20; // ~3 seconds total with 150ms sleeps
 
-    while (total_bytes_read < (ssize_t)(RESP_MSG_READ_BUF_SIZE))
+    // Single select call with longer timeout for entire message
+    fd_set read_fds;
+    struct timeval timeout;
+    FD_ZERO(&read_fds);
+    FD_SET(fd, &read_fds);
+    timeout.tv_sec = 3;  // 3 second timeout
+    timeout.tv_usec = 0;
+
+    int rdy = select(fd + 1, &read_fds, NULL, NULL, &timeout);
+    if (rdy <= 0)
     {
-        if ((wait_res = _wait_until_bytes_avail_for_read(fd)) < 0)
+        if (rdy == 0)
         {
-            return wait_res;
+            Log_Warn("msg_recv_resp: timeout waiting for response");
+            return MSGREV_AGAIN;
         }
+        Log_Error("msg_recv_resp: select error: %d (%s)", errno, strerror(errno));
+        return -1;
+    }
 
+    // Now read without select in loop - data is available
+    while (total_bytes_read < (ssize_t)(RESP_MSG_READ_BUF_SIZE) && retries < MAX_RETRIES)
+    {
         bytes_read = read(fd, read_buf + total_bytes_read, RESP_MSG_READ_BUF_SIZE - total_bytes_read);
         if (bytes_read < 0)
         {
-            if (errno == EINTR)
+            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
             {
+                retries++;
+                usleep(150000); // 150ms
                 continue;
             }
             Log_Error("msg_recv_resp: read error: %d (%s)", errno, strerror(errno));
@@ -255,9 +290,23 @@ ssize_t msg_recv_resp(int fd, ApiWireResponseMsg* out_msg)
         }
         if (bytes_read == 0)
         {
-            break; // EOF
+            // EOF - writer closed before we got all data
+            if (total_bytes_read == 0)
+            {
+                // No data yet, retry a few times for slow ARM systems
+                retries++;
+                usleep(150000); // 150ms
+                continue;
+            }
+            break;
         }
         total_bytes_read += bytes_read;
+    }
+
+    if (total_bytes_read < RESP_MSG_READ_BUF_SIZE)
+    {
+        Log_Error("msg_recv_resp: incomplete message: %zd/%zu bytes", total_bytes_read, RESP_MSG_READ_BUF_SIZE);
+        return -1;
     }
 
     memcpy(&msg_code, read_buf, sizeof(uint16_t));

--- a/src/utils/apiproto_utils/src/apiproto.c
+++ b/src/utils/apiproto_utils/src/apiproto.c
@@ -8,7 +8,16 @@
 
 #include "aduc/apiproto.h"
 #include "aduc/c_utils.h"
-#include "aduc/logging.h"
+
+#ifndef ADUC_APIPROTO_NO_LOGGING
+#    include "aduc/logging.h"
+#else
+// Define no-op logging macros when logging is disabled
+#    define Log_Error(...)
+#    define Log_Warn(...)
+#    define Log_Info(...)
+#    define Log_Debug(...)
+#endif
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -133,7 +142,7 @@ ssize_t msg_recv_req(int fd, ApiWireRequestMsg* out_msg)
             return wait_res;
         }
 
-        br = read(fd, ((char*)header_buf) + bytes_read_total, (MSG_HDR_LEN) - bytes_read_total);
+        br = read(fd, ((char*)header_buf) + bytes_read_total, (MSG_HDR_LEN)-bytes_read_total);
         if (br < 0)
         {
             if (errno == EINTR)
@@ -258,7 +267,7 @@ ssize_t msg_recv_resp(int fd, ApiWireResponseMsg* out_msg)
     struct timeval timeout;
     FD_ZERO(&read_fds);
     FD_SET(fd, &read_fds);
-    timeout.tv_sec = 3;  // 3 second timeout
+    timeout.tv_sec = 3; // 3 second timeout
     timeout.tv_usec = 0;
 
     int rdy = select(fd + 1, &read_fds, NULL, NULL, &timeout);


### PR DESCRIPTION
- Open for read to prevent EOF on client side (keep-alive descriptor) and clean it up
- Flush resp fifo and add some delay
- Remove by zlog dep by aducsdk that creeped in
- Add stderr proto traces if ADUC_SDK_DEBUG env var is set
- Add open resp fifo retries
- Increase select timeout to 500000 (500 ms)
- Retry write to resp fifo if errno == EAGAIN || errno == EWOULDBLOCK up to MAX_WRITE_RETRIES
- Use single select call to detect data ready to read and remove from loop
- Retry reads if errno == EAGAIN || errno == EWOULDBLOCK up to MAX_RETRIES with 150ms usleep between