### PR TITLE
Fix leaks

### DIFF
--- a/src/agent/adu_core_interface/src/device_properties.c
+++ b/src/agent/adu_core_interface/src/device_properties.c
@@ -87,6 +87,8 @@ bool DeviceProperties_AddManufacturerAndModel(JSON_Object* devicePropsObj, const
     success = true;
 
 done:
+    free(manufacturer);
+    free(model);
     if (!success)
     {
         Log_Error("Failed to get manufacturer and model device properties");

--- a/src/extensions/extension_manager/src/extension_manager_helper.cpp
+++ b/src/extensions/extension_manager/src/extension_manager_helper.cpp
@@ -144,6 +144,7 @@ unsigned int GetDownloadTimeoutInMinutes(const ExtensionManager_Download_Options
         Log_Info("downloadTimeoutInMinutes override from config: %u", config->downloadTimeoutInMinutes);
         ret = config->downloadTimeoutInMinutes;
     }
+    ADUC_ConfigInfo_ReleaseInstance(config);
 done:
     return ret;
 }

--- a/src/utils/config_utils/src/config_utils.c
+++ b/src/utils/config_utils/src/config_utils.c
@@ -690,6 +690,7 @@ void ADUC_ConfigInfo_UnInit(ADUC_ConfigInfo* config)
     free(config->extensionsStepHandlerFolder);
     free(config->extensionsDownloadHandlerFolder);
 
+    ADUC_AgentInfoArray_Free(config->agentCount, config->agents);
     json_value_free(config->rootJsonValue);
     memset(config, 0, sizeof(*config));
 }


### PR DESCRIPTION
Ran with `valgrind --leak-check=full --track-origins=yes --log-file=valgrind.log --verbose  ./out/bin/AducIotAgent -l 0 -e`

Thanks to my colleague Martin Rieva for finding and helping with the fix.

config_utils.c:388

```sh
==1575261== 274 (88 direct, 186 indirect) bytes in 1 blocks are definitely lost in loss record 696 of 783
==1575261==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==1575261==    by 0x146901: ADUC_Json_GetAgents (config_utils.c:388)
==1575261==    by 0x146D40: ADUC_ConfigInfo_Init (config_utils.c:515)
==1575261==    by 0x14772D: ADUC_ConfigInfo_GetInstance (config_utils.c:809)
==1575261==    by 0x13E365: main (main.c:925)
==1575261== 
==1575261== 274 (88 direct, 186 indirect) bytes in 1 blocks are definitely lost in loss record 697 of 783
==1575261==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==1575261==    by 0x881F21C: ADUC_Json_GetAgents (config_utils.c:388)
==1575261==    by 0x881F65B: ADUC_ConfigInfo_Init (config_utils.c:515)
==1575261==    by 0x8820048: ADUC_ConfigInfo_GetInstance (config_utils.c:808)
==1575261==    by 0x8818CAA: ScriptHandler_PerformAction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tagADUC_WorkflowData const*, bool) (script_handler.cpp:541)
==1575261==    by 0x8819ECE: ScriptHandlerImpl::PerformAction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tagADUC_WorkflowData const*) (script_handler.cpp:741)
==1575261==    by 0x881A146: ScriptHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (script_handler.cpp:794)
==1575261==    by 0x876025F: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1399)
==1575261==    by 0x87604B9: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1480)
==1575261==    by 0x876025F: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1399)
==1575261==    by 0x87604B9: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1480)
==1575261==    by 0x18C957: ADUC::LinuxPlatformLayer::IsInstalled(tagADUC_WorkflowData const*) (linux_adu_core_impl.cpp:329)
```

[valgrind_before.log](https://github.com/user-attachments/files/23680884/valgrind_before.log)

After the change no longer reporting that particular leak:
[valgrind_fixed.log](https://github.com/user-attachments/files/23680886/valgrind_fixed.log)

