### PR TITLE
Fix leak in root_key_util.c

### DIFF
--- a/src/utils/root_key_utils/src/root_key_util.c
+++ b/src/utils/root_key_utils/src/root_key_util.c
@@ -817,7 +817,7 @@ ADUC_Result RootKeyUtility_LoadSerializedPackage(const char* fileLocation, char*
 done:
 
     free(rootKeyPackageJsonString);
-
+    json_value_free(rootKeyPackageValue);
     return result;
 }
 


### PR DESCRIPTION
Thanks to @MartinRieva-Zoetis

Details:

```
==284340== 9,347 (32 direct, 9,315 indirect) bytes in 1 blocks are definitely lost in loss record 442 of 442
==284340==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==284340==    by 0x2DA690: json_value_init_object (in /workspaces/iot-hub-device-update/out/bin/AducIotAgent)
==284340==    by 0x2D7DF9: parse_object_value (in /workspaces/iot-hub-device-update/out/bin/AducIotAgent)
==284340==    by 0x2D7D63: parse_value (in /workspaces/iot-hub-device-update/out/bin/AducIotAgent)
==284340==    by 0x2D9D5A: json_parse_string (in /workspaces/iot-hub-device-update/out/bin/AducIotAgent)
==284340==    by 0x2D9C86: json_parse_file (in /workspaces/iot-hub-device-update/out/bin/AducIotAgent)
==284340==    by 0x1A380A: RootKeyUtility_LoadSerializedPackage (root_key_util.c:795)
==284340==    by 0x1A3174: RootKeyUtility_LoadPackageFromDisk (root_key_util.c:540)
==284340==    by 0x1A30C5: RootKeyUtility_ReloadPackageFromDisk (root_key_util.c:510)
==284340==    by 0x1A3946: ADUC_RootKeyUtility_IsUpdateStoreNeeded (root_key_util.c:859)
==284340==    by 0x186428: RootKeyWorkflow_UpdateRootKeys (rootkey_workflow.c:152)
==284340==    by 0x140B54: OrchestratorUpdateCallback (adu_core_interface.c:412)
```