### PR TITLE
Properly initialize content handler logging

### DIFF
--- a/src/agent/src/main.c
+++ b/src/agent/src/main.c
@@ -770,11 +770,11 @@ bool StartupAgent(const ADUC_LaunchArguments* launchArgs)
     // Send connection string to DO SDK for it to discover the Edge gateway if present.
     if (ConnectionStringUtils_IsNestedEdge(info.connectionString))
     {
-        result = ExtensionManager_InitializeContentDownloader(info.connectionString);
+        result = ExtensionManager_InitializeContentDownloader(info.connectionString, launchArgs->logLevel);
     }
     else
     {
-        result = ExtensionManager_InitializeContentDownloader(NULL /*initializeData*/);
+        result = ExtensionManager_InitializeContentDownloader(NULL /*initializeData*/, launchArgs->logLevel);
     }
 
 #ifdef ADUC_COMMAND_HELPER_H

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
@@ -35,10 +35,12 @@ EXPORTED_METHOD ADUC_Result Download(
 /**
  * @brief One-time initialization for the content downloader.
  *
+ * @param initializeData The initialization data.
  * @param logLevel The desired loglevel if logging is used.
  */
-EXPORTED_METHOD ADUC_Result Initialize(ADUC_LOG_SEVERITY logLevel)
+EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
+    UNREFERENCED_PARAMETER(initializeData); // Always NULL for curl.
     ADUC_Logging_Init(logLevel, "curl-content-downloader");
     return { ADUC_GeneralResult_Success };
 }

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
@@ -11,6 +11,7 @@
 #include <aduc/contract_utils.h> // for ADUC_ExtensionContractInfo
 #include <aduc/types/download.h> // for ADUC_DownloadProgressCallback
 #include <aduc/types/update_content.h> // for ADUC_FileEntity
+#include <aduc/logging.h> // ADUC_Logging_*, Log_*
 
 EXTERN_C_BEGIN
 
@@ -31,10 +32,23 @@ EXPORTED_METHOD ADUC_Result Download(
     return Download_curl(entity, workflowId, workFolder, timeoutInSeconds, downloadProgressCallback);
 }
 
-EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData)
+/**
+ * @brief One-time initialization for the content downloader.
+ *
+ * @param logLevel The desired loglevel if logging is used.
+ */
+EXPORTED_METHOD ADUC_Result Initialize(ADUC_LOG_SEVERITY logLevel)
 {
-    UNREFERENCED_PARAMETER(initializeData);
+    ADUC_Logging_Init(logLevel, "curl-content-downloader");
     return { ADUC_GeneralResult_Success };
+}
+
+/**
+ * @brief Cleanup logic before library is unloaded.
+ */
+EXPORTED_METHOD void Cleanup()
+{
+    ADUC_Logging_Uninit();
 }
 
 /**

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
@@ -40,7 +40,7 @@ EXPORTED_METHOD ADUC_Result Download(
  */
 EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
-    UNREFERENCED_PARAMETER(initializeData); // Always NULL for curl.
+    UNREFERENCED_PARAMETER(initializeData);
     ADUC_Logging_Init(logLevel, "curl-content-downloader");
     return { ADUC_GeneralResult_Success };
 }

--- a/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
@@ -54,10 +54,12 @@ EXPORTED_METHOD ADUC_Result GetContractInfo(ADUC_ExtensionContractInfo* contract
  * @brief Initializes the content downloader.
  *
  * @param initializeData The initialization data.
+ * @param logLevel The desired loglevel if logging is used.
  * @return ADUC_Result The result.
  */
-EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData)
+EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
+    ADUC_Logging_Init(logLevel, "deliveryoptimization-content-downloader");
     ADUC_Result result{ ADUC_GeneralResult_Success };
 
 #if defined(WIN32)
@@ -97,6 +99,14 @@ EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData)
 
 done:
     return result;
+}
+
+/**
+ * @brief Cleanup logic before library is unloaded.
+ */
+EXPORTED_METHOD void Cleanup()
+{
+    ADUC_Logging_Uninit();
 }
 
 /**

--- a/src/extensions/extension_manager/inc/aduc/extension_manager.h
+++ b/src/extensions/extension_manager/inc/aduc/extension_manager.h
@@ -14,6 +14,7 @@
 #include <aduc/types/download.h> /* ADUC_DownloadProgressCallback */
 #include <aduc/types/update_content.h> /* ADUC_FileEntity */
 #include <aduc/types/workflow.h> /* ADUC_WorkflowHandle */
+#include <aduc/logging.h> /* ADUC_LOG_SEVERITY */
 
 EXTERN_C_BEGIN
 
@@ -21,9 +22,10 @@ EXTERN_C_BEGIN
  * @brief Initializes the content downloader.
  *
  * @param initializeData The initialization data.
+ * @param logLevel The log level for the content downloader.
  * @return ADUC_Result The result of initialization.
  */
-ADUC_Result ExtensionManager_InitializeContentDownloader(const char* initializeData);
+ADUC_Result ExtensionManager_InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel);
 
 /**
  * @brief Downloads by using metadata download handler id and falls back to download with content downloader extension.

--- a/src/extensions/extension_manager/inc/aduc/extension_manager.hpp
+++ b/src/extensions/extension_manager/inc/aduc/extension_manager.hpp
@@ -63,7 +63,7 @@ public:
      * @param[in] initializeData A string contains downloader initialization data.
      * @return ADUC_Result
      */
-    static ADUC_Result InitializeContentDownloader(const char* initializeData);
+    static ADUC_Result InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel);
 
     /**
      * @brief The default download proc resolver.

--- a/src/extensions/extension_manager/src/extension_manager.cpp
+++ b/src/extensions/extension_manager/src/extension_manager.cpp
@@ -778,7 +778,7 @@ done:
     return result;
 }
 
-ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initializeData)
+ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
     void* lib = nullptr;
     InitializeProc _initialize = nullptr;
@@ -811,7 +811,7 @@ ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initialize
 
     try
     {
-        result = _initialize(initializeData);
+        result = _initialize(initializeData, logLevel);
     }
     catch (...)
     {
@@ -989,9 +989,9 @@ done:
 
 EXTERN_C_BEGIN
 
-ADUC_Result ExtensionManager_InitializeContentDownloader(const char* initializeData)
+ADUC_Result ExtensionManager_InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
-    return ExtensionManager::InitializeContentDownloader(initializeData);
+    return ExtensionManager::InitializeContentDownloader(initializeData, logLevel);
 }
 
 ADUC_Result ExtensionManager_Download(

--- a/src/extensions/extension_manager/src/extension_manager.cpp
+++ b/src/extensions/extension_manager/src/extension_manager.cpp
@@ -411,6 +411,12 @@ void ExtensionManager::UnloadAllExtensions()
 
     for (auto& lib : _libs)
     {
+        CleanupProc cleanup = nullptr;
+        cleanup = reinterpret_cast<CleanupProc>(ADUCPAL_dlsym(lib.second, CONTENT_DOWNLOADER__Cleanup__EXPORT_SYMBOL));
+        if (cleanup != nullptr)
+        {
+            cleanup();
+        }
         ADUCPAL_dlclose(lib.second);
     }
 
@@ -426,7 +432,8 @@ ADUC_Result ExtensionManager::LoadContentDownloaderLibrary(void** contentDownloa
 {
     ADUC_Result result = { ADUC_Result_Failure };
     static const char* functionNames[] = { CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL,
-                                           CONTENT_DOWNLOADER__Download__EXPORT_SYMBOL };
+                                           CONTENT_DOWNLOADER__Download__EXPORT_SYMBOL,
+                                           CONTENT_DOWNLOADER__Cleanup__EXPORT_SYMBOL };
     void* extensionLib = nullptr;
     GET_CONTRACT_INFO_PROC getContractInfoFn = nullptr;
 
@@ -781,7 +788,7 @@ done:
 ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
     void* lib = nullptr;
-    InitializeProc _initialize = nullptr;
+    InitializeProc initialize = nullptr;
 
     ADUC_Result result = ExtensionManager::LoadContentDownloaderLibrary(&lib);
     if (IsAducResultCodeFailure(result.ResultCode))
@@ -801,8 +808,8 @@ ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initialize
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    _initialize = reinterpret_cast<InitializeProc>(ADUCPAL_dlsym(lib, CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL));
-    if (_initialize == nullptr)
+    initialize = reinterpret_cast<InitializeProc>(ADUCPAL_dlsym(lib, CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL));
+    if (initialize == nullptr)
     {
         result = { /* .ResultCode = */ ADUC_Result_Failure,
                    /* .ExtendedResultCode = */ ADUC_ERC_CONTENT_DOWNLOADER_INITIALIZEPROC_NOTIMP };
@@ -811,7 +818,7 @@ ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initialize
 
     try
     {
-        result = _initialize(initializeData, logLevel);
+        result = initialize(initializeData, logLevel);
     }
     catch (...)
     {

--- a/src/extensions/inc/aduc/content_downloader_extension.hpp
+++ b/src/extensions/inc/aduc/content_downloader_extension.hpp
@@ -10,9 +10,10 @@
 
 #include "aduc/adu_core_exports.h"
 
+
 EXTERN_C_BEGIN
 
-typedef ADUC_Result (*InitializeProc)(const char* initializeData);
+typedef ADUC_Result (*InitializeProc)(const char* initializeData, ADUC_LOG_SEVERITY logLevel);
 
 typedef ADUC_Result (*DownloadProc)(
     const ADUC_FileEntity* entity,

--- a/src/extensions/inc/aduc/content_downloader_extension.hpp
+++ b/src/extensions/inc/aduc/content_downloader_extension.hpp
@@ -22,6 +22,8 @@ typedef ADUC_Result (*DownloadProc)(
     unsigned int timeoutInSeconds,
     ADUC_DownloadProgressCallback downloadProgressCallback);
 
+typedef void (*CleanupProc)();
+
 EXTERN_C_END
 
 #endif // ADUC_CONTENT_DOWNLOADER_EXTENSION_HPP

--- a/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
+++ b/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
@@ -21,8 +21,9 @@
  * @brief Initializes the content downloader.
  *
  * @param initializeData The initialization data.
+ * @param logLevel The log level for the content downloader.
  * @return ADUC_Result The result.
- * @details ADUC_Result Initialize(const char* initializeData)
+ * @details ADUC_Result Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
  */
 #define CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL "Initialize"
 

--- a/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
+++ b/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
@@ -28,6 +28,12 @@
 #define CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL "Initialize"
 
 /**
+ * @brief Cleanup logic before library is unloaded.
+ */
+#define CONTENT_DOWNLOADER__Cleanup__EXPORT_SYMBOL "Cleanup"
+
+
+/**
  * @brief The download export.
  *
  * @param entity The file entity.


### PR DESCRIPTION
I know you just cleared all Pull Requests, congrats! :sweat_smile: 

Fix #780 show curl logs.

While testing noticed that logLevel was not passed to contentDownloader, needed to pass logLevel so it works as expected for different `-l` parameters.

<img width="2444" height="572" alt="image" src="https://github.com/user-attachments/assets/0f5900ac-7735-4beb-b58c-c0f85c497898" />

do-client logs were also missing, added initialization now.

deliveryoptimization is harder to test for us but did a full build and could see the `do_download` logs now:

<img width="3789" height="405" alt="image" src="https://github.com/user-attachments/assets/f25853f6-61c9-4eab-ac56-40e13619de04" />

### Other changes:

* Added clean up logic when the library is being unloaded and renamed variable for consistency.

