### PR TITLE
Fix #749 - Add build steps in CI for Ubuntu 24.04 (noble)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["debian:12", "debian:11", "ubuntu:22.04", "ubuntu:20.04"]
+        os: ["debian:12", "debian:11", "ubuntu:24.04", "ubuntu:22.04", "ubuntu:20.04"]
         arch: [amd64, arm64]
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-latest' }}
     container:

--- a/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
+++ b/azurepipelines/build/native/adu-ubuntu-amd64-build.yml
@@ -123,3 +123,16 @@ extends:
                 parameters:
                   targetOs: "ubuntu2204"
                   targetArch: "amd64"
+
+          - job: BuildAduAgent_ubuntu2404
+            displayName: "Build ADU Agent - Ubuntu 24.04 (amd64)"
+            timeoutInMinutes: 120
+            cancelTimeoutInMinutes: 120
+            pool:
+              name: aduc_1es_client_pool
+              os: linux
+            steps:
+              - template: /azurepipelines/build/templates/adu-native-build-steps.yml@self
+                parameters:
+                  targetOs: "ubuntu2404"
+                  targetArch: "amd64"

--- a/azurepipelines/build/native/adu-ubuntu-arm64-build.yml
+++ b/azurepipelines/build/native/adu-ubuntu-arm64-build.yml
@@ -108,3 +108,16 @@ extends:
                 parameters:
                   targetOs: "ubuntu2204"
                   targetArch: "arm64"
+
+          - job: BuildAduAgent_ubuntu2404
+            displayName: "Build ADU Agent - Ubuntu 24.04 (arm64)"
+            timeoutInMinutes: 120
+            cancelTimeoutInMinutes: 120
+            pool:
+              name: aduc_1es_client_pool
+              os: linux
+            steps:
+              - template: /azurepipelines/build/templates/adu-native-build-steps.yml@self
+                parameters:
+                  targetOs: "ubuntu2404"
+                  targetArch: "arm64"


### PR DESCRIPTION
Update CI: Add Ubuntu 24.04 to the list of target builds.

Solving issue: #749 