### PR TITLE
fix: Fix Curl downloader default

### DIFF
--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -55,7 +55,7 @@ set (CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 
 set (
     CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
-    "${CMAKE_CURRENT_SOURCE_DIR}/debian/preinst;${CMAKE_CURRENT_SOURCE_DIR}/debian/postinst;${CMAKE_CURRENT_SOURCE_DIR}/debian/prerm;${CMAKE_CURRENT_SOURCE_DIR}/debian/postrm"
+    "${CMAKE_CURRENT_SOURCE_DIR}/debian/preinst;${CMAKE_CURRENT_SOURCE_DIR}/debian/postinst;${CMAKE_CURRENT_SOURCE_DIR}/debian/prerm;${CMAKE_CURRENT_SOURCE_DIR}/debian/postrm;${CMAKE_CURRENT_SOURCE_DIR}/debian/config;${CMAKE_CURRENT_SOURCE_DIR}/debian/templates"
 )
 
 include (CPack)

--- a/packages/debian/config
+++ b/packages/debian/config
@@ -4,9 +4,14 @@ set -e
 
 . /usr/share/debconf/confmodule
 
+if [ "$DEBIAN_FRONTEND" = "noninteractive" ]; then
+    exit 0
+fi
+
+
 db_version 2.0
 
-db_input high deviceupdate-agent/content-downloader || true
+db_input low deviceupdate-agent/content-downloader || true
 db_go || true
 
 exit 0

--- a/packages/debian/config
+++ b/packages/debian/config
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+. /usr/share/debconf/confmodule
+
+db_version 2.0
+
+db_input high deviceupdate-agent/content-downloader || true
+db_go || true
+
+exit 0

--- a/packages/debian/postinst
+++ b/packages/debian/postinst
@@ -10,9 +10,28 @@
 # Any error should exit the script (sort of)
 # See https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#The-Set-Builtin
 
-echo "******************** Running $0 $1 ***********************"
 
 set -e
+
+requested_content_downloader="curl"
+if [ -f /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+
+    debconf_content_downloader_key=deviceupdate-agent/content-downloader
+    if db_get "$debconf_content_downloader_key"; then
+        case "$RET" in
+            do|curl)
+                requested_content_downloader="$RET"
+            ;;
+        esac
+    fi
+
+    db_stop || true
+fi
+
+echo "******************** Running $0 $1 ***********************"
+
+postinst_action="$1"
 
 adu_conf_dir=/etc/adu
 adu_conf_file=du-config.json
@@ -217,6 +236,8 @@ setup_dirs_and_files() {
 }
 
 register_reference_extensions() {
+    local requested_downloader="$1"
+
     echo "Register all reference step handlers..."
 
     $adu_bin_path -l 2 --extension-type updateContentHandler --extension-id "microsoft/apt:1" --register-extension $adu_extensions_sources_dir/$adu_apt_handler_file
@@ -231,15 +252,22 @@ register_reference_extensions() {
     $adu_bin_path -l 2 --extension-type componentEnumerator --register-extension $adu_extensions_sources_dir/$adu_example_component_enumerator_file
 
     echo "Register content downloader extension..."
-    if [ -f "$adu_extensions_sources_dir/$adu_curl_content_downloader_file" ]; then
-        echo "Registering curl content downloader..."
-        $adu_bin_path -l 2 --extension-type contentDownloader --register-extension $adu_extensions_sources_dir/$adu_curl_content_downloader_file
-    elif [ -f "$adu_extensions_sources_dir/$adu_delivery_optimization_downloader_file" ]; then
-        echo "Registering DO content downloader..."
-        $adu_bin_path -l 2 --extension-type contentDownloader --register-extension $adu_extensions_sources_dir/$adu_delivery_optimization_downloader_file
+    if [ "$requested_downloader" = "do" ]; then
+        if [ -f "$adu_extensions_sources_dir/$adu_delivery_optimization_downloader_file" ]; then
+            echo "Registering DO content downloader..."
+            $adu_bin_path -l 2 --extension-type contentDownloader --register-extension $adu_extensions_sources_dir/$adu_delivery_optimization_downloader_file
+        else
+            echo "ERROR: DO content downloader was selected, but '$adu_delivery_optimization_downloader_file' is unavailable." >&2
+            exit 1
+        fi
     else
-        echo "ERROR: No content downloader found!"
-        exit 1
+        if [ -f "$adu_extensions_sources_dir/$adu_curl_content_downloader_file" ]; then
+            echo "Registering curl content downloader..."
+            $adu_bin_path -l 2 --extension-type contentDownloader --register-extension $adu_extensions_sources_dir/$adu_curl_content_downloader_file
+        else
+            echo "ERROR: curl content downloader was selected, but '$adu_curl_content_downloader_file' is unavailable." >&2
+            exit 1
+        fi
     fi
 
     echo "Register delta download handler..."
@@ -293,12 +321,14 @@ complete_migration_steps()
     fi
 }
 
-case "$1" in
+case "$postinst_action" in
     configure)
         setup_dirs_and_files
         register_adu_user_and_process_with_eis
 
-        register_reference_extensions
+        echo "Selected content downloader: $requested_content_downloader"
+
+        register_reference_extensions "$requested_content_downloader"
 
         register_and_enable_daemon
 
@@ -333,7 +363,7 @@ case "$1" in
     ;;
 
     *)
-        echo "postinst called with unknown argument \`$1'" >&2
+        echo "postinst called with unknown argument \`$postinst_action\`" >&2
         exit 1
     ;;
 esac

--- a/packages/debian/postinst
+++ b/packages/debian/postinst
@@ -350,13 +350,22 @@ case "$postinst_action" in
 
         # Do not restart the current deviceupdate-agent because we want the update workflow
         # to complete, and reports the agent's state to ADU Management service.
-        echo "============================================================"
-        echo
+        echo "============================================================" >&2
+        echo >&2
         echo "     ADU Agent service must be restarted." >&2
-        echo
+        echo >&2
         echo "     Please run 'sudo systemctl restart deviceupdate-agent'" >&2
-        echo
-        echo "============================================================"
+
+        if [ "$requested_content_downloader" = "curl" ] && [ -f "$adu_extensions_sources_dir/$adu_delivery_optimization_downloader_file" ]; then
+            echo "     Curl content downloader is currently set as the" >&2
+            echo "     default content downloader." >&2
+            echo "     To use Delivery Optimization content downloader," >&2
+            echo "     ensure you have deliveryoptimization-agent installed" >&2
+            echo "     and run 'sudo dpkg-reconfigure deviceupdate-agent'" >&2
+            echo "     to select DO content downloader." >&2
+        fi
+        echo >&2
+        echo "============================================================" >&2
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/debian/postinst
+++ b/packages/debian/postinst
@@ -36,7 +36,6 @@ adu_swupdate_handler_2_file=libmicrosoft_swupdate_2.so
 
 adu_example_component_enumerator_file=libcontoso_component_enumerator.so
 
-adu_curl_downloader_file=libcurl_content_downloader.so
 adu_delivery_optimization_downloader_file=libdeliveryoptimization_content_downloader.so
 adu_curl_content_downloader_file=libcurl_content_downloader.so
 
@@ -49,7 +48,7 @@ eis_idservice_dir=/etc/aziot/identityd/config.d
 # ADU Agent daemon needs to run as 'adu' user to be able to perform high-privilege tasks via adu-shell.
 adu_user=adu
 
-# The adu_group is the group that gives admins and partner users 
+# The adu_group is the group that gives admins and partner users
 # access to ADU resources like sandbox folder.
 adu_group=adu
 
@@ -232,12 +231,12 @@ register_reference_extensions() {
     $adu_bin_path -l 2 --extension-type componentEnumerator --register-extension $adu_extensions_sources_dir/$adu_example_component_enumerator_file
 
     echo "Register content downloader extension..."
-    if [ -f "$adu_extensions_sources_dir/$adu_delivery_optimization_downloader_file" ]; then
-        echo "Registering DO content downloader..."
-        $adu_bin_path -l 2 --extension-type contentDownloader --register-extension $adu_extensions_sources_dir/$adu_delivery_optimization_downloader_file
-    elif [ -f "$adu_extensions_sources_dir/$adu_curl_content_downloader_file" ]; then
+    if [ -f "$adu_extensions_sources_dir/$adu_curl_content_downloader_file" ]; then
         echo "Registering curl content downloader..."
         $adu_bin_path -l 2 --extension-type contentDownloader --register-extension $adu_extensions_sources_dir/$adu_curl_content_downloader_file
+    elif [ -f "$adu_extensions_sources_dir/$adu_delivery_optimization_downloader_file" ]; then
+        echo "Registering DO content downloader..."
+        $adu_bin_path -l 2 --extension-type contentDownloader --register-extension $adu_extensions_sources_dir/$adu_delivery_optimization_downloader_file
     else
         echo "ERROR: No content downloader found!"
         exit 1
@@ -302,6 +301,20 @@ case "$1" in
         register_reference_extensions
 
         register_and_enable_daemon
+
+        # Note: DO user and group are created by deliveryoptimization-agent Debian package,
+        # We are assuming that both DO user and group currently exist at this point.
+        # Add 'do' user to 'adu' group to allow DO to write to ADU download sandbox.
+        echo "Add the 'do' user to the 'adu' group and 'adu' to the 'do' group"
+        if getent passwd 'do' > /dev/null; then
+            usermod -aG 'adu' 'do'
+            # Note: We must add the 'adu' user to the 'do' group so that we can set the connection_string for DO
+            usermod -aG 'do' 'adu'
+
+            # Restart deliveryoptimization-agent service to ensure that the new 'do' user's groups take effect.
+            echo "Restart $ms_doclient_lite_service"
+            systemctl restart "$ms_doclient_lite_service"
+        fi
 
         complete_migration_steps
 

--- a/packages/debian/templates
+++ b/packages/debian/templates
@@ -6,5 +6,6 @@ Description: Select content downloader for Device Update agent
  Choose which content downloader implementation the Device Update agent should
  register during package installation.
  .
- - curl: Registers the curl downloader.
+ - curl (default): Registers the curl downloader.
+ .
  - do: Registers the Delivery Optimization downloader.

--- a/packages/debian/templates
+++ b/packages/debian/templates
@@ -6,6 +6,6 @@ Description: Select content downloader for Device Update agent
  Choose which content downloader implementation the Device Update agent should
  register during package installation.
  .
- - curl (default): Registers the curl downloader.
+ - curl: Registers the curl downloader. (default)
  .
  - do: Registers the Delivery Optimization downloader.

--- a/packages/debian/templates
+++ b/packages/debian/templates
@@ -1,0 +1,10 @@
+Template: deviceupdate-agent/content-downloader
+Type: select
+Choices: curl, do
+Default: curl
+Description: Select content downloader for Device Update agent
+ Choose which content downloader implementation the Device Update agent should
+ register during package installation.
+ .
+ - curl: Registers the curl downloader.
+ - do: Registers the Delivery Optimization downloader.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -51,6 +51,7 @@ cmake_dir_path="${work_folder}/deviceupdate-cmake"
 cmake_bin="cmake"
 rootkeypkg_curl=true
 enable_coverage=false
+support_delivery_optimization=false
 
 #
 # Export the compiler settings in case VM is wonky
@@ -88,6 +89,10 @@ Usage: build.sh [options...]
                                         Only valid for logging libraries that support file logging.
 
     --install-prefix <prefix>             Install prefix to pass to CMake.
+
+    --support-delivery-optimization     Whether to build with Delivery Optimization support. By default, it is disabled.
+                                            Note: Delivery Optimization is only supported on certain older platforms and OS versions.
+                                            It is won't be enabled on Ubuntu 24.04 and Debian 13 (trixie) and newer OS even if this option is specified.
 
     --install                             Install the following ADU components.
                                             From source: deviceupdate-agent.service & adu-swupdate.sh.
@@ -306,6 +311,9 @@ while [[ $1 != "" ]]; do
     --build-service-e2e-agent)
         srvc_e2e_agent_build=true
         ;;
+    --support-delivery-optimization)
+        support_delivery_optimization=true
+        ;;
     --log-lib)
         shift
         if [[ -z $1 || $1 == -* ]]; then
@@ -454,6 +462,20 @@ if [[ $srvc_e2e_agent_build == "true" ]]; then
     build_packages=true
 fi
 
+# Disable DO on Ubuntu 24.04 and newer
+if [[ $OS == "ubuntu" && $VER == "24.04" ]]; then
+    echo "WARN: Disabling Delivery Optimization for Ubuntu 24.04"
+    support_delivery_optimization=false
+    rootkeypkg_curl=true
+fi
+
+# Disable DO on Debian 13 (trixie) - not yet supported
+if [[ $OS == "debian" && $VER == "13" ]]; then
+    echo "WARN: Disabling Delivery Optimization for Debian 13 (not yet supported)"
+    support_delivery_optimization=false
+    rootkeypkg_curl=true
+fi
+
 # Output banner
 echo ''
 header "Building ADU Agent"
@@ -483,6 +505,7 @@ else
 fi
 bullet "Include Test Root Keys: $use_test_root_keys"
 bullet "Use Curl, not DO, for RootKey Package Download? $rootkeypkg_curl"
+bullet "Support Delivery Optimization: $support_delivery_optimization"
 echo ''
 
 CMAKE_OPTIONS=(
@@ -499,6 +522,7 @@ CMAKE_OPTIONS=(
     "-DADUC_TRACE_TARGET_DEPS=$trace_target_deps"
     "-DADUC_USE_TEST_ROOT_KEYS=$use_test_root_keys"
     "-DADUC_ROOTKEY_PKG_DOWNLOAD_WITH_CURL=$rootkeypkg_curl"
+    "-DADUC_BUILD_WITH_DELIVERY_OPTIMIZATION:BOOL=$support_delivery_optimization"
     "-DADUC_TMP_DIR_PATH:STRING=$work_folder"
     "-DCMAKE_BUILD_TYPE:STRING=$build_type"
     "-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON"
@@ -506,20 +530,6 @@ CMAKE_OPTIONS=(
     "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY:STRING=$runtime_dir"
     "-DCMAKE_INSTALL_PREFIX=$install_prefix"
 )
-
-# Disable DO on Ubuntu 24.04 and newer
-if [[ $OS == "ubuntu" && $VER == "24.04" ]]; then
-    echo "Disabling Delivery Optimization for Ubuntu 24.04"
-    CMAKE_OPTIONS+=("-DADUC_BUILD_WITH_DELIVERY_OPTIMIZATION=OFF")
-    CMAKE_OPTIONS+=("-DADUC_ROOTKEY_PKG_DOWNLOAD_WITH_CURL=ON")
-fi
-
-# Disable DO on Debian 13 (trixie) - not yet supported
-if [[ $OS == "debian" && $VER == "13" ]]; then
-    echo "Disabling Delivery Optimization for Debian 13 (not yet supported)"
-    CMAKE_OPTIONS+=("-DADUC_BUILD_WITH_DELIVERY_OPTIMIZATION=OFF")
-    CMAKE_OPTIONS+=("-DADUC_ROOTKEY_PKG_DOWNLOAD_WITH_CURL=ON")
-fi
 
 if [[ $major_version != "" ]]; then
     CMAKE_OPTIONS+=("-DADUC_VERSION_MAJOR=$major_version")
@@ -531,6 +541,10 @@ if [[ $patch_version != "" ]]; then
     CMAKE_OPTIONS+=("-DADUC_VERSION_PATCH=$patch_version")
 fi
 
+echo "CMAKE Options:"
+for opt in "${CMAKE_OPTIONS[@]}"; do
+    echo "  $opt"
+done
 for i in "${static_analysis_tools[@]}"; do
     case $i in
     clang-tidy)


### PR DESCRIPTION
This Would prefer to use the curl downloader over the DO downloader whenever available.

It would also ensure that the adu user is part of the 'do' group when available

It also introduces a prompt for picking the default registered downloader
<img width="1186" height="584" alt="image" src="https://github.com/user-attachments/assets/c447bec5-be45-48cd-b7f7-767a372b5bf4" />
