### PR TITLE
Fix leak when initializing zlog multiple times.

### DIFF
--- a/src/logging/zlog/src/init.c
+++ b/src/logging/zlog/src/init.c
@@ -22,6 +22,8 @@
 #    define ZLOG_ENABLE_FILE_LOG ZLOG_DISABLED
 #endif
 
+static int ref_count = 0;
+
 /**
  * @brief Convert ADUC_LOG_SEVERITY to ZLOG_SEVERITY
  * @param logLevel An ADUC log level
@@ -76,6 +78,11 @@ ADUC_LOG_SEVERITY g_logLevel = ADUC_LOG_INFO;
  */
 void ADUC_Logging_Init(ADUC_LOG_SEVERITY logLevel, const char* filePrefix)
 {
+    if (ref_count++ > 0)
+    {
+        return;
+    }
+
     g_logLevel = logLevel;
 
     // zlog_init doesn't create the log path, so attempt to create it here if it does not exist.
@@ -111,6 +118,11 @@ void ADUC_Logging_Init(ADUC_LOG_SEVERITY logLevel, const char* filePrefix)
  */
 void ADUC_Logging_Uninit()
 {
+    if (--ref_count > 0)
+    {
+        return;
+    }
+
     zlog_finish();
 }
 


### PR DESCRIPTION
The ADUC_Logging_Init is called multiple times within the same memory context and ADUC_Logging_Uninit must only be called once. This causes zlog_init to allocate memory multiple times without freeing it.

Details:

==216533== 13 bytes in 1 blocks are definitely lost in loss record 3 of 32
==216533==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==216533==    by 0x8790DA0: zlog_init (zlog.c:157)
==216533==    by 0x8790AD9: ADUC_Logging_Init (init.c:95)
==216533==    by 0x8760BF2: CreateUpdateContentHandlerExtension (handler_create.cpp:29)
==216533==    by 0x149CED: ExtensionManager::LoadUpdateContentHandlerExtension(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, ContentHandler**) (extension_manager.cpp:287)
==216533==    by 0x18C452: GetUpdateManifestHandler(tagADUC_WorkflowData const*, tagADUC_Result*) (linux_adu_core_impl.cpp:124)
==216533==    by 0x18CA78: ADUC::LinuxPlatformLayer::IsInstalled(tagADUC_WorkflowData const*) (linux_adu_core_impl.cpp:326)
==216533==    by 0x18E1EB: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}::operator()() const (linux_adu_core_impl.hpp:335)
==216533==    by 0x18F5F3: tagADUC_Result ADUC::ExceptionUtils::CallResultMethodAndHandleExceptions<ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}>(int, ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1} const&) (exception_utils.hpp:60)
==216533==    by 0x18E257: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*) (linux_adu_core_impl.hpp:336)
==216533==    by 0x144D56: ADUC_Workflow_MethodCall_IsInstalled (agent_workflow.c:1764)
==216533==    by 0x1427FE: ADUC_Workflow_HandleStartupWorkflowData (agent_workflow.c:397)
==216533==
==216533== 15 bytes in 1 blocks are definitely lost in loss record 4 of 32
==216533==    at 0x483877F: malloc (vg_replace_malloc.c:307)
==216533==    by 0x8790DF1: zlog_init (zlog.c:164)
==216533==    by 0x8790AD9: ADUC_Logging_Init (init.c:95)
==216533==    by 0x8760BF2: CreateUpdateContentHandlerExtension (handler_create.cpp:29)
==216533==    by 0x149CED: ExtensionManager::LoadUpdateContentHandlerExtension(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, ContentHandler**) (extension_manager.cpp:287)
==216533==    by 0x18C452: GetUpdateManifestHandler(tagADUC_WorkflowData const*, tagADUC_Result*) (linux_adu_core_impl.cpp:124)
==216533==    by 0x18CA78: ADUC::LinuxPlatformLayer::IsInstalled(tagADUC_WorkflowData const*) (linux_adu_core_impl.cpp:326)
==216533==    by 0x18E1EB: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}::operator()() const (linux_adu_core_impl.hpp:335)
==216533==    by 0x18F5F3: tagADUC_Result ADUC::ExceptionUtils::CallResultMethodAndHandleExceptions<ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1}>(int, ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*)::{lambda()#1} const&) (exception_utils.hpp:60)
==216533==    by 0x18E257: ADUC::LinuxPlatformLayer::IsInstalledCallback(void*, void*) (linux_adu_core_impl.hpp:336)
==216533==    by 0x144D56: ADUC_Workflow_MethodCall_IsInstalled (agent_workflow.c:1764)
==216533==    by 0x1427FE: ADUC_Workflow_HandleStartupWorkflowData (agent_workflow.c:397)