### PR TITLE
fix: Convert CMake booleans to C integers for file/console logging flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,8 +67,19 @@ else ()
 endif ()
 
 add_definitions (-DADUC_LOG_FOLDER="${ADUC_LOG_FOLDER}")
-add_definitions (-DADUC_ENABLE_CONSOLE_LOG=${ADUC_ENABLE_CONSOLE_LOG})
-add_definitions (-DADUC_ENABLE_FILE_LOG=${ADUC_ENABLE_FILE_LOG})
+# Convert CMake booleans (ON/OFF) to C preprocessor integers (1/0)
+# so that #if ADUC_ENABLE_CONSOLE_LOG / #if ADUC_ENABLE_FILE_LOG work correctly in init.c.
+if (ADUC_ENABLE_CONSOLE_LOG)
+    add_definitions (-DADUC_ENABLE_CONSOLE_LOG=1)
+else ()
+    add_definitions (-DADUC_ENABLE_CONSOLE_LOG=0)
+endif ()
+
+if (ADUC_ENABLE_FILE_LOG)
+    add_definitions (-DADUC_ENABLE_FILE_LOG=1)
+else ()
+    add_definitions (-DADUC_ENABLE_FILE_LOG=0)
+endif ()
 
 
 set (ADUC_TYPES_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/adu_types/inc)


### PR DESCRIPTION
# fix: Convert CMake booleans to C integers for file/console logging flags

## 🐛 Problem

Commit [`b7e5e8b0`](https://github.com/Azure/iot-hub-device-update/commit/b7e5e8b0) (*"Allow build.sh to disable logging. #796"*) added `#if ADUC_ENABLE_FILE_LOG` preprocessor guards in `src/logging/zlog/src/init.c`, but `src/CMakeLists.txt` passes the raw CMake boolean:

```cmake
add_definitions (-DADUC_ENABLE_FILE_LOG=${ADUC_ENABLE_FILE_LOG})  # produces -DADUC_ENABLE_FILE_LOG=ON
```

In C, `#if ON` evaluates the undefined identifier `ON` as **`0`**, silently **disabling all file logging** at compile time.

**Customer impact:** No ADU agent log files were created on the `vnext\delta` branch. Only `sw-update.log` (written by the swupdate handler's shell script, independent of zlog) was visible.

> **Note:** The customer's `du-diagnostics-config.json` `logPath` setting was not a factor — it controls where the diagnostics workflow **reads/collects** logs, not where the agent **writes** them (controlled by compile-time `ADUC_LOG_FOLDER`, default `/var/log/adu`).

---

## ✅ Fix

**Changed file:** `src/CMakeLists.txt`

Convert CMake booleans (`ON`/`OFF`) to C integers (`1`/`0`):

```cmake
# Before (broken):
add_definitions (-DADUC_ENABLE_FILE_LOG=${ADUC_ENABLE_FILE_LOG})

# After (fixed):
if (ADUC_ENABLE_FILE_LOG)
    add_definitions (-DADUC_ENABLE_FILE_LOG=1)
else ()
    add_definitions (-DADUC_ENABLE_FILE_LOG=0)
endif ()
```

Same pattern applied to `ADUC_ENABLE_CONSOLE_LOG`.

---


## 📋 Customer follow-up

After rebuilding with this fix, log files will be written to `/var/log/adu/`. The customer should update their `du-diagnostics-config.json` `logPath` to `/var/log/adu/` to match, or rebuild with `-DADUC_LOG_FOLDER="/adu/logs"` to match their existing config.
