### PR TITLE
Fix shellcheck warnings across all shell scripts

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -755,7 +755,9 @@ do_install_delta() {
     if [[ -f $dumpextfs_cmake ]] && ! grep -q "com_err" "$dumpextfs_cmake"; then
         echo "Patching dumpextfs CMakeLists.txt to add com_err linkage..."
         sed -i 's/pkg_check_modules(E2FSPROGS REQUIRED ext2fs)/pkg_check_modules(E2FSPROGS REQUIRED ext2fs)\npkg_check_modules(COM_ERR REQUIRED com_err)/' "$dumpextfs_cmake"
+        # shellcheck disable=SC2016 # CMake variables, not shell
         sed -i 's/target_include_directories(dumpextfs PRIVATE ${E2FSPROGS_INCLUDE_DIRS})/target_include_directories(dumpextfs PRIVATE ${E2FSPROGS_INCLUDE_DIRS} ${COM_ERR_INCLUDE_DIRS})/' "$dumpextfs_cmake"
+        # shellcheck disable=SC2016 # CMake variables, not shell
         sed -i 's/target_link_libraries(dumpextfs PRIVATE ${E2FSPROGS_LIBRARIES})/target_link_libraries(dumpextfs PRIVATE ${E2FSPROGS_LIBRARIES} ${COM_ERR_LIBRARIES})/' "$dumpextfs_cmake"
     fi
 
@@ -764,6 +766,7 @@ do_install_delta() {
     if [[ -f $recompress_cmake ]] && ! grep -q 'LIBCONFIG_C' "$recompress_cmake"; then
         echo "Patching recompress CMakeLists.txt to add libconfig C linkage..."
         sed -i 's/pkg_check_modules(LIBCONFIG REQUIRED libconfig++)/pkg_check_modules(LIBCONFIG REQUIRED libconfig++)\npkg_check_modules(LIBCONFIG_C REQUIRED libconfig)/' "$recompress_cmake"
+        # shellcheck disable=SC2016 # CMake variables, not shell
         sed -i 's/target_link_libraries(recompress PRIVATE ${LIBCONFIG_LIBRARIES} config++)/target_link_libraries(recompress PRIVATE ${LIBCONFIG_LIBRARIES} ${LIBCONFIG_C_LIBRARIES} config++ config)/' "$recompress_cmake"
     fi
 

--- a/scripts/sh-format.sh
+++ b/scripts/sh-format.sh
@@ -22,9 +22,6 @@ if [ -z "$GITROOT" ]; then
     GITROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 fi
 
-# Use the same work folder as install-deps.sh and build.sh
-work_folder="$(dirname "${GITROOT}")/.adu-tmp"
-
 # use readline -e to resolve symlink
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/src/adu-shell/scripts/adu-reboot-wrapper.sh
+++ b/src/adu-shell/scripts/adu-reboot-wrapper.sh
@@ -14,7 +14,7 @@ elapsed=0
 
 echo "ADU Reboot Wrapper: Waiting for agent to prepare (timeout: ${TIMEOUT}s)..."
 
-while [ -f "$LOCK_FILE" ] && [ $elapsed -lt $TIMEOUT ]; do
+while [ -f "$LOCK_FILE" ] && [ $elapsed -lt "$TIMEOUT" ]; do
     # Verify PID is still alive if lock contains PID
     if [ -r "$LOCK_FILE" ]; then
         pid=$(cat "$LOCK_FILE" 2>/dev/null)
@@ -34,7 +34,7 @@ done
 # Cleanup any remaining lock
 rm -f "$LOCK_FILE" 2>/dev/null
 
-if [ $elapsed -ge $TIMEOUT ]; then
+if [ $elapsed -ge "$TIMEOUT" ]; then
     echo "ADU Reboot Wrapper: Timeout reached after ${elapsed}s, forcing reboot"
 else
     echo "ADU Reboot Wrapper: Agent ready after ${elapsed}s, proceeding with reboot"


### PR DESCRIPTION
## Summary
Resolves all shellcheck warnings found across the repository's shell scripts.

### Changes
- **scripts/install-deps.sh**: Added `# shellcheck disable=SC2016` directives for 3 sed lines that intentionally use single-quoted CMake variables
- **scripts/sh-format.sh**: Removed unused `work_folder` variable (SC2034)
- **src/adu-shell/scripts/adu-reboot-wrapper.sh**: Quoted `$TIMEOUT` variable to prevent globbing/word splitting (SC2086)

### Validation
All `.sh` files pass `shellcheck --shell=bash` with zero findings.