### PR TITLE
Fix #858: manage linux platform layer async worker thread lifecycle

### DIFF
--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
@@ -59,6 +59,19 @@ std::unique_ptr<LinuxPlatformLayer> LinuxPlatformLayer::Create()
 
 LinuxPlatformLayer::~LinuxPlatformLayer()
 {
+    // Signal any in-flight worker that a shutdown is happening so cancellable
+    // operations (Download/Install/Apply) can return early, then wait for the
+    // worker to finish. This prevents the detached-thread use-after-free of
+    // workCompletionData / workflowData reported in issue #858.
+    _IsCancellationRequested = true;
+    {
+        std::lock_guard<std::mutex> lock(_activeWorkerMutex);
+        if (_activeWorker.joinable())
+        {
+            _activeWorker.join();
+        }
+    }
+
     ExtensionManager::Uninit();
 }
 

--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.hpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.hpp
@@ -10,7 +10,9 @@
 
 #include <atomic>
 #include <exception>
+#include <mutex>
 #include <thread>
+#include <utility>
 
 #include <time.h>
 
@@ -84,8 +86,10 @@ private:
                     workCompletionData->WorkCompletionToken, result, true /* isAsync */);
             } };
 
-            // Allow the thread to work independently of this main thread.
-            worker.detach();
+            // Transfer ownership of the worker thread to the platform layer instance so
+            // that its lifetime is bounded by the platform layer (avoids use-after-free
+            // of workCompletionData/workflowData if the agent shuts down mid-operation).
+            static_cast<LinuxPlatformLayer*>(token)->TrackWorker(std::move(worker));
 
             // Indicate that we've spun off a thread to do the actual work.
             return ADUC_Result{ ADUC_Result_Download_InProgress };
@@ -135,8 +139,10 @@ private:
                     workCompletionData->WorkCompletionToken, result, true /* isAsync */);
             } };
 
-            // Allow the thread to work independently of this main thread.
-            worker.detach();
+            // Transfer ownership of the worker thread to the platform layer instance so
+            // that its lifetime is bounded by the platform layer (avoids use-after-free
+            // of workCompletionData/workflowData if the agent shuts down mid-operation).
+            static_cast<LinuxPlatformLayer*>(token)->TrackWorker(std::move(worker));
 
             // Indicate that we've spun off a thread to do the actual work.
             result = { ADUC_Result_Backup_InProgress };
@@ -188,8 +194,10 @@ private:
                     workCompletionData->WorkCompletionToken, result, true /* isAsync */);
             } };
 
-            // Allow the thread to work independently of this main thread.
-            worker.detach();
+            // Transfer ownership of the worker thread to the platform layer instance so
+            // that its lifetime is bounded by the platform layer (avoids use-after-free
+            // of workCompletionData/workflowData if the agent shuts down mid-operation).
+            static_cast<LinuxPlatformLayer*>(token)->TrackWorker(std::move(worker));
 
             // Indicate that we've spun off a thread to do the actual work.
             result = { ADUC_Result_Install_InProgress };
@@ -239,8 +247,10 @@ private:
                     workCompletionData->WorkCompletionToken, result, true /* isAsync */);
             } };
 
-            // Allow the thread to work independently of this main thread.
-            worker.detach();
+            // Transfer ownership of the worker thread to the platform layer instance so
+            // that its lifetime is bounded by the platform layer (avoids use-after-free
+            // of workCompletionData/workflowData if the agent shuts down mid-operation).
+            static_cast<LinuxPlatformLayer*>(token)->TrackWorker(std::move(worker));
 
             // Indicate that we've spun off a thread to do the actual work.
             return ADUC_Result{ ADUC_Result_Apply_InProgress };
@@ -288,8 +298,10 @@ private:
                     workCompletionData->WorkCompletionToken, result, true /* isAsync */);
             } };
 
-            // Allow the thread to work independently of this main thread.
-            worker.detach();
+            // Transfer ownership of the worker thread to the platform layer instance so
+            // that its lifetime is bounded by the platform layer (avoids use-after-free
+            // of workCompletionData/workflowData if the agent shuts down mid-operation).
+            static_cast<LinuxPlatformLayer*>(token)->TrackWorker(std::move(worker));
 
             // Indicate that we've spun off a thread to do the actual work.
             return ADUC_Result{ ADUC_Result_Restore_InProgress };
@@ -419,6 +431,44 @@ private:
      * @brief Was Cancel called?
      */
     std::atomic_bool _IsCancellationRequested{ false };
+
+    /**
+     * @brief Serializes access to @p _activeWorker so that installation of a new
+     * worker thread and shutdown-time joining cannot race.
+     */
+    std::mutex _activeWorkerMutex;
+
+    /**
+     * @brief Tracks the currently running async worker thread spawned by one of
+     * the Download/Backup/Install/Apply/Restore callbacks.
+     *
+     * The async callbacks rely on pointers (workCompletionData, workflowData)
+     * that are owned by the agent and guaranteed valid only until
+     * WorkCompletionCallback fires. Previously the worker was detached, meaning
+     * agent shutdown could invalidate those pointers while the worker was still
+     * running (use-after-free). Keeping the thread joinable lets the destructor
+     * wait for it to finish before the platform layer (and anything it reaches
+     * into) goes away.
+     */
+    std::thread _activeWorker;
+
+    /**
+     * @brief Installs @p worker as the currently tracked async worker, joining
+     * any previous worker first so that at most one async operation is in
+     * flight and so that prior pointer captures are guaranteed released.
+     *
+     * The workflow engine only dispatches one async operation at a time, but we
+     * still join defensively to make the ownership model explicit.
+     */
+    void TrackWorker(std::thread&& worker)
+    {
+        std::lock_guard<std::mutex> lock(_activeWorkerMutex);
+        if (_activeWorker.joinable())
+        {
+            _activeWorker.join();
+        }
+        _activeWorker = std::move(worker);
+    }
 };
 } // namespace ADUC
 

--- a/src/platform_layers/linux_platform_layer/tests/linux_adu_core_impl_ut.cpp
+++ b/src/platform_layers/linux_platform_layer/tests/linux_adu_core_impl_ut.cpp
@@ -6,12 +6,18 @@
  * Licensed under the MIT License.
  */
 #include <catch2/catch_all.hpp>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstring>
+#include <mutex>
 #include <string>
+#include <thread>
 
 #include <aduc/adu_core_exports.h>
 #include <aduc/result.h>
 #include <aduc/types/adu_core.h>
+#include <aduc/types/workflow.h>
 
 #include <sys/stat.h> // stat, mkdir
 #include <unistd.h>   // rmdir
@@ -368,4 +374,279 @@ TEST_CASE("LinuxPlatformLayer callback function pointer consistency")
         ADUC_Unregister(callbacks1.PlatformLayerHandle);
         ADUC_Unregister(callbacks2.PlatformLayerHandle);
     }
+}
+
+//
+// Regression tests for issue #858 - worker thread lifecycle.
+//
+// The Download/Backup/Install/Apply/Restore callbacks spawn a worker thread that
+// captures raw pointers to workCompletionData and workflowData. Previously this
+// worker was detached, which meant the agent could shut down while the worker
+// was still running, leading to use-after-free on those pointers. The platform
+// layer now tracks the worker and joins it in its destructor; these tests
+// exercise that guarantee.
+//
+// We drive the worker through a safe, fast-failing path by passing a
+// workflowData with WorkflowHandle == nullptr. That causes
+// GetUpdateManifestHandler to return an early failure, the worker calls
+// WorkCompletionCallback, and exits - no real workflow infrastructure is
+// required.
+//
+
+namespace
+{
+struct WorkerLifecycleProbe
+{
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::atomic<int> completions{ 0 };
+    std::atomic<int> entered{ 0 };
+    ADUC_Result lastResult{};
+    std::atomic<std::thread::id> callerThreadId{};
+
+    // When non-null, OnComplete will wait on this until it becomes false,
+    // letting tests pin the worker thread inside the completion callback.
+    std::atomic<bool>* holdFlag{ nullptr };
+    std::condition_variable holdCv;
+
+    ADUC_WorkCompletionData MakeWorkCompletionData()
+    {
+        ADUC_WorkCompletionData data{};
+        data.WorkCompletionCallback = &WorkerLifecycleProbe::OnComplete;
+        data.WorkCompletionToken = this;
+        return data;
+    }
+
+    bool WaitForCompletions(int expected, std::chrono::milliseconds timeout)
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        return cv.wait_for(lock, timeout, [this, expected] { return completions.load() >= expected; });
+    }
+
+    bool WaitForEntered(int expected, std::chrono::milliseconds timeout)
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        return cv.wait_for(lock, timeout, [this, expected] { return entered.load() >= expected; });
+    }
+
+    void ReleaseHold()
+    {
+        if (holdFlag != nullptr)
+        {
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                holdFlag->store(false);
+            }
+            holdCv.notify_all();
+        }
+    }
+
+    static void OnComplete(const void* token, ADUC_Result result, bool /*isAsync*/)
+    {
+        auto* self = const_cast<WorkerLifecycleProbe*>(static_cast<const WorkerLifecycleProbe*>(token));
+        {
+            std::lock_guard<std::mutex> lock(self->mtx);
+            self->lastResult = result;
+            self->callerThreadId = std::this_thread::get_id();
+            ++self->entered;
+        }
+        self->cv.notify_all();
+
+        if (self->holdFlag != nullptr)
+        {
+            std::unique_lock<std::mutex> lock(self->mtx);
+            self->holdCv.wait(lock, [self] { return !self->holdFlag->load(); });
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(self->mtx);
+            ++self->completions;
+        }
+        self->cv.notify_all();
+    }
+};
+} // namespace
+
+TEST_CASE("LinuxPlatformLayer async worker thread completes and reports result")
+{
+    ADUC_UpdateActionCallbacks callbacks = {};
+    REQUIRE(IsAducResultCodeSuccess(ADUC_RegisterPlatformLayer(&callbacks, 0, nullptr).ResultCode));
+
+    WorkerLifecycleProbe probe;
+    auto workCompletionData = probe.MakeWorkCompletionData();
+
+    // Null WorkflowHandle makes GetUpdateManifestHandler fail fast in the worker.
+    ADUC_WorkflowData workflowData{};
+    workflowData.WorkflowHandle = nullptr;
+
+    SECTION("ApplyCallback returns InProgress synchronously and worker fires completion")
+    {
+        ADUC_Result callerResult =
+            callbacks.ApplyCallback(callbacks.PlatformLayerHandle, &workCompletionData, &workflowData);
+
+        CHECK(callerResult.ResultCode == ADUC_Result_Apply_InProgress);
+        REQUIRE(probe.WaitForCompletions(1, std::chrono::seconds(5)));
+        CHECK(probe.completions.load() == 1);
+        // The completion must come from the worker thread, not the calling thread.
+        CHECK(probe.callerThreadId.load() != std::this_thread::get_id());
+    }
+
+    SECTION("DownloadCallback runs worker to completion")
+    {
+        ADUC_Result callerResult =
+            callbacks.DownloadCallback(callbacks.PlatformLayerHandle, &workCompletionData, &workflowData);
+        CHECK(callerResult.ResultCode == ADUC_Result_Download_InProgress);
+        REQUIRE(probe.WaitForCompletions(1, std::chrono::seconds(5)));
+    }
+
+    ADUC_Unregister(callbacks.PlatformLayerHandle);
+}
+
+TEST_CASE("LinuxPlatformLayer sequential async callbacks serialize worker lifetimes")
+{
+    // Issuing a second async callback while the previous worker may still be
+    // running must not leak or detach the prior thread. TrackWorker joins the
+    // previous thread before adopting the new one.
+    ADUC_UpdateActionCallbacks callbacks = {};
+    REQUIRE(IsAducResultCodeSuccess(ADUC_RegisterPlatformLayer(&callbacks, 0, nullptr).ResultCode));
+
+    WorkerLifecycleProbe probe;
+    auto workCompletionData = probe.MakeWorkCompletionData();
+    ADUC_WorkflowData workflowData{};
+    workflowData.WorkflowHandle = nullptr;
+
+    constexpr int iterations = 5;
+    for (int i = 0; i < iterations; ++i)
+    {
+        ADUC_Result r = callbacks.ApplyCallback(callbacks.PlatformLayerHandle, &workCompletionData, &workflowData);
+        CHECK(r.ResultCode == ADUC_Result_Apply_InProgress);
+    }
+
+    REQUIRE(probe.WaitForCompletions(iterations, std::chrono::seconds(10)));
+    CHECK(probe.completions.load() == iterations);
+
+    ADUC_Unregister(callbacks.PlatformLayerHandle);
+}
+
+TEST_CASE("LinuxPlatformLayer destructor waits for in-flight worker (issue #858)")
+{
+    // Core regression for issue #858: after ADUC_Unregister returns, no worker
+    // thread may still be alive. If the destructor did not join the worker
+    // (as was the case with detach()), the worker could touch freed memory.
+    // We verify the worker's completion callback has fired by the time
+    // ADUC_Unregister returns - that guarantees the worker had progressed past
+    // the capture-using portion of its lambda.
+
+    ADUC_UpdateActionCallbacks callbacks = {};
+    REQUIRE(IsAducResultCodeSuccess(ADUC_RegisterPlatformLayer(&callbacks, 0, nullptr).ResultCode));
+
+    WorkerLifecycleProbe probe;
+    auto workCompletionData = probe.MakeWorkCompletionData();
+    ADUC_WorkflowData workflowData{};
+    workflowData.WorkflowHandle = nullptr;
+
+    ADUC_Result callerResult =
+        callbacks.ApplyCallback(callbacks.PlatformLayerHandle, &workCompletionData, &workflowData);
+    REQUIRE(callerResult.ResultCode == ADUC_Result_Apply_InProgress);
+
+    // Destructor must join the worker; the completion count must be observed
+    // as 1 by the time Unregister returns.
+    ADUC_Unregister(callbacks.PlatformLayerHandle);
+
+    CHECK(probe.completions.load() == 1);
+}
+
+TEST_CASE("LinuxPlatformLayer all async callbacks run their worker to completion")
+{
+    // Structural coverage: Backup / Install / Restore use the same TrackWorker
+    // pattern as Download / Apply. Verify each dispatches a worker that fires
+    // WorkCompletionCallback.
+    ADUC_UpdateActionCallbacks callbacks = {};
+    REQUIRE(IsAducResultCodeSuccess(ADUC_RegisterPlatformLayer(&callbacks, 0, nullptr).ResultCode));
+
+    WorkerLifecycleProbe probe;
+    auto workCompletionData = probe.MakeWorkCompletionData();
+    ADUC_WorkflowData workflowData{};
+    workflowData.WorkflowHandle = nullptr;
+
+    using AsyncCb = ADUC_Result (*)(ADUC_Token, const ADUC_WorkCompletionData*, ADUC_WorkflowDataToken);
+    struct CallbackCase
+    {
+        const char* name;
+        AsyncCb cb;
+        int expectedInProgress;
+    };
+
+    const CallbackCase cases[] = {
+        { "Backup", callbacks.BackupCallback, ADUC_Result_Backup_InProgress },
+        { "Install", callbacks.InstallCallback, ADUC_Result_Install_InProgress },
+        { "Restore", callbacks.RestoreCallback, ADUC_Result_Restore_InProgress },
+    };
+
+    int expectedCompletions = 0;
+    for (const auto& c : cases)
+    {
+        INFO("Callback: " << c.name);
+        ADUC_Result r = c.cb(callbacks.PlatformLayerHandle, &workCompletionData, &workflowData);
+        CHECK(r.ResultCode == c.expectedInProgress);
+        ++expectedCompletions;
+        REQUIRE(probe.WaitForCompletions(expectedCompletions, std::chrono::seconds(5)));
+    }
+    CHECK(probe.completions.load() == 3);
+
+    ADUC_Unregister(callbacks.PlatformLayerHandle);
+}
+
+TEST_CASE("LinuxPlatformLayer destructor blocks until an in-flight worker finishes")
+{
+    // Strong regression for issue #858: if the worker is still executing when
+    // the platform layer is destroyed, the destructor must block until the
+    // worker finishes. Before the fix (detach), Unregister would return
+    // immediately even while the worker still held raw pointers.
+    //
+    // Strategy: pin the worker thread inside the completion callback via a
+    // shared flag. Issue ApplyCallback, wait for the worker to enter
+    // OnComplete. Then call ADUC_Unregister from a separate thread and verify
+    // it does not return until we release the hold. At the moment the hold is
+    // released, the destructor's join() should complete and Unregister returns.
+
+    ADUC_UpdateActionCallbacks callbacks = {};
+    REQUIRE(IsAducResultCodeSuccess(ADUC_RegisterPlatformLayer(&callbacks, 0, nullptr).ResultCode));
+
+    WorkerLifecycleProbe probe;
+    std::atomic<bool> hold{ true };
+    probe.holdFlag = &hold;
+
+    auto workCompletionData = probe.MakeWorkCompletionData();
+    ADUC_WorkflowData workflowData{};
+    workflowData.WorkflowHandle = nullptr;
+
+    ADUC_Result callerResult =
+        callbacks.ApplyCallback(callbacks.PlatformLayerHandle, &workCompletionData, &workflowData);
+    REQUIRE(callerResult.ResultCode == ADUC_Result_Apply_InProgress);
+
+    // Wait until the worker has entered OnComplete and is blocked on the hold.
+    REQUIRE(probe.WaitForEntered(1, std::chrono::seconds(5)));
+    REQUIRE(probe.completions.load() == 0); // still pinned inside OnComplete
+
+    // Destroy the platform layer from another thread so we can observe that
+    // the destructor is blocked in join().
+    std::atomic<bool> unregisterReturned{ false };
+    std::thread destroyer([&] {
+        ADUC_Unregister(callbacks.PlatformLayerHandle);
+        unregisterReturned = true;
+    });
+
+    // Give the destroyer thread time to enter the destructor and attempt to
+    // join the worker. It must NOT return while the worker is pinned.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    CHECK(unregisterReturned.load() == false);
+    CHECK(probe.completions.load() == 0);
+
+    // Release the worker; the join() inside the destructor must now unblock.
+    probe.ReleaseHold();
+
+    destroyer.join();
+    CHECK(unregisterReturned.load() == true);
+    CHECK(probe.completions.load() == 1);
 }


### PR DESCRIPTION
The Download/Backup/Install/Apply/Restore callbacks in LinuxPlatformLayer spawned a std::thread and called detach() on it. The worker captured raw pointers to workCompletionData and workflowData, which are only guaranteed valid until WorkCompletionCallback fires. Agent shutdown (or workflow teardown) while the worker was still running could therefore invalidate those pointers and cause use-after-free / core dumps (related to #852).

Changes:
- Add an instance-owned std::thread (_activeWorker) plus a std::mutex (_activeWorkerMutex) to the LinuxPlatformLayer.
- Introduce a TrackWorker() helper that joins any previously installed worker under the mutex and takes ownership of the new one. Replace each of the five worker.detach() sites with a single call to TrackWorker(std::move(worker)), keeping the workflow-engine guarantee that at most one async operation is in flight while also making the ownership model explicit.
- Extend ~LinuxPlatformLayer to signal cancellation and join the active worker before ExtensionManager::Uninit(). This guarantees that by the time the platform layer is destroyed, no worker can still be touching workCompletionData / workflowData.

Tests (src/platform_layers/linux_platform_layer/tests/linux_adu_core_impl_ut.cpp):
- Happy-path async completion for Apply and Download (worker runs on a separate thread and invokes WorkCompletionCallback).
- Structural coverage for Backup, Install, Restore through the same TrackWorker path.
- Sequential invocations: five back-to-back ApplyCallback calls all complete without leaking or detaching the prior worker.
- Destructor waits for a naturally-completing worker (regression for #858).
- Destructor blocks until an in-flight worker finishes: the completion callback is pinned via a hold flag, Unregister is invoked from a second thread, and the test asserts Unregister does not return until the hold is released. Pre-fix (with detach) this would have observed Unregister returning early, proving the join is effective.