### PR TITLE
chore: add run_coverage.sh script to generate code coverage report

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,6 +58,7 @@ work_folder="$(dirname "${GITROOT}")/.adu-tmp"
 cmake_dir_path="${work_folder}/deviceupdate-cmake"
 cmake_bin="cmake"
 rootkeypkg_curl=false
+enable_coverage=false
 
 #
 # Export the compiler settings in case VM is wonky
@@ -121,6 +122,9 @@ Usage: build.sh [options...]
     --patch-version                       Patch version of ADU
 
     --rootkeypkg-curl                     Download the RootKey Package with curl instead of delivery optimization agent.
+
+    --coverage                            Enable coverage mode in build.sh:
+                                            instrumented build, force unit tests, then run test+report workflow.
 
     -h, --help                            Show this help message.
 
@@ -392,6 +396,9 @@ while [[ $1 != "" ]]; do
     --rootkeypkg-curl)
         rootkeypkg_curl="true"
         ;;
+    --coverage)
+        enable_coverage=true
+        ;;
     -h | --help)
         print_help
         $ret 0
@@ -409,6 +416,16 @@ done
 # work_folder has been set if --work-folder was specified.
 if [[ -z $cmake_dir_path ]]; then
     cmake_dir_path="${work_folder}/deviceupdate-cmake"
+fi
+
+# Coverage mode is owned by build.sh. It forces unit-test build and
+# applies instrumentation flags so the follow-up coverage step has data.
+if [[ $enable_coverage == "true" ]]; then
+    build_unittests=true
+    build_type=Debug
+    export CFLAGS="--coverage -O0 -g ${CFLAGS:-}"
+    export CXXFLAGS="--coverage -O0 -g ${CXXFLAGS:-}"
+    export LDFLAGS="--coverage ${LDFLAGS:-}"
 fi
 
 # Source build environment from install-deps.sh if it exists
@@ -470,6 +487,7 @@ bullet "Enable file log: $file_log"
 bullet "Logging library: $log_lib"
 bullet "Output directory: $output_directory"
 bullet "Build unit tests: $build_unittests"
+bullet "Coverage mode: $enable_coverage"
 bullet "Enable E2E testing: $enable_e2e_testing"
 bullet "Build packages: $build_packages"
 bullet "CMake: $cmake_bin"
@@ -640,6 +658,17 @@ if [[ $ret_val == 0 && $build_packages == "true" ]]; then
 fi
 
 popd > /dev/null || $ret
+
+if [[ $ret_val == 0 && $enable_coverage == "true" ]]; then
+    coverage_script="$script_dir/run_coverage.sh"
+    if [[ ! -x $coverage_script ]]; then
+        error "Coverage script not found or not executable: $coverage_script"
+        $ret 1
+    fi
+
+    "$coverage_script" --out-dir "$output_directory"
+    ret_val=$?
+fi
 
 if [[ $ret_val == 0 && $install_adu == "true" ]]; then
     install_adu_components

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+warn() { echo -e "\033[1;33mWarning:\033[0m $*" >&2; }
+error() { echo -e "\033[1;31mError:\033[0m $*" >&2; }
+
+# This script mainly does 2 things:
+# 1) Run unit tests to produce execution data (.gcda).
+# 2) Generate and publish a Cobertura coverage report.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+root_dir="$script_dir/.."
+
+out_dir="$root_dir/out"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -o | --out-dir)
+        shift
+        if [[ $# -eq 0 || $1 == -* ]]; then
+            error "--out-dir requires a value"
+            exit 1
+        fi
+        out_dir="$1"
+        shift
+        ;;
+    -h | --help)
+        cat << 'EOS'
+Usage: run_coverage.sh [options]
+
+Runs unit tests and generates a gcovr Cobertura XML report for Azure DevOps CI
+integration.
+
+Options:
+  -o, --out-dir <dir>     Build output directory (default: ../out)
+  -h, --help              Show this help
+
+Examples:
+  ./scripts/run_coverage.sh
+EOS
+        exit 0
+        ;;
+    *)
+        error "Invalid argument: $1"
+        exit 1
+        ;;
+    esac
+done
+
+# 1) Run unit tests to produce .gcda files.
+if ! command -v ctest > /dev/null 2>&1; then
+    error "ctest not found in PATH"
+    exit 1
+fi
+
+if ! command -v gcovr > /dev/null 2>&1; then
+    error "gcovr not found in PATH"
+    error "Install with: pip install gcovr"
+    exit 1
+fi
+
+pushd "$out_dir" > /dev/null
+ctest --output-on-failure
+
+coverage_report_dir="$out_dir/coverage"
+coverage_xml_path="$coverage_report_dir/Cobertura.xml"
+mkdir -p "$coverage_report_dir"
+
+# 2) Generate Cobertura report from collected coverage data.
+gcovr \
+    --root "$root_dir" \
+    --object-directory "$out_dir" \
+    --filter ".*/src/.*" \
+    --exclude ".*/tests?/.*" \
+    --exclude ".*/Testing/.*" \
+    --xml-pretty \
+    --output "$coverage_xml_path" \
+    --print-summary
+
+if [[ ! -s $coverage_xml_path ]]; then
+    warn "Cobertura report not generated: $coverage_xml_path"
+    exit 2
+fi
+
+echo "Coverage report (Cobertura XML): $coverage_xml_path"
+
+# Publish to Azure DevOps when running in pipeline context.
+if [[ ${TF_BUILD:-} == "True" || ${TF_BUILD:-} == "true" ]]; then
+    echo "##vso[codecoverage.publish codecoveragetool=Cobertura;summaryfile=$coverage_xml_path;reportdirectory=$coverage_report_dir;]"
+fi
+popd > /dev/null


### PR DESCRIPTION
Add run_coverage.sh script to generate code analysis report.

This script mainly does 2 things:
1) Run unit tests to produce execution data (.gcda).
2) Generate and publish a Cobertura coverage report.

Usage:
`build.sh --coverage`