### PR TITLE
Fix log level being defaulted to INFO on extensions.

### DIFF
--- a/src/logging/zlog/src/init.c
+++ b/src/logging/zlog/src/init.c
@@ -64,7 +64,7 @@ ADUC_LOG_SEVERITY g_logLevel = ADUC_LOG_INFO;
  */
 void ADUC_Logging_Init(ADUC_LOG_SEVERITY logLevel, const char* filePrefix)
 {
-    g_logLevel = ADUC_LOG_INFO;
+    g_logLevel = logLevel;
 
     // zlog_init doesn't create the log path, so attempt to create it here if it does not exist.
     // If it can't be created, zlogging will send output to console.


### PR DESCRIPTION
`g_logLevel` is returned by `ADUC_Logging_GetLevel()` which is passed to extensions on `*handler = createUpdateContentHandlerExtensionFn(ADUC_Logging_GetLevel());`

Even when running in `-l 0` the extension logs defaulted to info.