### PR TITLE
Fix memory leak in WorkflowHandle.

### DIFF
--- a/src/agent/adu_core_interface/src/adu_core_interface.c
+++ b/src/agent/adu_core_interface/src/adu_core_interface.c
@@ -119,6 +119,7 @@ void ADUC_WorkflowData_Uninit(ADUC_WorkflowData* workflowData)
     }
 
     workflow_free_string(workflowData->LastCompletedWorkflowId);
+    workflow_free(workflowData->WorkflowHandle);
     memset(workflowData, 0, sizeof(*workflowData));
 }
 


### PR DESCRIPTION
Thanks again to @MartinRieva-Zoetis for the help on this.

Details:
```
==9883== 62,664 (152 direct, 62,512 indirect) bytes in 1 blocks are definitely lost in loss record 744 of 744
==9883==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==9883==    by 0x192B5A: _workflow_parse (workflow_utils.c:1258)
==9883==    by 0x19547C: workflow_init (workflow_utils.c:2886)
==9883==    by 0x1428B6: ADUC_Workflow_HandlePropertyUpdate (agent_workflow.c:431)
==9883==    by 0x140BA2: OrchestratorUpdateCallback (adu_core_interface.c:419)
==9883==    by 0x140D49: AzureDeviceUpdateCoreInterface_PropertyUpdateCallback (adu_core_interface.c:481)
==9883==    by 0x13DB09: ADUC_PnP_ComponentClient_PropertyUpdate_Callback (main.c:554)
==9883==    by 0x15284D: VisitComponentProperties (pnp_protocol.c:216)
==9883==    by 0x152A43: VisitDesiredObject (pnp_protocol.c:289)
==9883==    by 0x152C24: PnP_ProcessTwinData (pnp_protocol.c:369)
==9883==    by 0x13DC98: ADUC_PnPDeviceTwin_Callback (main.c:628)
==9883==    by 0x1BA6C0: IoTHubClientCore_LL_RetrievePropertyComplete (in /workspaces/iot-hub-device-update/out/bin/AducIotAgent)
```