### PR TITLE
Fix #779: don't log SAS-token rotation as a broken connection

### DIFF
--- a/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
+++ b/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
@@ -214,6 +214,41 @@ ADUC_ClientHandle IoTHub_CommunicationManager_GetHandle()
 }
 
 /**
+ * @brief Categorization of an UNAUTHENTICATED connection status event.
+ *
+ * Used to distinguish the benign, expected case where the Azure IoT C SDK
+ * is rotating an expired SAS token (and will reconnect on its own) from
+ * a real connection failure that warrants an error in the logs.
+ */
+typedef enum tagADUC_ConnUnauthCategory
+{
+    ADUC_ConnUnauth_TransientSasRenewal = 0, /**< Expected SAS token renewal; log at Info. */
+    ADUC_ConnUnauth_Broken = 1, /**< Real failure; log at Error. */
+} ADUC_ConnUnauthCategory;
+
+/**
+ * @brief Categorizes an IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED event by reason.
+ *
+ * SAS-token expiry is part of the SDK's normal token-rotation flow (it fires
+ * about every 48 minutes for symmetric-key auth) and should not be reported
+ * as a broken connection. See GitHub issue #779.
+ *
+ * @param reason The IOTHUB_CLIENT_CONNECTION_STATUS_REASON reported alongside
+ *               the UNAUTHENTICATED status.
+ * @return ADUC_ConnUnauth_TransientSasRenewal for benign SAS-token rotation,
+ *         ADUC_ConnUnauth_Broken otherwise.
+ */
+ADUC_ConnUnauthCategory IoTHub_CommunicationManager_CategorizeUnauthenticated(
+    IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason)
+{
+    if (reason == IOTHUB_CLIENT_CONNECTION_EXPIRED_SAS_TOKEN)
+    {
+        return ADUC_ConnUnauth_TransientSasRenewal;
+    }
+    return ADUC_ConnUnauth_Broken;
+}
+
+/**
  * @brief A callback use for processing the IoT Hub Client connection status changed event.
  *
  * @param status An IoT Hub connection status
@@ -236,7 +271,16 @@ void IoTHub_CommunicationManager_ConnectionStatus_Callback(
         g_authentication_retries = 0;
         break;
     case IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED:
-        if (g_last_authenticated_time >= g_first_unauthenticated_time)
+        if (IoTHub_CommunicationManager_CategorizeUnauthenticated(status_reason)
+            == ADUC_ConnUnauth_TransientSasRenewal)
+        {
+            // Expected SAS-token rotation. The SDK will refresh the token and
+            // reconnect on its own; do not log an error and do not reset
+            // g_first_unauthenticated_time so that a *real* outage that
+            // follows still trips the "broken for N seconds" branch below.
+            Log_Info("IoTHub SAS token expired; SDK will renew the connection.");
+        }
+        else if (g_last_authenticated_time >= g_first_unauthenticated_time)
         {
             Log_Error("IoTHub connection is broken.");
             g_first_unauthenticated_time = now_time;

--- a/src/communication_managers/iothub_communication_manager/tests/iothub_communication_manager_ut.cpp
+++ b/src/communication_managers/iothub_communication_manager/tests/iothub_communication_manager_ut.cpp
@@ -835,6 +835,68 @@ TEST_CASE("IoTHub_CommunicationManager_Init and Deinit lifecycle")
 // Tests for ConnectionStatus_Callback exercising the "broken for X seconds" sub-branch
 //
 
+// Forward declaration of the internal categorization helper (kept out of the
+// public header). See GitHub issue #779.
+typedef enum tagADUC_ConnUnauthCategory
+{
+    ADUC_ConnUnauth_TransientSasRenewal = 0,
+    ADUC_ConnUnauth_Broken = 1,
+} ADUC_ConnUnauthCategory;
+
+extern "C" ADUC_ConnUnauthCategory IoTHub_CommunicationManager_CategorizeUnauthenticated(
+    IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason);
+
+TEST_CASE("Issue #779: SAS token expiry must not be categorized as 'broken'")
+{
+    // Expected SAS-token renewal: must NOT be treated as a broken connection.
+    CHECK(
+        IoTHub_CommunicationManager_CategorizeUnauthenticated(IOTHUB_CLIENT_CONNECTION_EXPIRED_SAS_TOKEN)
+        == ADUC_ConnUnauth_TransientSasRenewal);
+
+    // Real failures must still be categorized as broken.
+    CHECK(
+        IoTHub_CommunicationManager_CategorizeUnauthenticated(IOTHUB_CLIENT_CONNECTION_BAD_CREDENTIAL)
+        == ADUC_ConnUnauth_Broken);
+    CHECK(
+        IoTHub_CommunicationManager_CategorizeUnauthenticated(IOTHUB_CLIENT_CONNECTION_DEVICE_DISABLED)
+        == ADUC_ConnUnauth_Broken);
+    CHECK(
+        IoTHub_CommunicationManager_CategorizeUnauthenticated(IOTHUB_CLIENT_CONNECTION_NO_NETWORK)
+        == ADUC_ConnUnauth_Broken);
+    CHECK(
+        IoTHub_CommunicationManager_CategorizeUnauthenticated(IOTHUB_CLIENT_CONNECTION_COMMUNICATION_ERROR)
+        == ADUC_ConnUnauth_Broken);
+    CHECK(
+        IoTHub_CommunicationManager_CategorizeUnauthenticated(IOTHUB_CLIENT_CONNECTION_RETRY_EXPIRED)
+        == ADUC_ConnUnauth_Broken);
+    CHECK(
+        IoTHub_CommunicationManager_CategorizeUnauthenticated(IOTHUB_CLIENT_CONNECTION_NO_PING_RESPONSE)
+        == ADUC_ConnUnauth_Broken);
+    CHECK(
+        IoTHub_CommunicationManager_CategorizeUnauthenticated(IOTHUB_CLIENT_CONNECTION_OK)
+        == ADUC_ConnUnauth_Broken);
+}
+
+TEST_CASE("Issue #779: SAS expiry callback is handled benignly")
+{
+    // Authenticate first so any subsequent unauthenticated event would,
+    // under the old behavior, reset g_first_unauthenticated_time and log
+    // "IoTHub connection is broken."
+    IoTHub_CommunicationManager_ConnectionStatus_Callback(
+        IOTHUB_CLIENT_CONNECTION_AUTHENTICATED, IOTHUB_CLIENT_CONNECTION_OK, nullptr);
+    REQUIRE(IoTHub_CommunicationManager_IsAuthenticated() == true);
+
+    // SAS-token expiry: must not crash and must flip IsAuthenticated.
+    IoTHub_CommunicationManager_ConnectionStatus_Callback(
+        IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED, IOTHUB_CLIENT_CONNECTION_EXPIRED_SAS_TOKEN, nullptr);
+    CHECK(IoTHub_CommunicationManager_IsAuthenticated() == false);
+
+    // A second SAS expiry in a row should also be treated benignly.
+    IoTHub_CommunicationManager_ConnectionStatus_Callback(
+        IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED, IOTHUB_CLIENT_CONNECTION_EXPIRED_SAS_TOKEN, nullptr);
+    CHECK(IoTHub_CommunicationManager_IsAuthenticated() == false);
+}
+
 TEST_CASE("ConnectionStatus_Callback exercises both unauthenticated sub-branches")
 {
     SECTION("First unauthenticated triggers 'connection is broken' path")
@@ -849,7 +911,7 @@ TEST_CASE("ConnectionStatus_Callback exercises both unauthenticated sub-branches
         // First unauthenticated - hits "IoTHub connection is broken." branch
         IoTHub_CommunicationManager_ConnectionStatus_Callback(
             IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED,
-            IOTHUB_CLIENT_CONNECTION_EXPIRED_SAS_TOKEN,
+            IOTHUB_CLIENT_CONNECTION_BAD_CREDENTIAL,
             nullptr);
         CHECK(IoTHub_CommunicationManager_IsAuthenticated() == false);
     }


### PR DESCRIPTION
The IoT Hub C SDK fires the connection-status callback with reason IOTHUB_CLIENT_CONNECTION_EXPIRED_SAS_TOKEN as part of its normal token-rotation flow (~every 48 minutes for symmetric-key auth). The agent's UNAUTHENTICATED handler logged "IoTHub connection is broken." unconditionally, producing ~30 alarming errors per day on healthy devices and creating noise during support triage.

Distinguish the benign SAS-token rotation case from a real failure: introduce an internal helper IoTHub_CommunicationManager_Categorize- Unauthenticated() that maps EXPIRED_SAS_TOKEN to a transient category and everything else to "broken". The callback now logs Info ("SAS token expired; SDK will renew the connection.") for the transient case and leaves g_first_unauthenticated_time untouched so a real outage that follows still trips the existing "broken for N seconds" escalation branch. All other reasons retain the original error wording and state-tracking behavior; the retry-delay logic in PerformChannelManagement (which already special-cases EXPIRED_SAS_TOKEN to a 15s retry) is unchanged.

Add unit tests in iothub_communication_manager_ut.cpp:
  - "Issue #779: SAS token expiry must not be categorized as 'broken'" -- direct regression assertion over the helper for EXPIRED_SAS_TOKEN plus six other reasons.
  - "Issue #779: SAS expiry callback is handled benignly" -- drives the public callback through an authenticated -> SAS-expiry -> SAS-expiry sequence and asserts IsAuthenticated() flips to false without crashing.
  - Update the existing "exercises both unauthenticated sub-branches" case to use BAD_CREDENTIAL for the broken-branch coverage, since EXPIRED_SAS_TOKEN no longer takes that path.