### PR TITLE
feat(build): Support custom work folder for dependency installation and build 

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,14 +30,14 @@ jobs:
         if: matrix.os == 'ubuntu:22.04' || startsWith(matrix.os, 'ubuntu:2') && matrix.os >= 'ubuntu:22.04'
         shell: bash
         run: |
-            scripts/install-deps.sh --install-aduc-deps --install-do --install-cmake --install-shellcheck --install-valgrind apt
+            scripts/install-deps.sh --install-aduc-deps --install-do --install-cmake --install-shellcheck --install-valgrind apt --work-folder $GITHUB_WORKSPACE/.workspace
       - name: Install dependencies (without ValGrind)
         if: matrix.os != 'ubuntu:22.04' && !(startsWith(matrix.os, 'ubuntu:2') && matrix.os >= 'ubuntu:22.04')
         shell: bash
         run: |
-            scripts/install-deps.sh --install-aduc-deps --install-do --install-cmake --install-shellcheck
+            scripts/install-deps.sh --install-aduc-deps --install-do --install-cmake --install-shellcheck --work-folder $GITHUB_WORKSPACE/.workspace
       - name: Build packages and tests
-        run: scripts/build.sh --clean --build-unit-tests --build-packages --type MinSizeRel
+        run: scripts/build.sh --clean --build-unit-tests --build-packages --type MinSizeRel --work-folder $GITHUB_WORKSPACE/.workspace
       - name: Run tests
         run: |
           cd out

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ### VisualStudio Code
 .vscode/
 
+### ADU temporary folder for built dependencies and test data files
+.workspace/
+
 ### VisualStudio 2017
 .vs/
 

--- a/docs/agent-reference/how-to-build-agent-code.md
+++ b/docs/agent-reference/how-to-build-agent-code.md
@@ -58,6 +58,25 @@ dependencies. To see the usage info:
 ./scripts/install-deps.sh -h
 ```
 
+#### Customizing Dependency Build Location
+
+By default, dependencies are downloaded and built in `/tmp`. You can specify a custom location using the `--work-folder` option:
+
+```sh
+./scripts/install-deps.sh --install-all-deps --work-folder /path/to/your/workspace
+```
+
+This is useful when:
+- `/tmp` is mounted as `noexec` or has size constraints
+- You want to preserve downloaded source code using `--keep-source-code` option
+- Working in a containerized or restricted environment
+
+Example with preserved source code:
+
+```sh
+./scripts/install-deps.sh --install-all-deps --work-folder ~/adu-deps --keep-source-code
+```
+
 ### Install Optional Development Tools
 
 - Install the clang-format package (required for running `scripts/clang-format.sh`):
@@ -90,6 +109,19 @@ To see additional build options with build.sh:
 ```sh
 build.sh -h
 ```
+
+##### Customizing Build Artifact Location
+
+By default, temporary build artifacts (CMake, shellcheck, test data) are stored in `/tmp`. You can specify a custom location using the `--work-folder` option:
+
+```sh
+./scripts/build.sh --work-folder /path/to/your/workspace -c
+```
+
+This is useful when:
+- `/tmp` is mounted as `noexec` or has size constraints
+- You want to preserve build artifacts between system reboots
+- Working in a containerized or restricted environment
 
 ### Build and Run the unit tests
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,7 +47,7 @@ log_lib="zlog"
 install_prefix=/usr/local
 install_adu=false
 work_folder=/tmp
-cmake_dir_path="${work_folder}/deviceupdate-cmake"
+cmake_dir_path=""
 rootkeypkg_curl=false
 
 #
@@ -94,6 +94,11 @@ Usage: build.sh [options...]
     --content-handlers <handlers>         [Deprecated] use '--step-handlers' option instead.
     --step-handlers <handlers>            Specify a comma-delimited list of the step handlers to build.
                                             Default is '${step_handlers}'.
+
+    -f, --work-folder <work_folder>       Specifies the folder where temp artifacts will be stored.
+                                            This folder contains temporary build artifacts for dependencies,
+                                            CMake/shellcheck installations, and test data.
+                                            Default is /tmp.
 
     --cmake-path                          Override the cmake path such that CMake binary is at <cmake-path>/bin/cmake
 
@@ -333,6 +338,18 @@ while [[ $1 != "" ]]; do
         fi
         install_adu="true"
         ;;
+    -f | --work-folder)
+        shift
+        if [[ -z $1 || $1 == -* ]]; then
+            error "-f work folder parameter is mandatory."
+            $ret 1
+        fi
+        work_folder=$(realpath "$1" 2> /dev/null)
+        if [[ -z $work_folder ]]; then
+            error "Invalid or inaccessible work folder path: $1"
+            $ret 1
+        fi
+        ;;
     --cmake-path)
         shift
         if [[ -z $1 || $1 == -* ]]; then
@@ -367,6 +384,13 @@ while [[ $1 != "" ]]; do
     esac
     shift
 done
+
+# Set cmake_dir_path if not explicitly provided via --cmake-path.
+# Note: This must be done after argument parsing is complete so that
+# work_folder has been set if --work-folder was specified.
+if [[ -z $cmake_dir_path ]]; then
+    cmake_dir_path="${work_folder}/deviceupdate-cmake"
+fi
 
 if [[ $build_documentation == "true" ]]; then
     if ! [ -x "$(command -v doxygen)" ]; then
@@ -443,6 +467,7 @@ CMAKE_OPTIONS=(
     "-DADUC_TRACE_TARGET_DEPS=$trace_target_deps"
     "-DADUC_USE_TEST_ROOT_KEYS=$use_test_root_keys"
     "-DADUC_ROOTKEY_PKG_DOWNLOAD_WITH_CURL=$rootkeypkg_curl"
+    "-DADUC_TMP_DIR_PATH:STRING=$work_folder"
     "-DCMAKE_BUILD_TYPE:STRING=$build_type"
     "-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON"
     "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY:STRING=$library_dir"
@@ -542,7 +567,7 @@ fi
 
 if [[ $build_clean == "true" ]]; then
     rm -rf "$output_directory"
-    rm -rf "/tmp/adu/testdata"
+    rm -rf "${work_folder}/adu/testdata"
 fi
 
 mkdir -p "$output_directory"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -48,6 +48,7 @@ install_prefix=/usr/local
 install_adu=false
 work_folder=/tmp
 cmake_dir_path=""
+cmake_bin="cmake"
 rootkeypkg_curl=false
 
 #
@@ -392,6 +393,16 @@ if [[ -z $cmake_dir_path ]]; then
     cmake_dir_path="${work_folder}/deviceupdate-cmake"
 fi
 
+# Source build environment from install-deps.sh if it exists
+if [[ -f "$work_folder/.build-env" ]]; then
+    # shellcheck source=/dev/null
+    source "$work_folder/.build-env"
+    if [[ -n $ADU_CMAKE_BIN ]]; then
+        cmake_bin="$ADU_CMAKE_BIN"
+        bullet "Using cmake from build environment: $cmake_bin"
+    fi
+fi
+
 if [[ $build_documentation == "true" ]]; then
     if ! [ -x "$(command -v doxygen)" ]; then
         error "Can't build documentation - doxygen is not installed. Try: apt install doxygen"
@@ -411,7 +422,10 @@ fi
 
 runtime_dir=${output_directory}/bin
 library_dir=${output_directory}/lib
-cmake_bin="${cmake_dir_path}/bin/cmake"
+# Only set hardcoded cmake path if ADU_CMAKE_BIN wasn't set from .build-env
+if [[ -z $ADU_CMAKE_BIN ]]; then
+    cmake_bin="${cmake_dir_path}/bin/cmake"
+fi
 shellcheck_bin="${work_folder}/deviceupdate-shellcheck"
 
 if [[ $srvc_e2e_agent_build == "true" ]]; then

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1019,10 +1019,12 @@ fi
 
 # First off, install cmake if requested.
 if [[ $install_cmake == "true" ]]; then
+    cmake_installed=false
     if [[ $is_amd64 == "false" && $is_arm64 == "false" || $cmake_force_source == "true" ]]; then
-        if ! do_install_cmake_from_source; then
-            error "Failed to install cmake from source."
-            $ret 1
+        if do_install_cmake_from_source; then
+            cmake_installed=true
+        else
+            warn "Failed to install cmake from source. Falling back to system cmake."
         fi
     else
         arch=''
@@ -1038,14 +1040,28 @@ if [[ $install_cmake == "true" ]]; then
 
         if [[ -d $cmake_installer_dir && -x "${cmake_dir_symlink}/bin/cmake" ]]; then
             echo "${cmake_installer_dir} already exists. Skipping install of cmake..."
+            cmake_installed=true
         else
-            if ! do_install_cmake_from_installer "$arch"; then
-                error "Failed to install cmake using installer."
-                $ret 1
+            if do_install_cmake_from_installer "$arch"; then
+                cmake_installed=true
+            else
+                warn "Failed to install cmake using installer. Falling back to system cmake."
             fi
         fi
     fi
-    cmake_bin="${cmake_dir_symlink}/bin/cmake"
+    if [[ $cmake_installed == "true" ]]; then
+        cmake_bin="${cmake_dir_symlink}/bin/cmake"
+    else
+        echo "Using system cmake..."
+        cmake_bin="cmake"
+    fi
+fi
+
+# Write build environment to file for build.sh to source
+if [[ $install_cmake == "true" ]]; then
+    mkdir -p "$work_folder"
+    echo "ADU_CMAKE_BIN=$cmake_bin" > "$work_folder/.build-env"
+    echo "Build environment written to $work_folder/.build-env"
 fi
 
 # Install git hooks if requested.

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -652,6 +652,11 @@ do_install_cmake_from_source() {
     popd > /dev/null || return
 
     $SUDO ln -sf "${cmake_prefix}/${tarball_name}" "$cmake_dir_symlink"
+    ret_value=$?
+    if [ $ret_value -ne 0 ]; then
+        error "Failed to create cmake symlink at $cmake_dir_symlink"
+        return $ret_value
+    fi
 }
 
 do_install_cmake_from_installer() {
@@ -691,6 +696,11 @@ do_install_cmake_from_installer() {
     $SUDO rm "$fullpath_cmake_installer_sh" || return 1
 
     ln -sf "$cmake_installer_dir" "$cmake_dir_symlink"
+    ret_value=$?
+    if [ $ret_value -ne 0 ]; then
+        error "Failed to create cmake symlink at $cmake_dir_symlink"
+        return $ret_value
+    fi
 }
 
 do_install_shellcheck() {

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -65,7 +65,7 @@ install_cmake_version="$supported_cmake_version"
 cmake_force_source=false
 cmake_prefix="$work_folder"
 cmake_installer_dir=""
-cmake_dir_symlink="/tmp/deviceupdate-cmake"
+cmake_dir_symlink="${work_folder}/deviceupdate-cmake"
 cmake_bin="cmake"
 
 install_shellcheck=false
@@ -148,7 +148,9 @@ print_help() {
     echo "-p, --install-packages    Indicates that packages should be installed."
     echo "--install-packages-only   Indicates that only packages should be installed and that dependencies should not be installed from source."
     echo ""
-    echo "-f, --work-folder <work_folder>   Specifies the folder where source code will be cloned or downloaded."
+    echo "-f, --work-folder <work_folder>   Specifies the folder where temp artifacts will be stored."
+    echo "                                  This folder contains temporary build artifacts for dependencies,"
+    echo "                                  CMake/shellcheck installations, and test data."
     echo "                                  Default is /tmp."
     echo "-k, --keep-source-code            Indicates that source code should not be deleted after install from work_folder."
     echo ""
@@ -731,7 +733,7 @@ do_install_shellcheck() {
 
         $SUDO rm "work_folder/$tarball_filename" || return 1
 
-        ln -sf "${HOME}/.cabal/bin/shellcheck" "/tmp/deviceupdate-shellcheck" || return 1
+        ln -sf "${HOME}/.cabal/bin/shellcheck" "${work_folder}/deviceupdate-shellcheck" || return 1
     else
         echo "Installing shellcheck ${scver} from pre-built binaries..."
         local tar_filename="shellcheck-v${scver}.linux.${arch}.tar.xz"
@@ -745,7 +747,7 @@ do_install_shellcheck() {
 
         $SUDO rm "$work_folder/$tar_filename" || return 1
 
-        ln -sf "${work_folder}/shellcheck-v0.8.0/shellcheck" "/tmp/deviceupdate-shellcheck" || return 1
+        ln -sf "${work_folder}/shellcheck-v0.8.0/shellcheck" "${work_folder}/deviceupdate-shellcheck" || return 1
     fi
 }
 
@@ -907,7 +909,11 @@ while [[ $1 != "" ]]; do
         ;;
     -f | --work-folder)
         shift
-        work_folder=$(realpath "$1")
+        work_folder=$(realpath "$1" 2> /dev/null)
+        if [[ -z $work_folder ]]; then
+            error "Invalid or inaccessible work folder path: $1"
+            $ret 1
+        fi
         ;;
     -k | --keep-source-code)
         keep_source_code=true

--- a/src/extensions/step_handlers/script_handler/tests/script_handler_ut.cpp
+++ b/src/extensions/step_handlers/script_handler/tests/script_handler_ut.cpp
@@ -138,7 +138,7 @@ TEST_CASE("Script Handler Prepare Arguments Test")
     CHECK_THAT(
         results.scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/script_handler_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh" --target-options --action-install --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_install_aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/script_handler_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh\" --target-options --action-install --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_install_aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     results.args.clear();
 
     results = ScriptHandler_PerformAction("apply", &stepWorkflow, true);
@@ -149,7 +149,7 @@ TEST_CASE("Script Handler Prepare Arguments Test")
     CHECK_THAT(
         results.scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/script_handler_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh" --target-options --action-apply --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_apply_aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/script_handler_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh\" --target-options --action-apply --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_apply_aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     results.args.clear();
 
     results = ScriptHandler_PerformAction("cancel", &stepWorkflow, true);
@@ -160,7 +160,7 @@ TEST_CASE("Script Handler Prepare Arguments Test")
     CHECK_THAT(
         results.scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/script_handler_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh" --target-options --action-cancel --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_cancel_aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/script_handler_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh\" --target-options --action-cancel --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_cancel_aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     results.args.clear();
 
     results = ScriptHandler_PerformAction("is-installed", &stepWorkflow, true);
@@ -171,7 +171,7 @@ TEST_CASE("Script Handler Prepare Arguments Test")
     CHECK_THAT(
         results.scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/script_handler_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh" --target-options --action-is-installed --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_is-installed_aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/script_handler_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh\" --target-options --action-is-installed --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_is-installed_aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     results.args.clear();
 
     workflow_free(handle);
@@ -223,7 +223,7 @@ TEST_CASE("Script Handler Prepare Arguments Test v2.1")
     CHECK_THAT(
         results.scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/script_handler_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh" --target-options --action --target-options "install" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_install_aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/script_handler_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh\" --target-options --action --target-options \"install\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_install_aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     results.args.clear();
 
     results = ScriptHandler_PerformAction("apply", &stepWorkflow, true);
@@ -234,7 +234,7 @@ TEST_CASE("Script Handler Prepare Arguments Test v2.1")
     CHECK_THAT(
         results.scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/script_handler_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh" --target-options --action --target-options "apply" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_apply_aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/script_handler_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh\" --target-options --action --target-options \"apply\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_apply_aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     results.args.clear();
 
     results = ScriptHandler_PerformAction("cancel", &stepWorkflow, true);
@@ -245,7 +245,7 @@ TEST_CASE("Script Handler Prepare Arguments Test v2.1")
     CHECK_THAT(
         results.scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/script_handler_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh" --target-options --action --target-options "cancel" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_cancel_aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/script_handler_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh\" --target-options --action --target-options \"cancel\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_cancel_aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     results.args.clear();
 
     results = ScriptHandler_PerformAction("is-installed", &stepWorkflow, true);
@@ -256,7 +256,7 @@ TEST_CASE("Script Handler Prepare Arguments Test v2.1")
     CHECK_THAT(
         results.scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/script_handler_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh" --target-options --action --target-options "is-installed" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_is-installed_aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/script_handler_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh\" --target-options --action --target-options \"is-installed\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/action_is-installed_aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     results.args.clear();
 
     workflow_free(handle);

--- a/src/extensions/step_handlers/swupdate_handler_v2/tests/swupdate_handler_v2_ut.cpp
+++ b/src/extensions/step_handlers/swupdate_handler_v2/tests/swupdate_handler_v2_ut.cpp
@@ -116,6 +116,24 @@ static void set_test_config_folder()
     setenv(ADUC_CONFIG_FOLDER_ENV, path.c_str(), 1);
 }
 
+// Helper function to generate filecopy_workflow_2 with dynamic test data folder path
+static std::string get_filecopy_workflow_2()
+{
+    std::string testDataFolder = ADUC_TEST_DATA_FOLDER;
+    return R"( {                    )"
+    R"(     "workflow": {    )"
+    R"(         "action": 3, )"
+    R"(         "id": "d19de7fb-11d8-45f7-88e0-03872a591de8" )"
+    R"(      },  )"
+    R"(     "updateManifest": "{\"manifestVersion\":\"4\",\"updateId\":{\"provider\":\"Contoso\",\"name\":\"Virtual-Vacuum\",\"version\":\"30.0\"},\"compatibility\":[{\"deviceManufacturer\":\"contoso\",\"deviceModel\":\"virtual-vacuum-v1\"}],\"instructions\":{\"steps\":[{\"handler\":\"microsoft/swupdate:2\",\"files\":[\"fb7f654eb03c9900a\",\"ff2510f75ca8bf0d3\"],\"handlerProperties\":{\"installedCriteria\":\"This is swupdate filecopy test version 1.0\",\"arguments\":\"--software-version-file )" + testDataFolder + R"(/test-device/vacuum-1/data/mock-update-for-file-copy-test-1.txt\",\"scriptFileName\":\"example-du-swupdate-script.sh\",\"swuFileName\":\"du-agent-swupdate-filecopy-test-1_1.0.swu\"}}]},\"files\":{\"fb7f654eb03c9900a\":{\"fileName\":\"du-agent-swupdate-filecopy-test-1_1.0.swu\",\"sizeInBytes\":1536,\"hashes\":{\"sha256\":\"cWJKtVffvDj9B78lgCqWT/lKMBJ9AQ8UmUh48ad8JHA=\"}},\"ff2510f75ca8bf0d3\":{\"fileName\":\"example-du-swupdate-script.sh\",\"sizeInBytes\":24737,\"hashes\":{\"sha256\":\"Nc08FK/T5bOH07nC4GorKTgope5n3+cyb+Ar6KGaY9I=\"}}},\"createdDateTime\":\"2022-03-28T22:36:07.8445392Z\"}", )"
+    R"(     "updateManifestSignature": "eyJhbGciOiJSUzI1NiIsInNqd2siOiJleUpoYkdjaU9pSlNVekkxTmlJc0ltdHBaQ0k2SWtGRVZTNHlNREEzTURJdVVpSjkuZXlKcmRIa2lPaUpTVTBFaUxDSnVJam9pYkV4bWMwdHZPRmwwWW1Oak1sRXpUalV3VlhSTVNXWlhVVXhXVTBGRlltTm9LMFl2WTJVM1V6Rlpja3BvV0U5VGNucFRaa051VEhCVmFYRlFWSGMwZWxndmRHbEJja0ZGZFhrM1JFRmxWVzVGU0VWamVEZE9hM2QzZVRVdk9IcExaV3AyWTBWWWNFRktMMlV6UWt0SE5FVTBiMjVtU0ZGRmNFOXplSGRQUzBWbFJ6QkhkamwzVjB3emVsUmpUblprUzFoUFJGaEdNMVZRWlVveGIwZGlVRkZ0Y3pKNmJVTktlRUppZEZOSldVbDBiWFpwWTNneVpXdGtWbnBYUm5jdmRrdFVUblZMYXpob2NVczNTRkptYWs5VlMzVkxXSGxqSzNsSVVVa3dZVVpDY2pKNmEyc3plR2d4ZEVWUFN6azRWMHBtZUdKamFsQnpSRTgyWjNwWmVtdFlla05OZW1Fd1R6QkhhV0pDWjB4QlZGUTVUV1k0V1ZCd1dVY3lhblpQWVVSVmIwTlJiakpWWTFWU1RtUnNPR2hLWW5scWJscHZNa3B5SzFVNE5IbDFjVTlyTjBZMFdubFRiMEoyTkdKWVNrZ3lXbEpTV2tab0wzVlRiSE5XT1hkU2JWbG9XWEoyT1RGRVdtbHhhemhJVWpaRVUyeHVabTVsZFRJNFJsUm9SVzF0YjNOVlRUTnJNbGxNYzBKak5FSnZkWEIwTTNsaFNEaFpia3BVTnpSMU16TjFlakU1TDAxNlZIVnFTMmMzVkdGcE1USXJXR0owYmxwRU9XcFVSMkY1U25Sc2FFWmxWeXRJUXpVM1FYUkJSbHBvY1ZsM2VVZHJXQ3M0TTBGaFVGaGFOR0V4VHpoMU1qTk9WVWQxTWtGd04yOU5NVTR3ZVVKS0swbHNUM29pTENKbElqb2lRVkZCUWlJc0ltRnNaeUk2SWxKVE1qVTJJaXdpYTJsa0lqb2lRVVJWTGpJeE1EWXdPUzVTTGxNaWZRLlJLS2VBZE02dGFjdWZpSVU3eTV2S3dsNFpQLURMNnEteHlrTndEdkljZFpIaTBIa2RIZ1V2WnoyZzZCTmpLS21WTU92dXp6TjhEczhybXo1dnMwT1RJN2tYUG1YeDZFLUYyUXVoUXNxT3J5LS1aN2J3TW5LYTNkZk1sbkthWU9PdURtV252RWMyR0hWdVVTSzREbmw0TE9vTTQxOVlMNThWTDAtSEthU18xYmNOUDhXYjVZR08xZXh1RmpiVGtIZkNIU0duVThJeUFjczlGTjhUT3JETHZpVEtwcWtvM3RiSUwxZE1TN3NhLWJkZExUVWp6TnVLTmFpNnpIWTdSanZGbjhjUDN6R2xjQnN1aVQ0XzVVaDZ0M05rZW1UdV9tZjdtZUFLLTBTMTAzMFpSNnNTR281azgtTE1sX0ZaUmh4djNFZFNtR2RBUTNlMDVMRzNnVVAyNzhTQWVzWHhNQUlHWmcxUFE3aEpoZGZHdmVGanJNdkdTSVFEM09wRnEtZHREcEFXbUo2Zm5sZFA1UWxYek5tQkJTMlZRQUtXZU9BYjh0Yjl5aVhsemhtT1dLRjF4SzlseHpYUG9GNmllOFRUWlJ4T0hxTjNiSkVISkVoQmVLclh6YkViV2tFNm4zTEoxbkd5M1htUlVFcER0Umdpa0tBUzZybFhFT0VneXNjIn0.eyJzaGEyNTYiOiJheEhUZkdEa2ZVd0dYMnR2SmpxTmhzU3BDYmtyNVpEcXBQVFd4aE9jN2RnPSJ9.ZilWZQSDM59SFpoqpKk33pp9StovL03E9bGACRrfsdPOCXDSqmGBtQxmztg70BTAVpiH7kMlYj1g--no54STJn8_nvt82LX5HEj1xosypdMVIgsAPzhd8RhDKE8T7agrdR4c46PfephjvL7jLRFJN4ipaQIcMxHYaiMeV4KdHXzf-LMASU0tX_y_eGyEIKLNu5kgGnigu96f7JpQ4cgSq5ScZPqzkHutgsgFKG5pY5lefbxJjlepL5N82Bvwu_ZFkCWvo1YSdpMP4heP10xXiq2GIy3bN0yZHjMOIMt-f8jtLmZV7qEblkym6gmrYJENDjAe2rwh6q7ohGb5u_VtrignqV2ZSJobr4ENSBtCNT6Gtm0ZucQghvdEQ0iyM_XQfmDH2AnW_vqt1ymQYkn8HXV5zoeuse6ly4B8L_SzxQei0wZJcyXY61FarIxSth6qEq9my7Hvv8YAnTSp9tEZMSY9j6jYqryF1EV79sIobczkTIe6k1t_4d_xj8roleTf", )"
+    R"(     "fileUrls": { )"
+    R"(         "fb7f654eb03c9900a": "http://duinstance2--johndoe.b.nlu.dl.adu.microsoft.com/westus2/duinstance2/4d823623494d4a62b7877d58d0d89167/du-agent-swupdate-filecopy-test-1_1.0.swu", )"
+    R"(         "ff2510f75ca8bf0d3": "http://duinstance2--johndoe.b.nlu.dl.adu.microsoft.com/westus2/duinstance2/5daa1107aee443b095f0ac6a4548f4b0/example-du-swupdate-script.sh" )"
+    R"(      }  )"
+    R"( } )";
+}
+
 TEST_CASE("SWUpdate Prepare Arguments Test")
 {
     set_test_config_folder();
@@ -166,7 +184,7 @@ TEST_CASE("SWUpdate Prepare Arguments Test")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh" --target-options --action-install --target-options --swu-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh\" --target-options --action-install --target-options --swu-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     args.clear();
 
     result = SWUpdateHandler_PerformAction(
@@ -178,7 +196,7 @@ TEST_CASE("SWUpdate Prepare Arguments Test")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh" --target-options --action-apply --target-options --swu-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh\" --target-options --action-apply --target-options --swu-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     args.clear();
 
     result = SWUpdateHandler_PerformAction(
@@ -190,7 +208,7 @@ TEST_CASE("SWUpdate Prepare Arguments Test")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh" --target-options --action-cancel --target-options --swu-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh\" --target-options --action-cancel --target-options --swu-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     args.clear();
 
     result = SWUpdateHandler_PerformAction(
@@ -202,7 +220,7 @@ TEST_CASE("SWUpdate Prepare Arguments Test")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh" --target-options --action-is-installed --target-options --swu-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script.sh\" --target-options --action-is-installed --target-options --swu-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test version 1.0$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     args.clear();
 
     workflow_free(handle);
@@ -260,7 +278,7 @@ TEST_CASE("SWUpdate Prepare Arguments Test v2.1")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh" --target-options --action --target-options "install" --target-options --swu-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh\" --target-options --action --target-options \"install\" --target-options --swu-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     args.clear();
 
     result = SWUpdateHandler_PerformAction(
@@ -272,7 +290,7 @@ TEST_CASE("SWUpdate Prepare Arguments Test v2.1")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh" --target-options --action --target-options "apply" --target-options --swu-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh\" --target-options --action --target-options \"apply\" --target-options --swu-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     args.clear();
 
     result = SWUpdateHandler_PerformAction(
@@ -284,7 +302,7 @@ TEST_CASE("SWUpdate Prepare Arguments Test v2.1")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh" --target-options --action --target-options "cancel" --target-options --swu-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh\" --target-options --action --target-options \"cancel\" --target-options --swu-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     args.clear();
 
     result = SWUpdateHandler_PerformAction(
@@ -296,7 +314,7 @@ TEST_CASE("SWUpdate Prepare Arguments Test v2.1")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh" --target-options --action --target-options "is-installed" --target-options --swu-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --work-folder --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8" --target-options --result-file --target-options "/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json" --target-options --installed-criteria --target-options "grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/example-du-swupdate-script-2.1.sh\" --target-options --action --target-options \"is-installed\" --target-options --swu-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --work-folder --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8\" --target-options --result-file --target-options \"/var/lib/adu/downloads/d19de7fb-11d8-45f7-88e0-03872a591de8/aduc_result.json\" --target-options --installed-criteria --target-options \"grep '^This is swupdate filecopy test api version 2.1$' /usr/local/du/tests/swupdate-filecopy-test/mock-update-for-file-copy-test-1.txt\""));
     args.clear();
 
     workflow_free(handle);
@@ -314,14 +332,15 @@ TEST_CASE("SWUpdate sample script --action-is-installed")
     CHECK(swupdateHandler != nullptr);
     ExtensionManager::SetUpdateContentHandlerExtension("microsoft/swupdate:2", swupdateHandler);
 
-    ADUC_SystemUtils_RmDirRecursive("/tmp/adu/testdata/test-device");
+    ADUC_SystemUtils_RmDirRecursive((std::string(ADUC_TEST_DATA_FOLDER) + "/test-device").c_str());
 
     // Create test workflow data.
+    std::string workflow_json = get_filecopy_workflow_2();
     ADUC_WorkflowHandle handle = nullptr;
-    ADUC_Result result = workflow_init(filecopy_workflow_2, false, &handle);
+    ADUC_Result result = workflow_init(workflow_json.c_str(), false, &handle);
     CHECK(result.ResultCode != 0);
 
-    workflow_set_workfolder(handle, "/tmp/adu/testdata/swupdate_filecopy");
+    workflow_set_workfolder(handle, (std::string(ADUC_TEST_DATA_FOLDER) + "/swupdate_filecopy").c_str());
 
     result = PrepareStepsWorkflowDataObject(handle);
     CHECK(result.ResultCode != 0);
@@ -346,7 +365,7 @@ TEST_CASE("SWUpdate sample script --action-is-installed")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/tmp/adu/testdata/swupdate_filecopy/example-du-swupdate-script.sh" --target-options --action-is-installed --target-options --swu-file --target-options "/tmp/adu/testdata/swupdate_filecopy/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --software-version-file --target-options "/tmp/adu/testdata/test-device/vacuum-1/data/mock-update-for-file-copy-test-1.txt" --target-options --work-folder --target-options "/tmp/adu/testdata/swupdate_filecopy" --target-options --result-file --target-options "/tmp/adu/testdata/swupdate_filecopy/aduc_result.json" --target-options --installed-criteria --target-options "This is swupdate filecopy test version 1.0")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy/example-du-swupdate-script.sh\" --target-options --action-is-installed --target-options --swu-file --target-options \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --software-version-file --target-options \"" + ADUC_TEST_DATA_FOLDER + "/test-device/vacuum-1/data/mock-update-for-file-copy-test-1.txt\" --target-options --work-folder --target-options \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy\" --target-options --result-file --target-options \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy/aduc_result.json\" --target-options --installed-criteria --target-options \"This is swupdate filecopy test version 1.0\""));
 
     std::string output;
     int exitCode = ADUC_LaunchChildProcess(commandLineArgs[0], commandLineArgs, output);
@@ -354,7 +373,7 @@ TEST_CASE("SWUpdate sample script --action-is-installed")
     CHECK(exitCode == 0);
 
     // Check result file.
-    bool fileOk = ReadResultFile("/tmp/adu/testdata/swupdate_filecopy/aduc_result.json", &result);
+    bool fileOk = ReadResultFile((std::string(ADUC_TEST_DATA_FOLDER) + "/swupdate_filecopy/aduc_result.json").c_str(), &result);
     CHECK(fileOk);
     CHECK(result.ResultCode == 901);
     CHECK(result.ExtendedResultCode == 806359140); // (0x30101064)
@@ -375,11 +394,12 @@ TEST_CASE("SWUpdate sample script --action-download")
     ExtensionManager::SetUpdateContentHandlerExtension("microsoft/swupdate:2", swupdateHandler);
 
     // Create test workflow data.
+    std::string workflow_json = get_filecopy_workflow_2();
     ADUC_WorkflowHandle handle = nullptr;
-    ADUC_Result result = workflow_init(filecopy_workflow_2, false, &handle);
+    ADUC_Result result = workflow_init(workflow_json.c_str(), false, &handle);
     CHECK(result.ResultCode != 0);
 
-    workflow_set_workfolder(handle, "/tmp/adu/testdata/swupdate_filecopy");
+    workflow_set_workfolder(handle, (std::string(ADUC_TEST_DATA_FOLDER) + "/swupdate_filecopy").c_str());
 
     result = PrepareStepsWorkflowDataObject(handle);
     CHECK(result.ResultCode != 0);
@@ -404,7 +424,7 @@ TEST_CASE("SWUpdate sample script --action-download")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"( --config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/tmp/adu/testdata/swupdate_filecopy/example-du-swupdate-script.sh" --target-options --action-download --target-options --swu-file --target-options "/tmp/adu/testdata/swupdate_filecopy/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --software-version-file --target-options "/tmp/adu/testdata/test-device/vacuum-1/data/mock-update-for-file-copy-test-1.txt" --target-options --work-folder --target-options "/tmp/adu/testdata/swupdate_filecopy" --target-options --result-file --target-options "/tmp/adu/testdata/swupdate_filecopy/aduc_result.json" --target-options --installed-criteria --target-options "This is swupdate filecopy test version 1.0")"));
+            std::string(" --config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy/example-du-swupdate-script.sh\" --target-options --action-download --target-options --swu-file --target-options \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --software-version-file --target-options \"" + ADUC_TEST_DATA_FOLDER + "/test-device/vacuum-1/data/mock-update-for-file-copy-test-1.txt\" --target-options --work-folder --target-options \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy\" --target-options --result-file --target-options \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy/aduc_result.json\" --target-options --installed-criteria --target-options \"This is swupdate filecopy test version 1.0\""));
 
     std::string output;
     int exitCode = ADUC_LaunchChildProcess(commandLineArgs[0], commandLineArgs, output);
@@ -412,7 +432,7 @@ TEST_CASE("SWUpdate sample script --action-download")
     CHECK(exitCode == 0);
 
     // Check result file.
-    bool fileOk = ReadResultFile("/tmp/adu/testdata/swupdate_filecopy/aduc_result.json", &result);
+    bool fileOk = ReadResultFile((std::string(ADUC_TEST_DATA_FOLDER) + "/swupdate_filecopy/aduc_result.json").c_str(), &result);
     CHECK(fileOk);
     CHECK(result.ResultCode == 500);
     CHECK(result.ExtendedResultCode == 0);
@@ -433,11 +453,12 @@ TEST_CASE("SWUpdate sample script --action-install", "[.hide][functional_test]")
     ExtensionManager::SetUpdateContentHandlerExtension("microsoft/swupdate:2", swupdateHandler);
 
     // Create test workflow data.
+    std::string workflow_json = get_filecopy_workflow_2();
     ADUC_WorkflowHandle handle = nullptr;
-    ADUC_Result result = workflow_init(filecopy_workflow_2, false, &handle);
+    ADUC_Result result = workflow_init(workflow_json.c_str(), false, &handle);
     CHECK(result.ResultCode != 0);
 
-    workflow_set_workfolder(handle, "/tmp/adu/testdata/swupdate_filecopy");
+    workflow_set_workfolder(handle, (std::string(ADUC_TEST_DATA_FOLDER) + "/swupdate_filecopy").c_str());
 
     result = PrepareStepsWorkflowDataObject(handle);
     CHECK(result.ResultCode != 0);
@@ -462,7 +483,7 @@ TEST_CASE("SWUpdate sample script --action-install", "[.hide][functional_test]")
     CHECK_THAT(
         scriptOutput,
         Equals(
-            R"(--config-folder "/tmp/adu/testdata/swupdate_handler_v2_test_config" --update-type "microsoft/script" --update-action "execute" --target-data "/tmp/adu/testdata/swupdate_filecopy/example-du-swupdate-script.sh" --target-options --action-install --target-options --swu-file --target-options "/tmp/adu/testdata/swupdate_filecopy/du-agent-swupdate-filecopy-test-1_1.0.swu" --target-options --software-version-file --target-options "/tmp/adu/testdata/test-device/vacuum-1/data/mock-update-for-file-copy-test-1.txt" --target-options --work-folder --target-options "/tmp/adu/testdata/swupdate_filecopy" --target-options --result-file --target-options "/tmp/adu/testdata/swupdate_filecopy/aduc_result.json" --target-options --installed-criteria --target-options "This is swupdate filecopy test version 1.0")"));
+            std::string("--config-folder \"") + ADUC_TEST_DATA_FOLDER + "/swupdate_handler_v2_test_config\" --update-type \"microsoft/script\" --update-action \"execute\" --target-data \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy/example-du-swupdate-script.sh\" --target-options --action-install --target-options --swu-file --target-options \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy/du-agent-swupdate-filecopy-test-1_1.0.swu\" --target-options --software-version-file --target-options \"" + ADUC_TEST_DATA_FOLDER + "/test-device/vacuum-1/data/mock-update-for-file-copy-test-1.txt\" --target-options --work-folder --target-options \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy\" --target-options --result-file --target-options \"" + ADUC_TEST_DATA_FOLDER + "/swupdate_filecopy/aduc_result.json\" --target-options --installed-criteria --target-options \"This is swupdate filecopy test version 1.0\""));
 
     std::string output;
     int exitCode = ADUC_LaunchChildProcess(commandLineArgs[0], commandLineArgs, output);
@@ -472,7 +493,7 @@ TEST_CASE("SWUpdate sample script --action-install", "[.hide][functional_test]")
     printf("Output:\n%s", output.c_str());
 
     // Check result file.
-    bool fileOk = ReadResultFile("/tmp/adu/testdata/swupdate_filecopy/aduc_result.json", &result);
+    bool fileOk = ReadResultFile((std::string(ADUC_TEST_DATA_FOLDER) + "/swupdate_filecopy/aduc_result.json").c_str(), &result);
     CHECK(fileOk);
     CHECK(result.ResultCode == 600);
     CHECK(result.ExtendedResultCode == 0);
@@ -493,11 +514,12 @@ TEST_CASE("SWUpdate sample script --action-apply")
     ExtensionManager::SetUpdateContentHandlerExtension("microsoft/swupdate:2", swupdateHandler);
 
     // Create test workflow data.
+    std::string workflow_json = get_filecopy_workflow_2();
     ADUC_WorkflowHandle handle = nullptr;
-    ADUC_Result result = workflow_init(filecopy_workflow_2, false, &handle);
+    ADUC_Result result = workflow_init(workflow_json.c_str(), false, &handle);
     CHECK(result.ResultCode != 0);
 
-    workflow_set_workfolder(handle, "/tmp/adu/testdata/swupdate_filecopy");
+    workflow_set_workfolder(handle, (std::string(ADUC_TEST_DATA_FOLDER) + "/swupdate_filecopy").c_str());
 
     result = PrepareStepsWorkflowDataObject(handle);
     CHECK(result.ResultCode != 0);
@@ -527,7 +549,7 @@ TEST_CASE("SWUpdate sample script --action-apply")
     printf("Output:\n%s", output.c_str());
 
     // Check result file.
-    bool fileOk = ReadResultFile("/tmp/adu/testdata/swupdate_filecopy/aduc_result.json", &result);
+    bool fileOk = ReadResultFile((std::string(ADUC_TEST_DATA_FOLDER) + "/swupdate_filecopy/aduc_result.json").c_str(), &result);
     CHECK(fileOk);
     CHECK(result.ResultCode == 700);
     CHECK(result.ExtendedResultCode == 0);
@@ -548,11 +570,12 @@ TEST_CASE("SWUpdate sample script --action-cancel")
     ExtensionManager::SetUpdateContentHandlerExtension("microsoft/swupdate:2", swupdateHandler);
 
     // Create test workflow data.
+    std::string workflow_json = get_filecopy_workflow_2();
     ADUC_WorkflowHandle handle = nullptr;
-    ADUC_Result result = workflow_init(filecopy_workflow_2, false, &handle);
+    ADUC_Result result = workflow_init(workflow_json.c_str(), false, &handle);
     CHECK(result.ResultCode != 0);
 
-    workflow_set_workfolder(handle, "/tmp/adu/testdata/swupdate_filecopy");
+    workflow_set_workfolder(handle, (std::string(ADUC_TEST_DATA_FOLDER) + "/swupdate_filecopy").c_str());
 
     result = PrepareStepsWorkflowDataObject(handle);
     CHECK(result.ResultCode != 0);
@@ -582,7 +605,7 @@ TEST_CASE("SWUpdate sample script --action-cancel")
     printf("Output:\n%s", output.c_str());
 
     // Check result file.
-    bool fileOk = ReadResultFile("/tmp/adu/testdata/swupdate_filecopy/aduc_result.json", &result);
+    bool fileOk = ReadResultFile((std::string(ADUC_TEST_DATA_FOLDER) + "/swupdate_filecopy/aduc_result.json").c_str(), &result);
     CHECK(fileOk);
     CHECK(result.ResultCode == 801);
     CHECK(result.ExtendedResultCode == 0);


### PR DESCRIPTION
This improvement enhances flexibility for building and testing the ADU agent in containerized and restricted environments by introducing a configurable --work-folder option to both build.sh and install-deps.sh scripts.

Key improvements:
- Added --work-folder parameter to build.sh to allow specifying custom temporary artifact storage location (replaces hardcoded /tmp usage)
- Added --work-folder parameter to install-deps.sh for consistency, allowing custom dependency build location
- Updated docker-build.yml workflow to pass --work-folder parameter to both scripts, ensuring builds work in environments where /tmp is noexec or has size constraints
- Updated .gitignore to exclude .workspace/ directory (temporary build artifacts)
- Updated build system to pass ADUC_TMP_DIR_PATH to CMake configuration
- Fixed unit tests to use dynamic ADUC_TEST_DATA_FOLDER macro instead of hardcoded /tmp paths, improving test portability across different environments

Benefits:
- Builds now work in Docker containers and restricted environments
- Custom /tmp alternatives can be specified (e.g., /workspace, /home, etc.)
- Test data paths are no longer hardcoded, improving test flexibility
- Source code can be preserved between builds with --keep-source-code option
- Build artifacts survive system reboots when using custom work folders

Documentation:
- Added sections explaining --work-folder option usage in how-to-build-agent-code.md
- Included examples of using custom work folders in containerized environments