### PR TITLE
Fix leak in linux_adu_core_impl.cpp by adding destructor that cleans up ExtensionManager

### DIFF
--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
@@ -55,6 +55,11 @@ std::unique_ptr<LinuxPlatformLayer> LinuxPlatformLayer::Create()
     return std::unique_ptr<LinuxPlatformLayer>{ new LinuxPlatformLayer() };
 }
 
+LinuxPlatformLayer::~LinuxPlatformLayer()
+{
+    ExtensionManager::Uninit();
+}
+
 /**
  * @brief Set the ADUC_UpdateActionCallbacks object
  *

--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.hpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.hpp
@@ -30,6 +30,7 @@ class LinuxPlatformLayer
 {
 public:
     static std::unique_ptr<LinuxPlatformLayer> Create();
+    ~LinuxPlatformLayer();
 
     ADUC_Result SetUpdateActionCallbacks(ADUC_UpdateActionCallbacks* data);
 


### PR DESCRIPTION
Thank you @MartinRieva-Zoetis.

Details
```
==3375554== 16 bytes in 1 blocks are definitely lost in loss record 6 of 32
==3375554==    at 0x4838DEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==3375554==    by 0x875DCCC: StepsHandlerImpl::CreateContentHandler() (steps_handler.cpp:288)
==3375554==    by 0x8760C09: CreateUpdateContentHandlerExtension (handler_create.cpp:33)
==3375554==    by 0x8762253: ExtensionManager::LoadUpdateContentHandlerExtension(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, ContentHandler**) (extension_manager.cpp:287)
==3375554==    by 0x876025B: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1406)
==3375554==    by 0x87605B1: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1501)
==3375554==    by 0x18CA8D: ADUC::LinuxPlatformLayer::IsInstalled(tagADUC_WorkflowData const*) (linux_adu_core_impl.cpp:334)
==3375554==    by 0x18E1BD: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}::operator()() const (linux_adu_core_impl.hpp:335)
==3375554==    by 0x18F5C5: tagADUC_Result ADUC::ExceptionUtils::CallResultMethodAndHandleExceptions<ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}>(int, ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1} const&) (exception_utils.hpp:60)
==3375554==    by 0x18E229: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*) (linux_adu_core_impl.hpp:336)
==3375554==    by 0x144D56: ADUC_Workflow_MethodCall_IsInstalled (agent_workflow.c:1764)
==3375554==    by 0x1427FE: ADUC_Workflow_HandleStartupWorkflowData (agent_workflow.c:397)
==3375554==
==3375554== 16 bytes in 1 blocks are definitely lost in loss record 7 of 32
==3375554==    at 0x4838DEF: operator new(unsigned long) (vg_replace_malloc.c:342)
==3375554==    by 0x8817A64: ScriptHandlerImpl::CreateContentHandler() (script_handler.cpp:117)
==3375554==    by 0x88178E1: CreateUpdateContentHandlerExtension (script_handler.cpp:55)
==3375554==    by 0x8762253: ExtensionManager::LoadUpdateContentHandlerExtension(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, ContentHandler**) (extension_manager.cpp:287)
==3375554==    by 0x876025B: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1406)
==3375554==    by 0x87605B1: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1501)
==3375554==    by 0x8760341: StepsHandler_IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1419)
==3375554==    by 0x87605B1: StepsHandlerImpl::IsInstalled(tagADUC_WorkflowData const*) (steps_handler.cpp:1501)
==3375554==    by 0x18CA8D: ADUC::LinuxPlatformLayer::IsInstalled(tagADUC_WorkflowData const*) (linux_adu_core_impl.cpp:334)
==3375554==    by 0x18E1BD: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}::operator()() const (linux_adu_core_impl.hpp:335)
==3375554==    by 0x18F5C5: tagADUC_Result ADUC::ExceptionUtils::CallResultMethodAndHandleExceptions<ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}>(int, ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1} const&) (exception_utils.hpp:60)
==3375554==    by 0x18E229: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*) (linux_adu_core_impl.hpp:336)
```