### PR TITLE
Fix path for CMake in vscode with latest build.sh changes and enable test integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,8 @@
         "args": ["-l0","-e", "h"]
     },
     "cmake.buildDirectory": "${workspaceFolder}/out",
-    "cmake.cmakePath": "/tmp/deviceupdate-cmake/bin/cmake",
-    "cmake.cpackPath": "/tmp/deviceupdate-cmake/bin/cpack",
-    "cmake.ctestPath": "/tmp/deviceupdate-cmake/bin/ctest",
+    "cmake.cmakePath": "${workspaceFolder}/.workspace/deviceupdate-cmake/bin/cmake",
+    "cmake.cpackPath": "${workspaceFolder}/.workspace/deviceupdate-cmake/bin/cpack",
+    "cmake.ctestPath": "${workspaceFolder}/.workspace/deviceupdate-cmake/bin/ctest",
+    "cmake.ctest.testExplorerIntegrationEnabled": true,
 }


### PR DESCRIPTION
With the changes made in https://github.com/Azure/iot-hub-device-update/pull/802/changes#diff-3d64996115d0ac3b74e36f57ce6b00d6b4982614c41b1ed39eab8ef43b2e9a2b the cmake path is not longer hardcoded to `/tmp` so cmake is not found in the VS Code cmake integration.

Also enable the test integration by default. Which is quite handy to debug tests.

<img width="2491" height="1186" alt="image" src="https://github.com/user-attachments/assets/a0d573f6-d84e-442e-9e87-2c24af8152d9" />
