### PR TITLE
fix: Make DO recommended when built with DO support

### DIFF
--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -45,7 +45,8 @@ set (CPACK_DEBIAN_PACKAGE_SECTION "admin")
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps
 set (CPACK_DEBIAN_PACKAGE_DEPENDS "curl")
 if (ADUC_BUILD_WITH_DELIVERY_OPTIMIZATION)
-    set (CPACK_DEBIAN_PACKAGE_SUGGESTS "deliveryoptimization-agent (>= 1.0.0), libdeliveryoptimization (>= 1.0.0), deliveryoptimization-plugin-apt")
+    set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "deliveryoptimization-agent (>= 1.0.0), libdeliveryoptimization (>= 1.0.0)")
+    set (CPACK_DEBIAN_PACKAGE_SUGGESTS "deliveryoptimization-plugin-apt")
 endif ()
 
 # Use dpkg-shlibdeps to generate better package dependency list.

--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -43,11 +43,9 @@ set (CPACK_DEBIAN_PACKAGE_SECTION "admin")
 # If remove deliveryoptimization-agent from dependencies, preinst script must be updated accordingly.
 
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps
+set (CPACK_DEBIAN_PACKAGE_DEPENDS "curl")
 if (ADUC_BUILD_WITH_DELIVERY_OPTIMIZATION)
-    set (CPACK_DEBIAN_PACKAGE_DEPENDS "deliveryoptimization-agent (>= 1.0.0), libdeliveryoptimization (>= 1.0.0), curl")
-    set (CPACK_DEBIAN_PACKAGE_SUGGESTS "deliveryoptimization-plugin-apt")
-else ()
-    set (CPACK_DEBIAN_PACKAGE_DEPENDS "curl")
+    set (CPACK_DEBIAN_PACKAGE_SUGGESTS "deliveryoptimization-agent (>= 1.0.0), libdeliveryoptimization (>= 1.0.0), deliveryoptimization-plugin-apt")
 endif ()
 
 # Use dpkg-shlibdeps to generate better package dependency list.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -117,8 +117,8 @@ Usage: build.sh [options...]
 
     --patch-version                       Patch version of ADU
 
-    --rootkeypkg-curl                     Download the RootKey Package with curl instead of delivery optimization agent.
-
+    --rootkeypkg-curl                     (Deprecated) Download the RootKey Package with curl instead of delivery optimization agent.
+                                            curl is now used by default for root key package download on all platforms.
     --coverage                            Enable coverage mode in build.sh:
                                             instrumented build, force unit tests, then run test+report workflow.
 

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -16,7 +16,6 @@ out_dir="$root_dir/out"
 exclude_patterns=(
     ".*/tests?/.*"
     ".*/Testing/.*"
-    ".*/CMakeFiles/.*"
     # These extension paths contain code examples, so they do not need coverage reporting.
     ".*/src/extensions/component_enumerators/.*"
     ".*/src/extensions/content_downloaders/deliveryoptimization_downloader/.*"
@@ -57,9 +56,6 @@ EOS
     esac
 done
 
-# Resolve out_dir to an absolute path so it remains valid after pushd.
-out_dir="$(cd "$out_dir" && pwd)"
-
 # 1) Run unit tests to produce .gcda files.
 if ! command -v ctest > /dev/null 2>&1; then
     error "ctest not found in PATH"
@@ -84,8 +80,6 @@ gcovr_args=(
     --root "$root_dir"
     --object-directory "$out_dir"
     --filter ".*/src/.*"
-    --gcov-ignore-errors=no_working_dir_found
-    --gcov-ignore-errors=source_not_found
 )
 
 for pattern in "${exclude_patterns[@]}"; do

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -57,6 +57,9 @@ EOS
     esac
 done
 
+# Resolve out_dir to an absolute path so it remains valid after pushd.
+out_dir="$(cd "$out_dir" && pwd)"
+
 # 1) Run unit tests to produce .gcda files.
 if ! command -v ctest > /dev/null 2>&1; then
     error "ctest not found in PATH"

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -16,6 +16,7 @@ out_dir="$root_dir/out"
 exclude_patterns=(
     ".*/tests?/.*"
     ".*/Testing/.*"
+    ".*/CMakeFiles/.*"
     # These extension paths contain code examples, so they do not need coverage reporting.
     ".*/src/extensions/component_enumerators/.*"
     ".*/src/extensions/content_downloaders/deliveryoptimization_downloader/.*"
@@ -80,6 +81,8 @@ gcovr_args=(
     --root "$root_dir"
     --object-directory "$out_dir"
     --filter ".*/src/.*"
+    --gcov-ignore-errors=no_working_dir_found
+    --gcov-ignore-errors=source_not_found
 )
 
 for pattern in "${exclude_patterns[@]}"; do


### PR DESCRIPTION
This pull request updates the packaging and build script to reflect a shift in dependency management and default behaviors regarding the use of `curl` and delivery optimization components. The main focus is to make `curl` the default for certain operations and adjust dependencies and documentation accordingly.

**Packaging changes:**
- Made `curl` a required dependency for the Debian package, while moving `deliveryoptimization-agent` and `libdeliveryoptimization` to recommended dependencies instead of required ones. This simplifies the default installation and reduces strict dependency requirements.

**Build script documentation:**
- Updated the `--rootkeypkg-curl` option in `build.sh` to mark it as deprecated, clarifying that `curl` is now the default method for downloading the root key package on all platforms.