### PR TITLE
Fix leaks in steps_handler.cpp

### DIFF
--- a/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
@@ -126,7 +126,9 @@ ADUC_Result PrepareStepsWorkflowDataObject(ADUC_WorkflowHandle handle)
                     workflow_set_step_index(childHandle, i);
 
                     // Inherit parent's selected components.
-                    workflow_set_selected_components(childHandle, workflow_peek_selected_components(handle));
+                    const char* selectedComponents = workflow_peek_selected_components(handle);
+                    workflow_set_selected_components(childHandle, selectedComponents);
+                    free(const_cast<char*>(selectedComponents));
                 }
             }
             else
@@ -304,7 +306,10 @@ static char* CreateComponentSerializedString(JSON_Array* components, size_t inde
     JSON_Array* array = json_array(json_value_init_array());
     json_array_append_value(array, componentClone);
     json_object_set_value(json_object(root), "components", json_array_get_wrapping_value(array));
-    return json_serialize_to_string_pretty(root);
+
+    char* result = json_serialize_to_string_pretty(root);
+    json_value_free(root);
+    return result;
 }
 
 /**


### PR DESCRIPTION
Thanks to @MartinRieva-Zoetis

Details leak 1:

```
==294565== 9,048 (64 direct, 8,984 indirect) bytes in 2 blocks are definitely lost in loss record 390 of 390
==294565==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==294565==    by 0x8796358: json_value_init_object (in /var/lib/adu/extensions/sources/libmicrosoft_steps_1.so)
==294565==    by 0x875DCE5: CreateComponentSerializedString(json_array_t*, unsigned long) (steps_handler.cpp:303)
==294565==    by 0x875FEEF: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1340)
==294565==    by 0x87604C9: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1481)
==294565==    by 0x876026F: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1400)
==294565==    by 0x87604C9: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1481)
==294565==    by 0x18CA63: ADUC::LinuxPlatformLayer::IsInstalled(tagADUC_WorkflowData const*) (linux_adu_core_impl.cpp:329)
==294565==    by 0x18E193: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}::operator()() const (linux_adu_core_impl.hpp:334)
==294565==    by 0x18F59B: tagADUC_Result ADUC::ExceptionUtils::CallResultMethodAndHandleExceptions<ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}>(int, ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1} const&) (exception_utils.hpp:60)
==294565==    by 0x18E1FF: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*) (linux_adu_core_impl.hpp:335)
==294565==    by 0x144D56: ADUC_Workflow_MethodCall_IsInstalled (agent_workflow.c:1764)
```

Details leak 2:

```
==294565== 1,197 bytes in 1 blocks are definitely lost in loss record 373 of 390
==294565==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==294565==    by 0x8771BAD: mallocAndStrcpy_s (in /var/lib/adu/extensions/sources/libmicrosoft_steps_1.so)
==294565==    by 0x876CA3E: workflow_get_string_property (workflow_utils.c:1717)
==294565==    by 0x876CD1E: workflow_peek_selected_components (workflow_utils.c:1800)
==294565==    by 0x875D559: PrepareStepsWorkflowDataObject(void*) (steps_handler.cpp:130)
==294565==    by 0x875FCBA: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1286)
==294565==    by 0x87604C9: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1481)
==294565==    by 0x876026F: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1400)
==294565==    by 0x87604C9: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1481)
==294565==    by 0x18CA63: ADUC::LinuxPlatformLayer::IsInstalled(tagADUC_WorkflowData const*) (linux_adu_core_impl.cpp:329)
==294565==    by 0x18E193: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}::operator()() const (linux_adu_core_impl.hpp:334)
==294565==    by 0x18F59B: tagADUC_Result ADUC::ExceptionUtils::CallResultMethodAndHandleExceptions<ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)
```