### PR TITLE
fix: Fix CMAKE in rootkey workflow

### DIFF
--- a/src/rootkey_workflow/CMakeLists.txt
+++ b/src/rootkey_workflow/CMakeLists.txt
@@ -12,11 +12,6 @@ target_include_directories (${target_name} PUBLIC inc ${ADUC_EXPORT_INCLUDES})
 target_link_aziotsharedutil (${target_name} PRIVATE)
 find_package (Parson)
 
-if (ADUC_BUILD_UNIT_TESTS)
-    set (ROOTKEY_WORKFLOW_TEST_STORE_PATH "${CMAKE_BINARY_DIR}/rootkey_workflow_test_store")
-    set (ROOTKEY_WORKFLOW_TEST_STORE_PACKAGE_PATH "${ROOTKEY_WORKFLOW_TEST_STORE_PATH}/rootkeys.json")
-endif ()
-
 #
 # Turn -fPIC on, in order to use this library in another shared library.
 #
@@ -24,8 +19,8 @@ set_property (TARGET ${target_name} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_compile_definitions (
     ${target_name}
-    PRIVATE ADUC_ROOTKEY_STORE_PACKAGE_PATH="$<IF:$<BOOL:${ADUC_BUILD_UNIT_TESTS}>,${ROOTKEY_WORKFLOW_TEST_STORE_PACKAGE_PATH},${ADUC_ROOTKEY_STORE_PACKAGE_PATH}>"
-            ADUC_ROOTKEY_STORE_PATH="$<IF:$<BOOL:${ADUC_BUILD_UNIT_TESTS}>,${ROOTKEY_WORKFLOW_TEST_STORE_PATH},${ADUC_ROOTKEY_STORE_PATH}>"
+    PRIVATE ADUC_ROOTKEY_STORE_PACKAGE_PATH="${ADUC_ROOTKEY_STORE_PACKAGE_PATH}"
+            ADUC_ROOTKEY_STORE_PATH="${ADUC_ROOTKEY_STORE_PATH}"
             ADUC_ROOTKEY_PKG_URL_OVERRIDE="${ADUC_ROOTKEY_PKG_URL_OVERRIDE}")
 
 if (ROOTKEY_PKG_DOWNLOAD_USE_CURL)

--- a/src/rootkey_workflow/tests/CMakeLists.txt
+++ b/src/rootkey_workflow/tests/CMakeLists.txt
@@ -9,6 +9,11 @@ find_package (Catch2 REQUIRED)
 add_executable (${target_name})
 target_sources (${target_name} PRIVATE rootkey_workflow_ut.cpp)
 
+if (ADUC_BUILD_UNIT_TESTS)
+    set (ROOTKEY_WORKFLOW_TEST_STORE_PATH "${CMAKE_BINARY_DIR}/rootkey_workflow_test_store")
+    set (ROOTKEY_WORKFLOW_TEST_STORE_PACKAGE_PATH "${ROOTKEY_WORKFLOW_TEST_STORE_PATH}/rootkeys.json")
+endif ()
+
 target_link_libraries (
     ${target_name}
     PRIVATE Catch2::Catch2WithMain


### PR DESCRIPTION
Test configuration was accidentally got checked in to the rootkey workflow breaking the initialization. This fixes the issue.