### PR TITLE
Enhance content downloader with V2 contract and logging improvements

### DIFF
--- a/docs/agent-reference/device-update-agent-extensibility-points.md
+++ b/docs/agent-reference/device-update-agent-extensibility-points.md
@@ -100,6 +100,10 @@ See [DeliveryOptimization github](https://github.com/microsoft/do-client) for mo
 
 The shared library must export the symbols with function symbols documented in [extension_content_downloader_export_symbols.h](../../src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h)
 
+**V1 contract (1.0)** requires `Initialize(const char* initializeData)` and `Download(...)`.
+
+**V2 contract (2.0)** changes `Initialize` to accept a log level parameter — `Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)` — and adds an optional `Cleanup()` export called before the library is unloaded. V2 downloaders should report version 2.0 from `GetContractInfo`. See [extension-contract-versions](./extension-contract-versions.md) for details.
+
 Examples include [deliveryoptimization-content-downloader](../../src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp) and [curl-content-downloader](../../src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp).
 
 ## Download Handler extension type

--- a/docs/agent-reference/extension-contract-versions.md
+++ b/docs/agent-reference/extension-contract-versions.md
@@ -25,6 +25,27 @@ If the symbol exists, it will be called to populate the ADUC_ExtensionContractIn
 
 If the agent does not support the contract version opted-into by the extension, then it will fail with an ExtendedResultCode matching the pattern `ADUC_ERC_{ExtensionType}_UNSUPPORTED_CONTRACT_VERSION` in [result_codes.json](../../scripts/error_code_generator_defs/result_codes.json) or in the build-generated [src/inc/aduc/result.h](../../src/inc/aduc/result.h).
 
+## Content Downloader Contract Versions
+
+### V1 (1.0)
+
+The original content downloader contract. Required exports:
+
+- `GetContractInfo` (optional; omitting defaults to V1)
+- `Initialize(const char* initializeData)`
+- `Download(...)`
+
+### V2 (2.0)
+
+V2 extends V1 with logging initialization support and a cleanup hook:
+
+- `GetContractInfo` (should report version 2.0)
+- `Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)` — accepts a log level so the downloader can initialize its own logging
+- `Download(...)` — unchanged from V1
+- `Cleanup()` — optional; called before the library is unloaded to release logging and other resources
+
+The agent detects the contract version at load time via `GetContractInfo` and dispatches accordingly. V1 extensions continue to work without changes.
+
 ## Back compatibility
 
 To support older custom extensions prior to GA, not including `GetContractInfo` symbol will be implicitly conflated with extension version 1.0 for the extension type, but eventually a version of the agent will make omitting `GetContractInfo` a failure, so it is strongly suggested to include it and to update older extensions.

--- a/src/agent/src/main.c
+++ b/src/agent/src/main.c
@@ -770,11 +770,11 @@ bool StartupAgent(const ADUC_LaunchArguments* launchArgs)
     // Send connection string to DO SDK for it to discover the Edge gateway if present.
     if (ConnectionStringUtils_IsNestedEdge(info.connectionString))
     {
-        result = ExtensionManager_InitializeContentDownloader(info.connectionString);
+        result = ExtensionManager_InitializeContentDownloader(info.connectionString, launchArgs->logLevel);
     }
     else
     {
-        result = ExtensionManager_InitializeContentDownloader(NULL /*initializeData*/);
+        result = ExtensionManager_InitializeContentDownloader(NULL /*initializeData*/, launchArgs->logLevel);
     }
 
 #ifdef ADUC_COMMAND_HELPER_H

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
@@ -61,8 +61,8 @@ EXPORTED_METHOD void Cleanup()
  */
 EXPORTED_METHOD ADUC_Result GetContractInfo(ADUC_ExtensionContractInfo* contractInfo)
 {
-    contractInfo->majorVer = ADUC_V1_CONTRACT_MAJOR_VER;
-    contractInfo->minorVer = ADUC_V1_CONTRACT_MINOR_VER;
+    contractInfo->majorVer = ADUC_V2_CONTRACT_MAJOR_VER;
+    contractInfo->minorVer = ADUC_V2_CONTRACT_MINOR_VER;
     return ADUC_Result{ ADUC_GeneralResult_Success, 0 };
 }
 

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
@@ -35,10 +35,12 @@ EXPORTED_METHOD ADUC_Result Download(
 /**
  * @brief One-time initialization for the content downloader.
  *
+ * @param initializeData The initialization data.
  * @param logLevel The desired loglevel if logging is used.
  */
-EXPORTED_METHOD ADUC_Result Initialize(ADUC_LOG_SEVERITY logLevel)
+EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
+    UNREFERENCED_PARAMETER(initializeData); // Always NULL for curl.
     ADUC_Logging_Init(logLevel, "curl-content-downloader");
     return { ADUC_GeneralResult_Success };
 }

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
@@ -11,6 +11,7 @@
 #include <aduc/contract_utils.h> // for ADUC_ExtensionContractInfo
 #include <aduc/types/download.h> // for ADUC_DownloadProgressCallback
 #include <aduc/types/update_content.h> // for ADUC_FileEntity
+#include <aduc/logging.h> // ADUC_Logging_*, Log_*
 
 EXTERN_C_BEGIN
 
@@ -31,10 +32,23 @@ EXPORTED_METHOD ADUC_Result Download(
     return Download_curl(entity, workflowId, workFolder, timeoutInSeconds, downloadProgressCallback);
 }
 
-EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData)
+/**
+ * @brief One-time initialization for the content downloader.
+ *
+ * @param logLevel The desired loglevel if logging is used.
+ */
+EXPORTED_METHOD ADUC_Result Initialize(ADUC_LOG_SEVERITY logLevel)
 {
-    UNREFERENCED_PARAMETER(initializeData);
+    ADUC_Logging_Init(logLevel, "curl-content-downloader");
     return { ADUC_GeneralResult_Success };
+}
+
+/**
+ * @brief Cleanup logic before library is unloaded.
+ */
+EXPORTED_METHOD void Cleanup()
+{
+    ADUC_Logging_Uninit();
 }
 
 /**

--- a/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/curl_content_downloader.EXPORTS.cpp
@@ -40,7 +40,7 @@ EXPORTED_METHOD ADUC_Result Download(
  */
 EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
-    UNREFERENCED_PARAMETER(initializeData); // Always NULL for curl.
+    UNREFERENCED_PARAMETER(initializeData);
     ADUC_Logging_Init(logLevel, "curl-content-downloader");
     return { ADUC_GeneralResult_Success };
 }

--- a/src/extensions/content_downloaders/curl_downloader/tests/curl_content_downloader_ut.cpp
+++ b/src/extensions/content_downloaders/curl_downloader/tests/curl_content_downloader_ut.cpp
@@ -470,7 +470,7 @@ TEST_CASE("Initialize returns success with non-null data")
     CHECK(result.ResultCode == ADUC_GeneralResult_Success);
 }
 
-TEST_CASE("GetContractInfo populates version 1.0 and returns success")
+TEST_CASE("GetContractInfo populates version 2.0 and returns success")
 {
     ADUC_ExtensionContractInfo contractInfo{};
     contractInfo.majorVer = 99;
@@ -479,8 +479,8 @@ TEST_CASE("GetContractInfo populates version 1.0 and returns success")
     ADUC_Result result = GetContractInfo(&contractInfo);
 
     CHECK(result.ResultCode == ADUC_GeneralResult_Success);
-    CHECK(contractInfo.majorVer == ADUC_V1_CONTRACT_MAJOR_VER);
-    CHECK(contractInfo.minorVer == ADUC_V1_CONTRACT_MINOR_VER);
+    CHECK(contractInfo.majorVer == ADUC_V2_CONTRACT_MAJOR_VER);
+    CHECK(contractInfo.minorVer == ADUC_V2_CONTRACT_MINOR_VER);
 }
 
 TEST_CASE("Download EXPORT delegates to Download_curl (nullptr entity)")

--- a/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
@@ -54,10 +54,12 @@ EXPORTED_METHOD ADUC_Result GetContractInfo(ADUC_ExtensionContractInfo* contract
  * @brief Initializes the content downloader.
  *
  * @param initializeData The initialization data.
+ * @param logLevel The desired loglevel if logging is used.
  * @return ADUC_Result The result.
  */
-EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData)
+EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
+    ADUC_Logging_Init(logLevel, "deliveryoptimization-content-downloader");
     ADUC_Result result{ ADUC_GeneralResult_Success };
 
 #if defined(WIN32)
@@ -97,6 +99,14 @@ EXPORTED_METHOD ADUC_Result Initialize(const char* initializeData)
 
 done:
     return result;
+}
+
+/**
+ * @brief Cleanup logic before library is unloaded.
+ */
+EXPORTED_METHOD void Cleanup()
+{
+    ADUC_Logging_Uninit();
 }
 
 /**

--- a/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
+++ b/src/extensions/content_downloaders/deliveryoptimization_downloader/deliveryoptimization_content_downloader.EXPORTS.cpp
@@ -45,8 +45,8 @@ EXTERN_C_BEGIN
  */
 EXPORTED_METHOD ADUC_Result GetContractInfo(ADUC_ExtensionContractInfo* contractInfo)
 {
-    contractInfo->majorVer = ADUC_V1_CONTRACT_MAJOR_VER;
-    contractInfo->minorVer = ADUC_V1_CONTRACT_MINOR_VER;
+    contractInfo->majorVer = ADUC_V2_CONTRACT_MAJOR_VER;
+    contractInfo->minorVer = ADUC_V2_CONTRACT_MINOR_VER;
     return ADUC_Result{ ADUC_GeneralResult_Success, 0 };
 }
 

--- a/src/extensions/extension_manager/inc/aduc/extension_manager.h
+++ b/src/extensions/extension_manager/inc/aduc/extension_manager.h
@@ -14,6 +14,7 @@
 #include <aduc/types/download.h> /* ADUC_DownloadProgressCallback */
 #include <aduc/types/update_content.h> /* ADUC_FileEntity */
 #include <aduc/types/workflow.h> /* ADUC_WorkflowHandle */
+#include <aduc/logging.h> /* ADUC_LOG_SEVERITY */
 
 EXTERN_C_BEGIN
 
@@ -21,9 +22,10 @@ EXTERN_C_BEGIN
  * @brief Initializes the content downloader.
  *
  * @param initializeData The initialization data.
+ * @param logLevel The log level for the content downloader.
  * @return ADUC_Result The result of initialization.
  */
-ADUC_Result ExtensionManager_InitializeContentDownloader(const char* initializeData);
+ADUC_Result ExtensionManager_InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel);
 
 /**
  * @brief Downloads by using metadata download handler id and falls back to download with content downloader extension.

--- a/src/extensions/extension_manager/inc/aduc/extension_manager.hpp
+++ b/src/extensions/extension_manager/inc/aduc/extension_manager.hpp
@@ -63,7 +63,7 @@ public:
      * @param[in] initializeData A string contains downloader initialization data.
      * @return ADUC_Result
      */
-    static ADUC_Result InitializeContentDownloader(const char* initializeData);
+    static ADUC_Result InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel);
 
     /**
      * @brief The default download proc resolver.

--- a/src/extensions/extension_manager/src/extension_manager.cpp
+++ b/src/extensions/extension_manager/src/extension_manager.cpp
@@ -409,14 +409,21 @@ void ExtensionManager::UnloadAllExtensions()
     // Make sure we unload every handlers first.
     UnloadAllUpdateContentHandlers();
 
-    for (auto& lib : _libs)
+    // Call Cleanup on the content downloader if it is a V2 contract.
+    if (_contentDownloader != nullptr
+        && ADUC_ContractUtils_IsV2Contract(&_contentDownloaderContractVersion))
     {
-        CleanupProc cleanup = nullptr;
-        cleanup = reinterpret_cast<CleanupProc>(ADUCPAL_dlsym(lib.second, CONTENT_DOWNLOADER__Cleanup__EXPORT_SYMBOL));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        CleanupProc cleanup = reinterpret_cast<CleanupProc>(
+            ADUCPAL_dlsym(_contentDownloader, CONTENT_DOWNLOADER__Cleanup__EXPORT_SYMBOL));
         if (cleanup != nullptr)
         {
             cleanup();
         }
+    }
+
+    for (auto& lib : _libs)
+    {
         ADUCPAL_dlclose(lib.second);
     }
 
@@ -432,8 +439,7 @@ ADUC_Result ExtensionManager::LoadContentDownloaderLibrary(void** contentDownloa
 {
     ADUC_Result result = { ADUC_Result_Failure };
     static const char* functionNames[] = { CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL,
-                                           CONTENT_DOWNLOADER__Download__EXPORT_SYMBOL,
-                                           CONTENT_DOWNLOADER__Cleanup__EXPORT_SYMBOL };
+                                           CONTENT_DOWNLOADER__Download__EXPORT_SYMBOL };
     void* extensionLib = nullptr;
     GET_CONTRACT_INFO_PROC getContractInfoFn = nullptr;
 
@@ -788,7 +794,6 @@ done:
 ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
     void* lib = nullptr;
-    InitializeProc initialize = nullptr;
 
     ADUC_Result result = ExtensionManager::LoadContentDownloaderLibrary(&lib);
     if (IsAducResultCodeFailure(result.ResultCode))
@@ -796,7 +801,55 @@ ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initialize
         goto done;
     }
 
-    if (!ADUC_ContractUtils_IsV1Contract(&ExtensionManager::_contentDownloaderContractVersion))
+    if (ADUC_ContractUtils_IsV2Contract(&ExtensionManager::_contentDownloaderContractVersion))
+    {
+        // V2 contract: Initialize(const char*, ADUC_LOG_SEVERITY)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        InitializeProc initializeV2 =
+            reinterpret_cast<InitializeProc>(ADUCPAL_dlsym(lib, CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL));
+        if (initializeV2 == nullptr)
+        {
+            result = { /* .ResultCode = */ ADUC_Result_Failure,
+                       /* .ExtendedResultCode = */ ADUC_ERC_CONTENT_DOWNLOADER_INITIALIZEPROC_NOTIMP };
+            goto done;
+        }
+
+        try
+        {
+            result = initializeV2(initializeData, logLevel);
+        }
+        catch (...)
+        {
+            result = { /* .ResultCode = */ ADUC_Result_Failure,
+                       /* .ExtendedResultCode = */ ADUC_ERC_CONTENT_DOWNLOADER_INITIALIZE_EXCEPTION };
+            goto done;
+        }
+    }
+    else if (ADUC_ContractUtils_IsV1Contract(&ExtensionManager::_contentDownloaderContractVersion))
+    {
+        // V1 contract: Initialize(const char*)
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        InitializeV1Proc initializeV1 =
+            reinterpret_cast<InitializeV1Proc>(ADUCPAL_dlsym(lib, CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL));
+        if (initializeV1 == nullptr)
+        {
+            result = { /* .ResultCode = */ ADUC_Result_Failure,
+                       /* .ExtendedResultCode = */ ADUC_ERC_CONTENT_DOWNLOADER_INITIALIZEPROC_NOTIMP };
+            goto done;
+        }
+
+        try
+        {
+            result = initializeV1(initializeData);
+        }
+        catch (...)
+        {
+            result = { /* .ResultCode = */ ADUC_Result_Failure,
+                       /* .ExtendedResultCode = */ ADUC_ERC_CONTENT_DOWNLOADER_INITIALIZE_EXCEPTION };
+            goto done;
+        }
+    }
+    else
     {
         Log_Error(
             "Unsupported contract version %d.%d",
@@ -804,26 +857,6 @@ ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initialize
             ExtensionManager::_contentDownloaderContractVersion.minorVer);
         result.ResultCode = ADUC_GeneralResult_Failure;
         result.ExtendedResultCode = ADUC_ERC_CONTENT_DOWNLOADER_UNSUPPORTED_CONTRACT_VERSION;
-        goto done;
-    }
-
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    initialize = reinterpret_cast<InitializeProc>(ADUCPAL_dlsym(lib, CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL));
-    if (initialize == nullptr)
-    {
-        result = { /* .ResultCode = */ ADUC_Result_Failure,
-                   /* .ExtendedResultCode = */ ADUC_ERC_CONTENT_DOWNLOADER_INITIALIZEPROC_NOTIMP };
-        goto done;
-    }
-
-    try
-    {
-        result = initialize(initializeData, logLevel);
-    }
-    catch (...)
-    {
-        result = { /* .ResultCode = */ ADUC_Result_Failure,
-                   /* .ExtendedResultCode = */ ADUC_ERC_CONTENT_DOWNLOADER_INITIALIZE_EXCEPTION };
         goto done;
     }
 
@@ -865,7 +898,8 @@ ADUC_Result ExtensionManager::Download(
         goto done;
     }
 
-    if (!ADUC_ContractUtils_IsV1Contract(&ExtensionManager::_contentDownloaderContractVersion))
+    if (!ADUC_ContractUtils_IsV1Contract(&ExtensionManager::_contentDownloaderContractVersion)
+        && !ADUC_ContractUtils_IsV2Contract(&ExtensionManager::_contentDownloaderContractVersion))
     {
         Log_Error(
             "Unsupported contract version %d.%d",

--- a/src/extensions/extension_manager/src/extension_manager.cpp
+++ b/src/extensions/extension_manager/src/extension_manager.cpp
@@ -778,7 +778,7 @@ done:
     return result;
 }
 
-ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initializeData)
+ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
     void* lib = nullptr;
     InitializeProc _initialize = nullptr;
@@ -811,7 +811,7 @@ ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initialize
 
     try
     {
-        result = _initialize(initializeData);
+        result = _initialize(initializeData, logLevel);
     }
     catch (...)
     {
@@ -989,9 +989,9 @@ done:
 
 EXTERN_C_BEGIN
 
-ADUC_Result ExtensionManager_InitializeContentDownloader(const char* initializeData)
+ADUC_Result ExtensionManager_InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
-    return ExtensionManager::InitializeContentDownloader(initializeData);
+    return ExtensionManager::InitializeContentDownloader(initializeData, logLevel);
 }
 
 ADUC_Result ExtensionManager_Download(

--- a/src/extensions/extension_manager/src/extension_manager.cpp
+++ b/src/extensions/extension_manager/src/extension_manager.cpp
@@ -411,6 +411,12 @@ void ExtensionManager::UnloadAllExtensions()
 
     for (auto& lib : _libs)
     {
+        CleanupProc cleanup = nullptr;
+        cleanup = reinterpret_cast<CleanupProc>(ADUCPAL_dlsym(lib.second, CONTENT_DOWNLOADER__Cleanup__EXPORT_SYMBOL));
+        if (cleanup != nullptr)
+        {
+            cleanup();
+        }
         ADUCPAL_dlclose(lib.second);
     }
 
@@ -426,7 +432,8 @@ ADUC_Result ExtensionManager::LoadContentDownloaderLibrary(void** contentDownloa
 {
     ADUC_Result result = { ADUC_Result_Failure };
     static const char* functionNames[] = { CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL,
-                                           CONTENT_DOWNLOADER__Download__EXPORT_SYMBOL };
+                                           CONTENT_DOWNLOADER__Download__EXPORT_SYMBOL,
+                                           CONTENT_DOWNLOADER__Cleanup__EXPORT_SYMBOL };
     void* extensionLib = nullptr;
     GET_CONTRACT_INFO_PROC getContractInfoFn = nullptr;
 
@@ -781,7 +788,7 @@ done:
 ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
 {
     void* lib = nullptr;
-    InitializeProc _initialize = nullptr;
+    InitializeProc initialize = nullptr;
 
     ADUC_Result result = ExtensionManager::LoadContentDownloaderLibrary(&lib);
     if (IsAducResultCodeFailure(result.ResultCode))
@@ -801,8 +808,8 @@ ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initialize
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    _initialize = reinterpret_cast<InitializeProc>(ADUCPAL_dlsym(lib, CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL));
-    if (_initialize == nullptr)
+    initialize = reinterpret_cast<InitializeProc>(ADUCPAL_dlsym(lib, CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL));
+    if (initialize == nullptr)
     {
         result = { /* .ResultCode = */ ADUC_Result_Failure,
                    /* .ExtendedResultCode = */ ADUC_ERC_CONTENT_DOWNLOADER_INITIALIZEPROC_NOTIMP };
@@ -811,7 +818,7 @@ ADUC_Result ExtensionManager::InitializeContentDownloader(const char* initialize
 
     try
     {
-        result = _initialize(initializeData, logLevel);
+        result = initialize(initializeData, logLevel);
     }
     catch (...)
     {

--- a/src/extensions/extension_manager/tests/inc/extension_manager_download_test_case.hpp
+++ b/src/extensions/extension_manager/tests/inc/extension_manager_download_test_case.hpp
@@ -9,6 +9,7 @@
 #ifndef EXTENSIONMANAGER_DOWNLOAD_TEST_CASE
 #define EXTENSIONMANAGER_DOWNLOAD_TEST_CASE
 
+#include <aduc/contract_utils.h>
 #include <aduc/extension_manager.hpp>
 #include <aduc/result.h>
 
@@ -32,6 +33,12 @@ public:
     ExtensionManagerDownloadTestCase& operator=(ExtensionManagerDownloadTestCase&&) = delete;
 
     ExtensionManagerDownloadTestCase(DownloadTestScenario scenario) : download_scenario{ scenario }
+    {
+    }
+
+    ExtensionManagerDownloadTestCase(
+        DownloadTestScenario scenario, ADUC_ExtensionContractInfo contractInfo)
+        : download_scenario{ scenario }, contractVersion{ contractInfo }
     {
     }
 
@@ -59,6 +66,7 @@ private:
 
 private:
     DownloadTestScenario download_scenario{ DownloadTestScenario::Invalid };
+    ADUC_ExtensionContractInfo contractVersion{ ADUC_V1_CONTRACT_MAJOR_VER, ADUC_V1_CONTRACT_MINOR_VER };
     ADUC_Result actual_result{};
     ADUC_Result expected_result{};
 

--- a/src/extensions/extension_manager/tests/src/extension_manager_download_test_case.cpp
+++ b/src/extensions/extension_manager/tests/src/extension_manager_download_test_case.cpp
@@ -143,7 +143,7 @@ void ExtensionManagerDownloadTestCase::RunScenario()
 void ExtensionManagerDownloadTestCase::InitCommon()
 {
     ExtensionManager::SetContentDownloaderLibrary(&mockLib);
-    ExtensionManager::SetContentDownloaderContractVersion(mockContractInfo);
+    ExtensionManager::SetContentDownloaderContractVersion(contractVersion);
 
     unique_json_value msgValue{ json_parse_file(pnpMsgPath.c_str()) };
     unique_json_value updateManifestValue{ json_parse_file(updateManifestPath.c_str()) };

--- a/src/extensions/extension_manager/tests/src/extension_manager_download_test_case.cpp
+++ b/src/extensions/extension_manager/tests/src/extension_manager_download_test_case.cpp
@@ -142,7 +142,7 @@ void ExtensionManagerDownloadTestCase::RunScenario()
         break;
 
     case DownloadTestScenario::UnsupportedContractVersion:
-        ExtensionManager::SetContentDownloaderContractVersion({ 2, 0 });
+        ExtensionManager::SetContentDownloaderContractVersion({ 3, 0 });
         mockProcResolver = mockDownloadSuccessProcResolver;
         expected_result.ResultCode = ADUC_GeneralResult_Failure;
         expected_result.ExtendedResultCode = ADUC_ERC_CONTENT_DOWNLOADER_UNSUPPORTED_CONTRACT_VERSION;

--- a/src/extensions/extension_manager/tests/src/extension_manager_ut.cpp
+++ b/src/extensions/extension_manager/tests/src/extension_manager_ut.cpp
@@ -5,8 +5,12 @@
  * @copyright Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
  */
+#include <aduc/contract_utils.h>
+#include <aduc/extension_manager.hpp>
+#include <aduc/logging.h>
 #include <aduc/result.h>
 #include <catch2/catch_all.hpp>
+#include <dlfcn.h>
 #include <extension_manager_download_test_case.hpp>
 
 bool operator==(ADUC_Result a, ADUC_Result b)
@@ -36,4 +40,95 @@ TEST_CASE("ExtensionManager::Download failure should return failure ResultCode a
 
     CHECK(actual_result.ResultCode == expected_result.ResultCode);
     CHECK(actual_result.ExtendedResultCode == expected_result.ExtendedResultCode);
+}
+
+//
+// V2 contract tests
+//
+
+TEST_CASE("ExtensionManager::Download with V2 contract should succeed")
+{
+    ADUC_ExtensionContractInfo v2Contract{ ADUC_V2_CONTRACT_MAJOR_VER, ADUC_V2_CONTRACT_MINOR_VER };
+
+    ExtensionManagerDownloadTestCase testCase{ DownloadTestScenario::BasicDownloadSuccess, v2Contract };
+    REQUIRE_NOTHROW(testCase.RunScenario());
+
+    ADUC_Result actual_result = testCase.GetActualResult();
+    CHECK(actual_result.ResultCode == 1); // success
+    CHECK(actual_result.ExtendedResultCode == 0);
+}
+
+TEST_CASE("ExtensionManager::Download with unsupported contract version should fail")
+{
+    ADUC_ExtensionContractInfo unsupportedContract{ 3, 0 };
+
+    ExtensionManagerDownloadTestCase testCase{ DownloadTestScenario::BasicDownloadSuccess, unsupportedContract };
+    REQUIRE_NOTHROW(testCase.RunScenario());
+
+    ADUC_Result actual_result = testCase.GetActualResult();
+    CHECK(IsAducResultCodeFailure(actual_result.ResultCode));
+    CHECK(actual_result.ExtendedResultCode == ADUC_ERC_CONTENT_DOWNLOADER_UNSUPPORTED_CONTRACT_VERSION);
+}
+
+TEST_CASE("InitializeContentDownloader with unsupported contract version returns error")
+{
+    // Set up mock library and an unsupported contract version.
+    // The unsupported version check happens before any dlsym call,
+    // so this is safe with a mock (non-dlopen) library handle.
+    class MockLib
+    {
+    };
+    MockLib mock;
+    ExtensionManager::SetContentDownloaderLibrary(&mock);
+    ExtensionManager::SetContentDownloaderContractVersion(ADUC_ExtensionContractInfo{ 3, 0 });
+
+    ADUC_Result result = ExtensionManager::InitializeContentDownloader(nullptr, ADUC_LOG_DEBUG);
+
+    CHECK(IsAducResultCodeFailure(result.ResultCode));
+    CHECK(result.ExtendedResultCode == ADUC_ERC_CONTENT_DOWNLOADER_UNSUPPORTED_CONTRACT_VERSION);
+}
+
+TEST_CASE("InitializeContentDownloader with V1 contract does not return unsupported version error")
+{
+    // Use a real dlopen handle (the main program) so dlsym is safe to call.
+    // dlsym will return NULL for "Initialize" since the test binary doesn't export it.
+    void* safeHandle = dlopen(nullptr, RTLD_LAZY);
+    REQUIRE(safeHandle != nullptr);
+
+    ExtensionManager::SetContentDownloaderLibrary(safeHandle);
+    ExtensionManager::SetContentDownloaderContractVersion(
+        ADUC_ExtensionContractInfo{ ADUC_V1_CONTRACT_MAJOR_VER, ADUC_V1_CONTRACT_MINOR_VER });
+
+    ADUC_Result result = ExtensionManager::InitializeContentDownloader(nullptr, ADUC_LOG_DEBUG);
+
+    CHECK(IsAducResultCodeFailure(result.ResultCode));
+    // Must NOT be the unsupported contract version error — proves V1 path was taken.
+    CHECK(result.ExtendedResultCode != ADUC_ERC_CONTENT_DOWNLOADER_UNSUPPORTED_CONTRACT_VERSION);
+    // Should be INITIALIZEPROC_NOTIMP since the test binary doesn't export "Initialize".
+    CHECK(result.ExtendedResultCode == ADUC_ERC_CONTENT_DOWNLOADER_INITIALIZEPROC_NOTIMP);
+
+    ExtensionManager::SetContentDownloaderLibrary(nullptr);
+    dlclose(safeHandle);
+}
+
+TEST_CASE("InitializeContentDownloader with V2 contract does not return unsupported version error")
+{
+    // Same as V1 test but for V2 contract: verify V2 is accepted and V2 code path is taken.
+    void* safeHandle = dlopen(nullptr, RTLD_LAZY);
+    REQUIRE(safeHandle != nullptr);
+
+    ExtensionManager::SetContentDownloaderLibrary(safeHandle);
+    ExtensionManager::SetContentDownloaderContractVersion(
+        ADUC_ExtensionContractInfo{ ADUC_V2_CONTRACT_MAJOR_VER, ADUC_V2_CONTRACT_MINOR_VER });
+
+    ADUC_Result result = ExtensionManager::InitializeContentDownloader(nullptr, ADUC_LOG_DEBUG);
+
+    CHECK(IsAducResultCodeFailure(result.ResultCode));
+    // Must NOT be the unsupported contract version error — proves V2 path was taken.
+    CHECK(result.ExtendedResultCode != ADUC_ERC_CONTENT_DOWNLOADER_UNSUPPORTED_CONTRACT_VERSION);
+    // Should be INITIALIZEPROC_NOTIMP since the test binary doesn't export "Initialize".
+    CHECK(result.ExtendedResultCode == ADUC_ERC_CONTENT_DOWNLOADER_INITIALIZEPROC_NOTIMP);
+
+    ExtensionManager::SetContentDownloaderLibrary(nullptr);
+    dlclose(safeHandle);
 }

--- a/src/extensions/extension_manager/tests/src/extension_manager_ut.cpp
+++ b/src/extensions/extension_manager/tests/src/extension_manager_ut.cpp
@@ -405,7 +405,7 @@ TEST_CASE("InitializeContentDownloader fails when downloader lib not loaded")
     ExtMgrCleanup cleanup;
     ExtensionManager::SetContentDownloaderLibrary(nullptr);
 
-    ADUC_Result result = ExtensionManager::InitializeContentDownloader("test");
+    ADUC_Result result = ExtensionManager::InitializeContentDownloader("test", ADUC_LOG_DEBUG);
     CHECK(result.ResultCode == 0);
 }
 
@@ -415,9 +415,9 @@ TEST_CASE("InitializeContentDownloader fails when contract version is unsupporte
 
     int fakeLib = 42;
     ExtensionManager::SetContentDownloaderLibrary(&fakeLib);
-    ExtensionManager::SetContentDownloaderContractVersion({ 2, 0 });
+    ExtensionManager::SetContentDownloaderContractVersion({ 3, 0 });
 
-    ADUC_Result result = ExtensionManager::InitializeContentDownloader("test");
+    ADUC_Result result = ExtensionManager::InitializeContentDownloader("test", ADUC_LOG_DEBUG);
 
     CHECK(result.ResultCode == ADUC_GeneralResult_Failure);
     CHECK(result.ExtendedResultCode == ADUC_ERC_CONTENT_DOWNLOADER_UNSUPPORTED_CONTRACT_VERSION);
@@ -459,7 +459,7 @@ TEST_CASE("ExtensionManager_InitializeContentDownloader wrapper returns failure 
     ExtMgrCleanup cleanup;
     ExtensionManager::SetContentDownloaderLibrary(nullptr);
 
-    ADUC_Result result = ExtensionManager_InitializeContentDownloader("test");
+    ADUC_Result result = ExtensionManager_InitializeContentDownloader("test", ADUC_LOG_DEBUG);
     CHECK(result.ResultCode == 0);
 }
 

--- a/src/extensions/inc/aduc/content_downloader_extension.hpp
+++ b/src/extensions/inc/aduc/content_downloader_extension.hpp
@@ -10,9 +10,10 @@
 
 #include "aduc/adu_core_exports.h"
 
+
 EXTERN_C_BEGIN
 
-typedef ADUC_Result (*InitializeProc)(const char* initializeData);
+typedef ADUC_Result (*InitializeProc)(const char* initializeData, ADUC_LOG_SEVERITY logLevel);
 
 typedef ADUC_Result (*DownloadProc)(
     const ADUC_FileEntity* entity,

--- a/src/extensions/inc/aduc/content_downloader_extension.hpp
+++ b/src/extensions/inc/aduc/content_downloader_extension.hpp
@@ -13,6 +13,10 @@
 
 EXTERN_C_BEGIN
 
+// V1 contract: Initialize takes only initializeData.
+typedef ADUC_Result (*InitializeV1Proc)(const char* initializeData);
+
+// V2 contract: Initialize takes initializeData and logLevel.
 typedef ADUC_Result (*InitializeProc)(const char* initializeData, ADUC_LOG_SEVERITY logLevel);
 
 typedef ADUC_Result (*DownloadProc)(

--- a/src/extensions/inc/aduc/content_downloader_extension.hpp
+++ b/src/extensions/inc/aduc/content_downloader_extension.hpp
@@ -22,6 +22,8 @@ typedef ADUC_Result (*DownloadProc)(
     unsigned int timeoutInSeconds,
     ADUC_DownloadProgressCallback downloadProgressCallback);
 
+typedef void (*CleanupProc)();
+
 EXTERN_C_END
 
 #endif // ADUC_CONTENT_DOWNLOADER_EXTENSION_HPP

--- a/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
+++ b/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
@@ -4,8 +4,16 @@
 #include <aduc/exports/extension_common_export_symbols.h> // for GetContractInfo__EXPORT_SYMBOL
 
 //
-// Content Downloader Extension export V1 symbols.
-// These are the V1 symbols that must be implemented by a content downloader extension.
+// Content Downloader Extension export symbols.
+//
+// V1 contract (1.0) symbols:
+//   - GetContractInfo (optional, defaults to V1 if absent)
+//   - Initialize(const char* initializeData)
+//   - Download(...)
+//
+// V2 contract (2.0) adds:
+//   - Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
+//   - Cleanup()  (optional, called before library unload if present)
 //
 
 /**
@@ -20,18 +28,16 @@
 /**
  * @brief Initializes the content downloader.
  *
- * @param initializeData The initialization data.
- * @param logLevel The log level for the content downloader.
- * @return ADUC_Result The result.
- * @details ADUC_Result Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
+ * V1 contract: ADUC_Result Initialize(const char* initializeData)
+ * V2 contract: ADUC_Result Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
  */
 #define CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL "Initialize"
 
 /**
- * @brief Cleanup logic before library is unloaded.
+ * @brief Cleanup logic before library is unloaded (V2 contract only).
+ * @details void Cleanup()
  */
 #define CONTENT_DOWNLOADER__Cleanup__EXPORT_SYMBOL "Cleanup"
-
 
 /**
  * @brief The download export.

--- a/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
+++ b/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
@@ -21,8 +21,9 @@
  * @brief Initializes the content downloader.
  *
  * @param initializeData The initialization data.
+ * @param logLevel The log level for the content downloader.
  * @return ADUC_Result The result.
- * @details ADUC_Result Initialize(const char* initializeData)
+ * @details ADUC_Result Initialize(const char* initializeData, ADUC_LOG_SEVERITY logLevel)
  */
 #define CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL "Initialize"
 

--- a/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
+++ b/src/extensions/inc/aduc/exports/extension_content_downloader_export_symbols.h
@@ -28,6 +28,12 @@
 #define CONTENT_DOWNLOADER__Initialize__EXPORT_SYMBOL "Initialize"
 
 /**
+ * @brief Cleanup logic before library is unloaded.
+ */
+#define CONTENT_DOWNLOADER__Cleanup__EXPORT_SYMBOL "Cleanup"
+
+
+/**
  * @brief The download export.
  *
  * @param entity The file entity.

--- a/src/utils/contract_utils/inc/aduc/contract_utils.h
+++ b/src/utils/contract_utils/inc/aduc/contract_utils.h
@@ -16,6 +16,9 @@
 #define ADUC_V1_CONTRACT_MAJOR_VER 1 //!< The major version of the v1 contract model
 #define ADUC_V1_CONTRACT_MINOR_VER 0 //!< The minor version of the v1 contract model
 
+#define ADUC_V2_CONTRACT_MAJOR_VER 2 //!< The major version of the v2 contract model
+#define ADUC_V2_CONTRACT_MINOR_VER 0 //!< The minor version of the v2 contract model
+
 /**
  * @brief The Extenstion Contract Info struct that wraps the version for the contract information
  */
@@ -33,6 +36,13 @@ EXTERN_C_BEGIN
  * @returns true if a v1 contract version ; false otherwise
  */
 bool ADUC_ContractUtils_IsV1Contract(ADUC_ExtensionContractInfo* contractInfo);
+
+/**
+ * @brief Checks if @p contractInfo is a v2 contract
+ * @param contractInfo the contractInfo to check
+ * @returns true if a v2 contract version ; false otherwise
+ */
+bool ADUC_ContractUtils_IsV2Contract(ADUC_ExtensionContractInfo* contractInfo);
 
 EXTERN_C_END
 

--- a/src/utils/contract_utils/src/contract_utils.c
+++ b/src/utils/contract_utils/src/contract_utils.c
@@ -18,3 +18,10 @@ bool ADUC_ContractUtils_IsV1Contract(ADUC_ExtensionContractInfo* contractInfo)
         || (contractInfo->majorVer == ADUC_V1_CONTRACT_MAJOR_VER
             && contractInfo->minorVer == ADUC_V1_CONTRACT_MINOR_VER);
 }
+
+bool ADUC_ContractUtils_IsV2Contract(ADUC_ExtensionContractInfo* contractInfo)
+{
+    return contractInfo != NULL
+        && contractInfo->majorVer == ADUC_V2_CONTRACT_MAJOR_VER
+        && contractInfo->minorVer == ADUC_V2_CONTRACT_MINOR_VER;
+}


### PR DESCRIPTION
NOTE: This pull request contains an improvement in ADU Agent logging proposed by PR #828 by @AndreRicardo-Zoetis  (Thank you!)
 
This pull request updates the content downloader extension contract to version 2.0, introducing improved logging initialization and cleanup support. The changes ensure backward compatibility with version 1.0 while enabling new extensions to take advantage of enhanced initialization and resource management. Documentation has been updated to reflect the new contract, and the agent and extension manager have been refactored to support both V1 and V2 contracts.

**Content Downloader Contract V2 Support:**

- Added support for V2 (2.0) content downloader contract, which changes the `Initialize` method to accept a `logLevel` parameter and introduces an optional `Cleanup` export for resource cleanup before unloading the library. The agent now detects the contract version at load time and dispatches accordingly. [[1]](diffhunk://#diff-d3c09f0f9447441097cd2105ad45f098cf1ac9c1e11e3b6ccc7d3d52d7321e23R28-R48)], [[2]](diffhunk://#diff-46061bc88f3de55b7a9248f880aab5c4c4810f40a13b61af716c729d72d7f92dR103-R106)], [[3]](diffhunk://#diff-40a092357131344b9089713f8a99624250888317c73f859d7126391c82ce04e3L34-R55)], [[4]](diffhunk://#diff-b9820db2ea540c0a1c6eca8a9448b121ba41792944e98777c7b676d8ba44bc22L48-R62)], [[5]](diffhunk://#diff-b9820db2ea540c0a1c6eca8a9448b121ba41792944e98777c7b676d8ba44bc22R104-R111)])

- Updated both `curl_content_downloader.EXPORTS.cpp` and `deliveryoptimization_content_downloader.EXPORTS.cpp` to implement the V2 contract: initializing logging in `Initialize`, reporting contract version 2.0 in `GetContractInfo`, and providing a `Cleanup` method to uninitialize logging. [[1]](diffhunk://#diff-40a092357131344b9089713f8a99624250888317c73f859d7126391c82ce04e3L34-R55)], [[2]](diffhunk://#diff-40a092357131344b9089713f8a99624250888317c73f859d7126391c82ce04e3L48-R65)], [[3]](diffhunk://#diff-b9820db2ea540c0a1c6eca8a9448b121ba41792944e98777c7b676d8ba44bc22L48-R62)], [[4]](diffhunk://#diff-b9820db2ea540c0a1c6eca8a9448b121ba41792944e98777c7b676d8ba44bc22R104-R111)])

**Agent and Extension Manager Refactoring:**

- Refactored the agent and extension manager to pass the `logLevel` parameter to the content downloader's `Initialize` method and to call the `Cleanup` export when unloading V2 contract libraries. [[1]](diffhunk://#diff-20e66a9e7f47f0f0b841242b41f0e23dac7ade46222b5df8862705974d06cd69L773-R777)], [[2]](diffhunk://#diff-6425ea47f674ab8af43d33f1cec5da425933468901479dc8808604370de20031R17-R28)], [[3]](diffhunk://#diff-00729b105cae0f9d20d17e631c2fa5b134017844e36bef41bdd48079d8050038L66-R66)], [[4]](diffhunk://#diff-46985b5f2a13e77cdfbe95801dde4341a995fd5026519ba098d0f6228a4e691dR412-R424)], [[5]](diffhunk://#diff-46985b5f2a13e77cdfbe95801dde4341a995fd5026519ba098d0f6228a4e691dL781-R834)], [[6]](diffhunk://#diff-46985b5f2a13e77cdfbe95801dde4341a995fd5026519ba098d0f6228a4e691dL814-R861)], [[7]](diffhunk://#diff-46985b5f2a13e77cdfbe95801dde4341a995fd5026519ba098d0f6228a4e691dL861-R902)], [[8]](diffhunk://#diff-46985b5f2a13e77cdfbe95801dde4341a995fd5026519ba098d0f6228a4e691dL992-R1035)])

**Documentation Updates:**

- Updated documentation to describe the V2 contract changes, including the new logging and cleanup features, and to guide extension authors on supporting both V1 and V2. [[1]](diffhunk://#diff-d3c09f0f9447441097cd2105ad45f098cf1ac9c1e11e3b6ccc7d3d52d7321e23R28-R48)], [[2]](diffhunk://#diff-46061bc88f3de55b7a9248f880aab5c4c4810f40a13b61af716c729d72d7f92dR103-R106)])

**Test Suite Enhancements:**

- Extended the test infrastructure to support specifying the contract version for test cases, enabling testing of both V1 and V2 contract behaviors. [[1]](diffhunk://#diff-8436aca5a8f550adc48ee2029064bd4973080373f224400d310fc9075dd0f3f7R12)], [[2]](diffhunk://#diff-8436aca5a8f550adc48ee2029064bd4973080373f224400d310fc9075dd0f3f7R39-R44)], [[3]](diffhunk://#diff-8436aca5a8f550adc48ee2029064bd4973080373f224400d310fc9075dd0f3f7R69)], [[4]](diffhunk://#diff-5f39585f5db6a56a48049e38a21308b536835c0ed26beb318c064cfd35f93cc7L146-R146)], [[5]](diffhunk://#diff-1e0efb425560f4643164b91ad3752c76e9bca05d3a418c88a636a69e3afd2379R8-R13)])