### PR TITLE
Fix leaks in workflow_utils.c

### DIFF
--- a/src/utils/workflow_utils/src/workflow_utils.c
+++ b/src/utils/workflow_utils/src/workflow_utils.c
@@ -3062,6 +3062,8 @@ void workflow_uninit(ADUC_WorkflowHandle handle)
             VECTOR_destroy(wf->ResultExtraExtendedResultCodes);
             wf->ResultExtraExtendedResultCodes = NULL;
         }
+
+        free(wf->Children);
     }
 
     _workflow_free_updateaction(handle);
@@ -3270,7 +3272,6 @@ ADUC_WorkflowHandle workflow_remove_child(ADUC_WorkflowHandle handle, int index)
         size_t bytes = sizeof(ADUC_Workflow*) * wf->ChildCount - (size_t)(index + 1);
         memmove(wf->Children + index, wf->Children + (index + 1), bytes);
     }
-
     wf->ChildCount--;
 
     workflow_set_parent(child, NULL);

--- a/src/utils/workflow_utils/src/workflow_utils.c
+++ b/src/utils/workflow_utils/src/workflow_utils.c
@@ -2372,11 +2372,11 @@ done:
     {
         entity->Hash = NULL; // will be freed with tempHash below
         ADUC_FileEntity_Uninit(entity);
+    }
 
-        if (tempHash != NULL)
-        {
-            ADUC_Hash_FreeArray(tempHashCount, tempHash);
-        }
+    if (tempHash != NULL)
+    {
+        ADUC_Hash_FreeArray(tempHashCount, tempHash);
     }
 
     return succeeded;
@@ -4059,6 +4059,10 @@ done:
     if (!succeeded && fileEntityInited)
     {
         ADUC_FileEntity_Uninit(entity);
+    }
+    if (tempHash != NULL)
+    {
+        ADUC_Hash_FreeArray(tempHashCount, tempHash);
     }
 
     return succeeded;

--- a/src/utils/workflow_utils/src/workflow_utils.c
+++ b/src/utils/workflow_utils/src/workflow_utils.c
@@ -2370,7 +2370,6 @@ bool workflow_get_update_file_by_name(ADUC_WorkflowHandle handle, const char* fi
 done:
     if (!succeeded)
     {
-        entity->Hash = NULL; // will be freed with tempHash below
         ADUC_FileEntity_Uninit(entity);
     }
 


### PR DESCRIPTION
Details:
```
==874023== 204 (48 direct, 156 indirect) bytes in 3 blocks are definitely lost in loss record 73 of 95
==874023==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==874023==    by 0x8768D0B: ADUC_HashArray_AllocAndInit (parser_utils.c:66)
==874023==    by 0x87707D9: workflow_get_step_detached_manifest_file (workflow_utils.c:4029)
==874023==    by 0x875D5AD: PrepareStepsWorkflowDataObject(void*) (steps_handler.cpp:138)
==874023==    by 0x875FD8C: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1305)
==874023==    by 0x87605B1: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1502)
==874023==    by 0x18CA63: ADUC::LinuxPlatformLayer::IsInstalled(tagADUC_WorkflowData const*) (linux_adu_core_impl.cpp:329)
==874023==    by 0x18E193: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}::operator()() const (linux_adu_core_impl.hpp:334)
==874023==    by 0x18F59B: tagADUC_Result ADUC::ExceptionUtils::CallResultMethodAndHandleExceptions<ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}>(int, ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1} const&) (exception_utils.hpp:60)
==874023==    by 0x18E1FF: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*) (linux_adu_core_impl.hpp:335)
==874023==    by 0x144D56: ADUC_Workflow_MethodCall_IsInstalled (agent_workflow.c:1764)
==874023==    by 0x1427FE: ADUC_Workflow_HandleStartupWorkflowData (agent_workflow.c:397)
```

Fix leak in workflow_utils.c

Details:
```
==891255== 136 (32 direct, 104 indirect) bytes in 2 blocks are definitely lost in loss record 69 of 92
==891255==    at 0x483AB65: calloc (vg_replace_malloc.c:760)
==891255==    by 0x88268C7: ADUC_HashArray_AllocAndInit (parser_utils.c:66)
==891255==    by 0x882F067: workflow_get_update_file_by_name (workflow_utils.c:2344)
==891255==    by 0x8817B5D: Script_Handler_DownloadPrimaryScriptFile(void*) (script_handler.cpp:146)
==891255==    by 0x881A182: ScriptHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (script_handler.cpp:803)
==891255==    by 0x8760341: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1419)
==891255==    by 0x87605B1: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1502)
==891255==    by 0x8760341: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1419)
==891255==    by 0x87605B1: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1502)
==891255==    by 0x18CA63: ADUC::LinuxPlatformLayer::IsInstalled(tagADUC_WorkflowData const*) (linux_adu_core_impl.cpp:329)
==891255==    by 0x18E193: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}::operator()() const (linux_adu_core_impl.hpp:334)
==891255==    by 0x18F59B: tagADUC_Result ADUC::ExceptionUtils::CallResultMethodAndHandleExceptions<ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}>(int, ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1} const&) (exception_utils.hpp:60)
```