### PR TITLE
Fix leak in script_handler.cpp

### DIFF
--- a/src/extensions/step_handlers/script_handler/src/script_handler.cpp
+++ b/src/extensions/step_handlers/script_handler/src/script_handler.cpp
@@ -504,6 +504,10 @@ done:
     {
         json_value_free(selectedComponentsValue);
     }
+    if (selectedComponentsJson != nullptr)
+    {
+        free(const_cast<char*>(selectedComponentsJson));
+    }
 
     workflow_free_string(installedCriteria);
     return result;


### PR DESCRIPTION
Details:
```
==864198== 2,394 bytes in 2 blocks are definitely lost in loss record 98 of 100
==864198==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==864198==    by 0x8838A51: mallocAndStrcpy_s (in /var/lib/adu/extensions/sources/libmicrosoft_script_1.so)
==864198==    by 0x882DED9: workflow_get_string_property (workflow_utils.c:1717)
==864198==    by 0x882E1B9: workflow_peek_selected_components (workflow_utils.c:1800)
==864198==    by 0x881816A: ScriptHandlerImpl::PrepareScriptArguments(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&) (script_handler.cpp:308)
==864198==    by 0x88190FE: ScriptHandler_PerformAction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tagADUC_WorkflowData const*, bool) (script_handler.cpp:571)
==864198==    by 0x8819F3A: ScriptHandlerImpl::PerformAction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, tagADUC_WorkflowData const*) (script_handler.cpp:749)
==864198==    by 0x881A1B2: ScriptHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (script_handler.cpp:802)
==864198==    by 0x8760325: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1417)
==864198==    by 0x8760595: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1500)
==864198==    by 0x8760325: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1417)
==864198==    by 0x8760595: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1500)
```