### PR TITLE
Fix memory leaks reported by Valgrind

### DIFF
--- a/src/agent/adu_core_interface/src/adu_core_interface.c
+++ b/src/agent/adu_core_interface/src/adu_core_interface.c
@@ -417,14 +417,12 @@ void OrchestratorUpdateCallback(
     }
 
     ADUC_Workflow_HandlePropertyUpdate(workflowData, (const unsigned char*)jsonString, sourceContext->forceUpdate);
-    free(jsonString);
-    jsonString = ackString;
 
     // ACK the request.
     jsonToSend = PnP_CreateReportedPropertyWithStatus(
         g_aduPnPComponentName,
         g_aduPnPComponentServicePropertyName,
-        jsonString,
+        ackString,
         PNP_STATUS_SUCCESS,
         "", // Description for this acknowledgement.
         propertyVersion);
@@ -455,6 +453,7 @@ done:
     workflow_free_string(workFolder);
     STRING_delete(jsonToSend);
     free(jsonString);
+    free(ackString);
 
     Log_Info("OrchestratorPropertyUpdateCallback ended");
 }

--- a/src/agent/command_helper/src/command_helper.c
+++ b/src/agent/command_helper/src/command_helper.c
@@ -408,4 +408,10 @@ void UninitializeCommandListenerThread()
 {
     Log_Info("De-initializing command listener thread");
     g_terminate_thread_request = true;
+    if (g_commandListenerThreadCreated)
+    {
+        pthread_cancel(g_commandListenerThread);
+        pthread_join(g_commandListenerThread, NULL);
+        g_commandListenerThreadCreated = false;
+    }
 }

--- a/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
@@ -117,6 +117,7 @@ ADUC_Result PrepareStepsWorkflowDataObject(ADUC_WorkflowHandle handle)
                     workflowLevel,
                     i,
                     selectedComponents);
+                free(const_cast<char*>(selectedComponents));
 
                 // Create child workflow using inline step data.
                 result = workflow_create_from_inline_step(handle, i, &childHandle);


### PR DESCRIPTION
Fix memory leaks reported by running

```sh
valgrind --leak-check=full --track-origins=yes --log-file=valgrind.log --verbose  ./out/bin/AducIotAgent -l 0 -e
```

Work done in collaboration with @MartinRieva-Zoetis

Before the fixes:
[Uploading valgrind_2025-11-25_before.log…]()

After the fixes:
[valgrind.log](https://github.com/user-attachments/files/23744523/valgrind.log)
