### PR TITLE
Fix leaks in steps_handler.cpp

### DIFF
--- a/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
@@ -221,9 +221,11 @@ ADUC_Result PrepareStepsWorkflowDataObject(ADUC_WorkflowHandle handle)
                             result.ExtendedResultCode = ADUC_ERC_STEPS_HANDLER_SET_SELECTED_COMPONENTS_FAILURE;
                         }
 
+                        const char* selected_components = workflow_peek_selected_components(childHandle);
                         Log_Debug(
                             "Set child handle's selected components: %s",
-                            workflow_peek_selected_components(childHandle));
+                            selected_components);
+                        free(const_cast<char*>(selected_components));
                     }
                 }
             }

--- a/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
@@ -320,6 +320,7 @@ static ADUC_Result GetSelectedComponentsArray(ADUC_WorkflowHandle handle, JSON_A
     ADUC_Result result = { ADUC_Result_Failure };
     JSON_Value* rootValue = nullptr;
     JSON_Object* rootObject = nullptr;
+    JSON_Array* componentsArrayLocal = nullptr;
 
     if (componentsArray == nullptr)
     {
@@ -346,7 +347,14 @@ static ADUC_Result GetSelectedComponentsArray(ADUC_WorkflowHandle handle, JSON_A
     }
 
     rootObject = json_object(rootValue);
-    *componentsArray = json_object_get_array(rootObject, "components");
+    componentsArrayLocal = json_object_get_array(rootObject, "components");
+    if (componentsArrayLocal == nullptr)
+    {
+        result.ExtendedResultCode = ADUC_ERC_STEPS_HANDLER_INVALID_COMPONENTS_DATA;
+        goto done;
+    }
+
+    *componentsArray = json_value_get_array(json_value_deep_copy(json_array_get_wrapping_value(componentsArrayLocal)));
     if (*componentsArray == nullptr)
     {
         result.ExtendedResultCode = ADUC_ERC_STEPS_HANDLER_INVALID_COMPONENTS_DATA;
@@ -357,6 +365,7 @@ static ADUC_Result GetSelectedComponentsArray(ADUC_WorkflowHandle handle, JSON_A
     result.ExtendedResultCode = 0;
 
 done:
+    json_value_free(rootValue);
     return result;
 }
 
@@ -476,6 +485,7 @@ static ADUC_Result HandleComponents(
                 workflow_set_result_details(handle, msg);
             }
         }
+    json_value_free(json_array_get_wrapping_value(selectedComponentsArray));
     }
 
     result.ResultCode = ADUC_Result_Success;
@@ -1124,6 +1134,7 @@ done:
         workflow_set_state(handle, ADUCITF_State_Failed);
     }
 
+    json_value_free(json_array_get_wrapping_value(selectedComponentsArray));
     json_free_serialized_string(serializedComponentString);
     workflow_free_string(workFolder);
 
@@ -1459,6 +1470,7 @@ static ADUC_Result StepsHandler_IsInstalled(const tagADUC_WorkflowData* workflow
 
 done:
 
+    json_value_free(json_array_get_wrapping_value(selectedComponentsArray));
     json_free_serialized_string(serializedComponentString);
     workflow_free_string(workFolder);
 

--- a/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
+++ b/src/extensions/update_manifest_handlers/steps_handler/src/steps_handler.cpp
@@ -366,6 +366,7 @@ static ADUC_Result GetSelectedComponentsArray(ADUC_WorkflowHandle handle, JSON_A
 
 done:
     json_value_free(rootValue);
+    free(const_cast<char*>(selectedComponents));
     return result;
 }
 


### PR DESCRIPTION
Thanks to @MartinRieva-Zoetis

Details:

```
==618647== 8,568 (64 direct, 8,504 indirect) bytes in 2 blocks are definitely lost in loss record 154 of 154
==618647==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==618647==    by 0x87963BB: json_value_init_object (in /var/lib/adu/extensions/sources/libmicrosoft_steps_1.so)
==618647==    by 0x8793B24: parse_object_value (in /var/lib/adu/extensions/sources/libmicrosoft_steps_1.so)
==618647==    by 0x8793A8E: parse_value (in /var/lib/adu/extensions/sources/libmicrosoft_steps_1.so)
==618647==    by 0x8795A85: json_parse_string (in /var/lib/adu/extensions/sources/libmicrosoft_steps_1.so)
==618647==    by 0x875DE33: GetSelectedComponentsArray(void*, json_array_t**) (steps_handler.cpp:347)
==618647==    by 0x875FD61: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1308)
==618647==    by 0x87604F9: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1487)
==618647==    by 0x876029F: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1405)
==618647==    by 0x87604F9: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1487)
==618647==    by 0x18CA63: ADUC::LinuxPlatformLayer::IsInstalled(tagADUC_WorkflowData const*) (linux_adu_core_impl.cpp:329)
==618647==    by 0x18E193: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}::operator()() const (linux_adu_core_impl.hpp:334)
```