### PR TITLE
Report detailed error result for failed workflows

### DIFF
--- a/src/adu_workflow/src/agent_workflow.c
+++ b/src/adu_workflow/src/agent_workflow.c
@@ -1033,7 +1033,7 @@ void ADUC_Workflow_WorkCompletionCallback(const void* workCompletionToken, ADUC_
             // Reset so that a Retry/Replacement avoids cancel and instead properly starts processing.
             workflow_set_operation_in_progress(workflowData->WorkflowHandle, false);
 
-            ADUC_Workflow_SetUpdateState(workflowData, nextUpdateStateOnFailure);
+            ADUC_Workflow_SetUpdateStateWithResult(workflowData, nextUpdateStateOnFailure, result);
 
             ADUC_Workflow_AutoTransitionWorkflow(workflowData, false);
         }


### PR DESCRIPTION
Include the error result for failed workflows as do the other states such as cancel, invalid desired update action data, etc to make it consistent.

Thanks to my colleague for this change @HenrikAndreasen-Zoetis