### PR TITLE
Fix leaks in jws_utils.c

### DIFF
--- a/src/utils/jws_utils/src/jws_utils.c
+++ b/src/utils/jws_utils/src/jws_utils.c
@@ -619,6 +619,9 @@ done:
         CONSTBUFFER_DecRef(sha256HashPubKey);
     }
 
+    free(N);
+    free(e);
+
     return result;
 }
 


### PR DESCRIPTION
Details
```
==618647== 513 bytes in 1 blocks are definitely lost in loss record 125 of 154
==618647==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==618647==    by 0x16557B: mallocAndStrcpy_s (in /workspaces/iot-hub-device-update/out/bin/AducIotAgent)
==618647==    by 0x19C577: GetStringValueFromJSON (jws_utils.c:63)
==618647==    by 0x19D238: IsSigningKeyDisallowed (jws_utils.c:561)
==618647==    by 0x19CEB9: VerifySJWK (jws_utils.c:408)
==618647==    by 0x19D0E4: VerifyJWSWithSJWK (jws_utils.c:502)
==618647==    by 0x19232C: workflow_validate_update_manifest_signature (workflow_utils.c:910)
==618647==    by 0x192C24: _workflow_parse (workflow_utils.c:1301)
==618647==    by 0x19548A: workflow_init (workflow_utils.c:2886)
==618647==    by 0x1428C5: ADUC_Workflow_HandlePropertyUpdate (agent_workflow.c:431)
==618647==    by 0x140BB1: OrchestratorUpdateCallback (adu_core_interface.c:420)
==618647==    by 0x140D58: AzureDeviceUpdateCoreInterface_PropertyUpdateCallback (adu_core_interface.c:482)
```