### PR TITLE
Show ExtendedResultCode in IoTHub for "Last Attempted Update" in "Details"

### DIFF
--- a/src/adu_types/inc/aduc/types/update_content.h
+++ b/src/adu_types/inc/aduc/types/update_content.h
@@ -65,6 +65,11 @@ EXTERN_C_BEGIN
 #define ADUCITF_FIELDNAME_RESULTCODE "resultCode"
 
 /**
+ * @brief JSON field name for ExtendedResultCode property.
+ */
+#define ADUCITF_FIELDNAME_EXTENDEDRESULTCODE "extendedResultCode"
+
+/**
  * @brief JSON field name for ExtendedResultCodes property.
  */
 #define ADUCITF_FIELDNAME_EXTENDEDRESULTCODES "extendedResultCodes"

--- a/src/agent/adu_core_interface/src/adu_core_interface.c
+++ b/src/agent/adu_core_interface/src/adu_core_interface.c
@@ -491,12 +491,20 @@ void AzureDeviceUpdateCoreInterface_PropertyUpdateCallback(
 // Reporting
 //
 static JSON_Status _json_object_set_update_result(
-    JSON_Object* object, int32_t resultCode, STRING_HANDLE extendedResultCodes, const char* resultDetails)
+    JSON_Object* object, ADUC_Result result, STRING_HANDLE extendedResultCodes, const char* resultDetails)
 {
-    JSON_Status status = json_object_set_number(object, ADUCITF_FIELDNAME_RESULTCODE, resultCode);
+    JSON_Status status = json_object_set_number(object, ADUCITF_FIELDNAME_RESULTCODE, result.ResultCode);
     if (status != JSONSuccess)
     {
         Log_Error("Could not set value for field: %s", ADUCITF_FIELDNAME_RESULTCODE);
+        goto done;
+    }
+
+    // Show ExtendedResultCode in IoTHub for "Last Attempted Update" in "Details"
+    status = json_object_set_number(object, ADUCITF_FIELDNAME_EXTENDEDRESULTCODE, result.ExtendedResultCode);
+    if (status != JSONSuccess)
+    {
+        Log_Error("Could not set value for field: %s", ADUCITF_FIELDNAME_EXTENDEDRESULTCODE);
         goto done;
     }
 
@@ -776,7 +784,7 @@ JSON_Value* GetReportingJsonValue(
 
     // Set top-level update state and result.
     jsonStatus = _json_object_set_update_result(
-        lastInstallResultObject, rootResult.ResultCode, rootResultERCs, workflow_peek_result_details(handle));
+        lastInstallResultObject, rootResult, rootResultERCs, workflow_peek_result_details(handle));
 
     if (jsonStatus != JSONSuccess)
     {
@@ -833,7 +841,7 @@ JSON_Value* GetReportingJsonValue(
                 ADUC_ReportingUtils_CreateReportingErcHexStr(childResult.ExtendedResultCode, true /* is_first */);
             jsonStatus = _json_object_set_update_result(
                 childResultObject,
-                childResult.ResultCode,
+                childResult,
                 childExtendedResultCodes,
                 workflow_peek_result_details(childHandle));
 


### PR DESCRIPTION
When there is a failure the "Extended result code" of "Last Attempted Update" is not being displayed in Azure IoT Hub.

After the PR:

<img width="1129" height="1361" alt="image" src="https://github.com/user-attachments/assets/f936b3e0-7934-4734-a203-5641e48ddce7" />


Thanks to my colleague for this change @HenrikAndreasen-Zoetis