### PR TITLE
Rootkey Validator Tool

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,3 +96,6 @@ add_subdirectory (logging)
 add_subdirectory (platform_layers)
 add_subdirectory (rootkey_workflow)
 add_subdirectory (utils)
+
+# Tools
+add_subdirectory (${CMAKE_SOURCE_DIR}/tools/rootkey_validator ${CMAKE_BINARY_DIR}/tools/rootkey_validator)

--- a/src/rootkey_workflow/tests/rootkey_workflow_ut.cpp
+++ b/src/rootkey_workflow/tests/rootkey_workflow_ut.cpp
@@ -117,6 +117,7 @@ std::string WriteTempPackageAndGetFileUrl(
 
 void ResetRootKeyStoreForTest()
 {
+    RootKeyUtility_ClearLocalStore();
 #ifdef ADUC_ROOTKEY_STORE_PATH
     std::error_code ec;
     std::filesystem::remove_all(std::filesystem::path(ADUC_ROOTKEY_STORE_PATH), ec);

--- a/src/utils/root_key_utils/inc/root_key_util.h
+++ b/src/utils/root_key_utils/inc/root_key_util.h
@@ -26,6 +26,7 @@ ADUC_Result RootKeyUtility_LoadSerializedPackage(const char* fileLocation, char*
 void RootKeyUtility_SetReportingErc(ADUC_Result_t erc);
 void RootKeyUtility_ClearReportingErc();
 ADUC_Result_t RootKeyUtility_GetReportingErc();
+void RootKeyUtility_ClearLocalStore();
 bool ADUC_RootKeyUtility_IsUpdateStoreNeeded(const STRING_HANDLE storePath, const ADUC_RootKeyPackage* packageToTest);
 ADUC_Result RootKeyUtility_GetDisabledSigningKeys(VECTOR_HANDLE* outDisabledSigningKeyList);
 bool RootKeyUtility_RootKeyIsDisabled(const ADUC_RootKeyPackage* rootKeyPackage, const char* keyId);

--- a/src/utils/root_key_utils/src/root_key_util.c
+++ b/src/utils/root_key_utils/src/root_key_util.c
@@ -836,6 +836,16 @@ ADUC_Result_t RootKeyUtility_GetReportingErc()
     return s_rootKeyErc;
 }
 
+void RootKeyUtility_ClearLocalStore()
+{
+    if (s_localStore != NULL)
+    {
+        ADUC_RootKeyPackageUtils_Destroy(s_localStore);
+        free(s_localStore);
+        s_localStore = NULL;
+    }
+}
+
 /**
  * @brief Checks if the local store needs to be updated with the package @p packageToTest
  * @details This function will load the local store if it is not already loaded and then compare the local store with @p packageToTest

--- a/tools/rootkey_validator/CMakeLists.txt
+++ b/tools/rootkey_validator/CMakeLists.txt
@@ -13,11 +13,14 @@ target_sources (${target_name} PRIVATE main.cpp)
 # The rootkeypackage_utils library only compiles one downloader (curl or DO)
 # based on the ROOTKEY_PKG_DOWNLOAD_USE_CURL flag. We want both available at
 # runtime, so compile the other downloader source directly into this tool.
+# DO download is only possible when the DO SDK is available.
 if (ROOTKEY_PKG_DOWNLOAD_USE_CURL)
-    # rootkeypackage_utils already has curl download; add DO download
-    target_sources (
-        ${target_name}
-        PRIVATE ${CMAKE_SOURCE_DIR}/src/utils/rootkeypackage_utils/src/rootkeypackage_do_download.cpp)
+    if (ADUC_BUILD_WITH_DELIVERY_OPTIMIZATION)
+        # rootkeypackage_utils already has curl download; add DO download
+        target_sources (
+            ${target_name}
+            PRIVATE ${CMAKE_SOURCE_DIR}/src/utils/rootkeypackage_utils/src/rootkeypackage_do_download.cpp)
+    endif ()
 else ()
     # rootkeypackage_utils already has DO download; add curl download
     target_sources (
@@ -44,6 +47,10 @@ target_link_libraries (${target_name} PRIVATE aduc::process_utils)
 
 # Link DO SDK for DO download
 target_link_dosdk (${target_name} PRIVATE)
+
+if (ADUC_BUILD_WITH_DELIVERY_OPTIMIZATION)
+    target_compile_definitions (${target_name} PRIVATE ADUC_HAVE_DO_DOWNLOAD=1)
+endif ()
 
 target_compile_definitions (
     ${target_name}

--- a/tools/rootkey_validator/CMakeLists.txt
+++ b/tools/rootkey_validator/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required (VERSION 3.5)
+
+set (target_name rootkey_validator)
+
+include (agentRules)
+
+compileasc99 ()
+disablertti ()
+
+add_executable (${target_name})
+target_sources (${target_name} PRIVATE main.cpp)
+
+# The rootkeypackage_utils library only compiles one downloader (curl or DO)
+# based on the ROOTKEY_PKG_DOWNLOAD_USE_CURL flag. We want both available at
+# runtime, so compile the other downloader source directly into this tool.
+if (ROOTKEY_PKG_DOWNLOAD_USE_CURL)
+    # rootkeypackage_utils already has curl download; add DO download
+    target_sources (
+        ${target_name}
+        PRIVATE ${CMAKE_SOURCE_DIR}/src/utils/rootkeypackage_utils/src/rootkeypackage_do_download.cpp)
+else ()
+    # rootkeypackage_utils already has DO download; add curl download
+    target_sources (
+        ${target_name}
+        PRIVATE ${CMAKE_SOURCE_DIR}/src/utils/rootkeypackage_utils/src/rootkeypackage_curl_download.cpp)
+endif ()
+
+target_include_directories (${target_name} PUBLIC ${ADUC_EXPORT_INCLUDES})
+
+target_link_aziotsharedutil (${target_name} PRIVATE)
+find_package (Parson REQUIRED)
+
+target_link_libraries (
+    ${target_name}
+    PRIVATE
+        aduc::rootkeypackage_utils
+        aduc::root_key_utils
+        aduc::logging
+        aduc::system_utils
+        Parson::parson)
+
+# Link process_utils for curl download (needed by ADUC_LaunchChildProcess)
+target_link_libraries (${target_name} PRIVATE aduc::process_utils)
+
+# Link DO SDK for DO download
+target_link_dosdk (${target_name} PRIVATE)
+
+target_compile_definitions (
+    ${target_name}
+    PRIVATE ADUC_ROOTKEY_STORE_PACKAGE_PATH="${ADUC_ROOTKEY_STORE_PACKAGE_PATH}"
+            ADUC_ROOTKEY_PKG_URL_OVERRIDE="${ADUC_ROOTKEY_PKG_URL_OVERRIDE}")

--- a/tools/rootkey_validator/README.md
+++ b/tools/rootkey_validator/README.md
@@ -1,0 +1,95 @@
+# Root Key Package Validator Tool
+
+A standalone CLI tool that downloads a root key package from a URL and runs it through the full root key validation flow used by the Device Update agent.
+
+## What it does
+
+1. **Downloads** the root key package JSON from the specified URL using either curl or DeliveryOptimization
+2. **Reads** the downloaded JSON file
+3. **Parses** the JSON into an `ADUC_RootKeyPackage` structure
+4. **Validates** the package signatures against the hardcoded root keys compiled into the agent
+
+## Building
+
+This tool is built as part of the main project. From your build directory:
+
+```bash
+# Configure (curl download support is included regardless of this flag)
+cmake ..
+
+# Build just the tool
+cmake --build . --target rootkey_validator
+```
+
+Both curl and DeliveryOptimization downloaders are always compiled into the tool, regardless of the `ADUC_ROOTKEY_PKG_DOWNLOAD_WITH_CURL` build flag. You can select which downloader to use at runtime.
+
+## Usage
+
+```bash
+# Run with defaults (curl downloader, default URL)
+./rootkey_validator
+
+# Use DeliveryOptimization downloader instead
+./rootkey_validator --downloader do
+
+# Use curl downloader explicitly
+./rootkey_validator --downloader curl
+
+# Run with a custom URL
+./rootkey_validator --url "http://example.com/rootkeypackage.json"
+
+# Specify a custom working directory for downloads
+./rootkey_validator --workdir /tmp/my_rootkey_test
+
+# Combine options
+./rootkey_validator --downloader curl --url "http://example.com/rootkeypackage.json" --workdir /tmp/test
+
+# Show help
+./rootkey_validator --help
+```
+
+## Options
+
+| Option         | Default | Description |
+|----------------|---------|-------------|
+| `--url`        | `http://granite-iothub-aat-dui--granite-iothub-aat-du.b.nlu.dl.adu.microsoft.com/SouthCentralUS/rootkeypackages/rootkeypackage-2.json` | URL of the root key package to download |
+| `--workdir`    | `/tmp/rootkey_validator` | Working directory for downloaded files |
+| `--downloader` | `curl` | Download method: `curl` or `do` (DeliveryOptimization) |
+
+### Downloader notes
+
+- **curl** — Shells out to `/usr/bin/curl`. Works on any system with curl installed. This is the default.
+- **do** (DeliveryOptimization) — Uses the DO SDK. Requires the `deliveryoptimization-agent` service to be running.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | Root key package downloaded and validated successfully |
+| 1    | Failure (download, parse, or validation error) |
+
+## Example output
+
+```
+=== Root Key Package Validator Tool ===
+
+URL:        http://granite-iothub-aat-dui--granite-iothub-aat-du.b.nlu.dl.adu.microsoft.com/SouthCentralUS/rootkeypackages/rootkeypackage-2.json
+WorkDir:    /tmp/rootkey_validator
+Downloader: Curl
+
+[Step 1/4] Downloading root key package using Curl...
+[Step 1/4] SUCCESS: Downloaded to /tmp/rootkey_validator/rootkey-validator-tool/rootkeypackage-2.json
+
+[Step 2/4] Reading and parsing JSON...
+[Step 2/4] SUCCESS: Read 3437 bytes of JSON
+
+[Step 3/4] Parsing root key package structure...
+[Step 3/4] SUCCESS: Root key package parsed successfully
+
+[Step 4/4] Validating root key package with hardcoded keys...
+[Step 4/4] SUCCESS: Root key package is VALID
+
+=== Final Result ===
+ResultCode: 1 (0x00000001)
+ERC:        0 (0x00000000)
+Overall:    PASSED

--- a/tools/rootkey_validator/main.cpp
+++ b/tools/rootkey_validator/main.cpp
@@ -1,0 +1,230 @@
+/**
+ * @file main.cpp
+ * @brief Standalone tool that downloads a root key package from a URL
+ * and runs it through the full rootkey validation flow.
+ *
+ * Usage:
+ *   rootkey_validator [--url <URL>] [--workdir <DIR>] [--downloader curl|do]
+ *
+ * Defaults:
+ *   URL:        http://granite-iothub-aat-dui--granite-iothub-aat-du.b.nlu.dl.adu.microsoft.com/SouthCentralUS/rootkeypackages/rootkeypackage-2.json
+ *   workdir:    /tmp/rootkey_validator
+ *   downloader: curl
+ *
+ * @copyright Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ */
+
+#include <aduc/c_utils.h>
+#include <aduc/rootkeypackage_curl_download.h>
+#include <aduc/rootkeypackage_do_download.h>
+#include <aduc/rootkeypackage_download.h>
+#include <aduc/rootkeypackage_parse.h>
+#include <aduc/rootkeypackage_utils.h>
+#include <azure_c_shared_utility/strings.h>
+#include <parson.h>
+#include <root_key_util.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#define DEFAULT_URL                                                                                                    \
+    "http://granite-iothub-aat-dui--granite-iothub-aat-du.b.nlu.dl.adu.microsoft.com/SouthCentralUS/"                  \
+    "rootkeypackages/rootkeypackage-2.json"
+
+#define DEFAULT_WORKDIR "/tmp/rootkey_validator"
+#define WORKFLOW_ID "rootkey-validator-tool"
+
+enum DownloaderType
+{
+    Downloader_Curl,
+    Downloader_DO,
+};
+
+static void print_usage(const char* argv0)
+{
+    fprintf(stderr, "\nUsage: %s [--url <URL>] [--workdir <DIR>] [--downloader curl|do]\n\n", argv0);
+    fprintf(stderr, "  --url         URL of the root key package to download and validate.\n");
+    fprintf(stderr, "                Default: %s\n\n", DEFAULT_URL);
+    fprintf(stderr, "  --workdir     Working directory for downloads.\n");
+    fprintf(stderr, "                Default: %s\n\n", DEFAULT_WORKDIR);
+    fprintf(stderr, "  --downloader  Download method: 'curl' or 'do' (DeliveryOptimization).\n");
+    fprintf(stderr, "                Default: curl\n\n");
+}
+
+static std::string slurp_file(const std::string& filepath)
+{
+    std::ifstream ifs(filepath);
+    if (!ifs.is_open())
+    {
+        return {};
+    }
+    std::stringstream ss;
+    ss << ifs.rdbuf();
+    return ss.str();
+}
+
+int main(int argc, char** argv)
+{
+    const char* url = DEFAULT_URL;
+    const char* workdir = DEFAULT_WORKDIR;
+    DownloaderType downloaderType = Downloader_Curl;
+
+    // Parse command-line arguments
+    for (int i = 1; i < argc; ++i)
+    {
+        if (strcmp(argv[i], "--url") == 0 && i + 1 < argc)
+        {
+            url = argv[++i];
+        }
+        else if (strcmp(argv[i], "--workdir") == 0 && i + 1 < argc)
+        {
+            workdir = argv[++i];
+        }
+        else if (strcmp(argv[i], "--downloader") == 0 && i + 1 < argc)
+        {
+            ++i;
+            if (strcmp(argv[i], "curl") == 0)
+            {
+                downloaderType = Downloader_Curl;
+            }
+            else if (strcmp(argv[i], "do") == 0)
+            {
+                downloaderType = Downloader_DO;
+            }
+            else
+            {
+                fprintf(stderr, "Unknown downloader: '%s'. Must be 'curl' or 'do'.\n", argv[i]);
+                print_usage(argv[0]);
+                return 1;
+            }
+        }
+        else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0)
+        {
+            print_usage(argv[0]);
+            return 0;
+        }
+        else
+        {
+            fprintf(stderr, "Unknown argument: %s\n", argv[i]);
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    const char* downloaderName = (downloaderType == Downloader_Curl) ? "Curl" : "DeliveryOptimization";
+    RootKeyPkgDownloadFunc downloadFn =
+        (downloaderType == Downloader_Curl) ? DownloadRootKeyPkg_Curl : DownloadRootKeyPkg_DO;
+
+    printf("=== Root Key Package Validator Tool ===\n\n");
+    printf("URL:        %s\n", url);
+    printf("WorkDir:    %s\n", workdir);
+    printf("Downloader: %s\n\n", downloaderName);
+
+    ADUC_Result result = { ADUC_GeneralResult_Failure, 0 };
+    STRING_HANDLE downloadedFile = nullptr;
+    ADUC_RootKeyPackage rootKeyPackage{};
+    bool rootKeyPackageInited = false;
+
+    // ---- Step 1: Download ----
+    printf("[Step 1/4] Downloading root key package using %s...\n", downloaderName);
+
+    ADUC_RootKeyPkgDownloaderInfo downloaderInfo{
+        downloaderName,
+        downloadFn,
+        workdir,
+    };
+
+    result = ADUC_RootKeyPackageUtils_DownloadPackage(url, WORKFLOW_ID, &downloaderInfo, &downloadedFile);
+
+    if (IsAducResultCodeFailure(result.ResultCode))
+    {
+        fprintf(
+            stderr,
+            "[Step 1/4] FAILED: Download failed. ResultCode: %d, ERC: 0x%08x\n",
+            result.ResultCode,
+            result.ExtendedResultCode);
+        goto done;
+    }
+
+    printf("[Step 1/4] SUCCESS: Downloaded to %s\n\n", STRING_c_str(downloadedFile));
+
+    // ---- Step 2: Read JSON ----
+    {
+        printf("[Step 2/4] Reading and parsing JSON...\n");
+
+        std::string jsonString = slurp_file(STRING_c_str(downloadedFile));
+        if (jsonString.empty())
+        {
+            fprintf(stderr, "[Step 2/4] FAILED: Could not read file '%s'\n", STRING_c_str(downloadedFile));
+            result.ResultCode = ADUC_GeneralResult_Failure;
+            result.ExtendedResultCode = 0;
+            goto done;
+        }
+
+        printf("[Step 2/4] SUCCESS: Read %zu bytes of JSON\n\n", jsonString.length());
+
+        // ---- Step 3: Parse root key package ----
+        printf("[Step 3/4] Parsing root key package structure...\n");
+
+        result = ADUC_RootKeyPackageUtils_Parse(jsonString.c_str(), &rootKeyPackage);
+
+        if (IsAducResultCodeFailure(result.ResultCode))
+        {
+            fprintf(
+                stderr,
+                "[Step 3/4] FAILED: Parse failed. ResultCode: %d, ERC: 0x%08x\n",
+                result.ResultCode,
+                result.ExtendedResultCode);
+            goto done;
+        }
+
+        rootKeyPackageInited = true;
+        printf("[Step 3/4] SUCCESS: Root key package parsed successfully\n\n");
+    }
+
+    // ---- Step 4: Validate with hardcoded keys ----
+    printf("[Step 4/4] Validating root key package with hardcoded keys...\n");
+
+    result = RootKeyUtility_ValidateRootKeyPackageWithHardcodedKeys(&rootKeyPackage);
+
+    if (IsAducResultCodeFailure(result.ResultCode))
+    {
+        fprintf(
+            stderr,
+            "[Step 4/4] FAILED: Validation failed. ResultCode: %d, ERC: 0x%08x\n",
+            result.ResultCode,
+            result.ExtendedResultCode);
+        goto done;
+    }
+
+    printf("[Step 4/4] SUCCESS: Root key package is VALID\n\n");
+    result.ResultCode = ADUC_GeneralResult_Success;
+
+done:
+    printf("=== Final Result ===\n");
+    printf("ResultCode: %d (0x%08x)\n", result.ResultCode, result.ResultCode);
+    printf("ERC:        %d (0x%08x)\n", result.ExtendedResultCode, result.ExtendedResultCode);
+
+    if (IsAducResultCodeFailure(result.ResultCode))
+    {
+        printf("Overall:    FAILED\n");
+    }
+    else
+    {
+        printf("Overall:    PASSED\n");
+    }
+
+    STRING_delete(downloadedFile);
+
+    if (rootKeyPackageInited)
+    {
+        ADUC_RootKeyPackageUtils_Destroy(&rootKeyPackage);
+    }
+
+    return IsAducResultCodeFailure(result.ResultCode) ? 1 : 0;
+}

--- a/tools/rootkey_validator/main.cpp
+++ b/tools/rootkey_validator/main.cpp
@@ -17,8 +17,11 @@
 
 #include <aduc/c_utils.h>
 #include <aduc/rootkeypackage_curl_download.h>
-#include <aduc/rootkeypackage_do_download.h>
 #include <aduc/rootkeypackage_download.h>
+
+#if ADUC_HAVE_DO_DOWNLOAD
+#include <aduc/rootkeypackage_do_download.h>
+#endif
 #include <aduc/rootkeypackage_parse.h>
 #include <aduc/rootkeypackage_utils.h>
 #include <azure_c_shared_utility/strings.h>
@@ -42,7 +45,9 @@
 enum DownloaderType
 {
     Downloader_Curl,
+#if ADUC_HAVE_DO_DOWNLOAD
     Downloader_DO,
+#endif
 };
 
 static void print_usage(const char* argv0)
@@ -52,7 +57,11 @@ static void print_usage(const char* argv0)
     fprintf(stderr, "                Default: %s\n\n", DEFAULT_URL);
     fprintf(stderr, "  --workdir     Working directory for downloads.\n");
     fprintf(stderr, "                Default: %s\n\n", DEFAULT_WORKDIR);
+#if ADUC_HAVE_DO_DOWNLOAD
     fprintf(stderr, "  --downloader  Download method: 'curl' or 'do' (DeliveryOptimization).\n");
+#else
+    fprintf(stderr, "  --downloader  Download method: 'curl'.\n");
+#endif
     fprintf(stderr, "                Default: curl\n\n");
 }
 
@@ -92,13 +101,19 @@ int main(int argc, char** argv)
             {
                 downloaderType = Downloader_Curl;
             }
+#if ADUC_HAVE_DO_DOWNLOAD
             else if (strcmp(argv[i], "do") == 0)
             {
                 downloaderType = Downloader_DO;
             }
+#endif
             else
             {
+#if ADUC_HAVE_DO_DOWNLOAD
                 fprintf(stderr, "Unknown downloader: '%s'. Must be 'curl' or 'do'.\n", argv[i]);
+#else
+                fprintf(stderr, "Unknown downloader: '%s'. Only 'curl' is supported in this build.\n", argv[i]);
+#endif
                 print_usage(argv[0]);
                 return 1;
             }
@@ -116,9 +131,14 @@ int main(int argc, char** argv)
         }
     }
 
+#if ADUC_HAVE_DO_DOWNLOAD
     const char* downloaderName = (downloaderType == Downloader_Curl) ? "Curl" : "DeliveryOptimization";
     RootKeyPkgDownloadFunc downloadFn =
         (downloaderType == Downloader_Curl) ? DownloadRootKeyPkg_Curl : DownloadRootKeyPkg_DO;
+#else
+    const char* downloaderName = "Curl";
+    RootKeyPkgDownloadFunc downloadFn = DownloadRootKeyPkg_Curl;
+#endif
 
     printf("=== Root Key Package Validator Tool ===\n\n");
     printf("URL:        %s\n", url);


### PR DESCRIPTION
Adds a standalone CLI tool (`rootkey_validator`) that downloads a root key package from a URL and runs it through the full root key validation flow used by the Device Update agent. This tool enables engineers to quickly verify that a root key package can be downloaded, parsed, and validated against the hardcoded root keys without needing to deploy or run the full agent.

Validating root key packages currently requires running the full Device Update agent end-to-end. This tool provides a lightweight, targeted way to test the root key validation pipeline independently, which is useful for:

- Verifying new root key packages before rolling them out
- Debugging root key validation failures in isolation
- Testing with different download methods (curl vs. DeliveryOptimization)
- CI/CD validation of root key package integrity
