### PR TITLE
SDK status API: bug fixes, end-to-end tests, doc cleanup

### DIFF
--- a/docs/agent-reference/GetAduServiceStatus.md
+++ b/docs/agent-reference/GetAduServiceStatus.md
@@ -16,7 +16,7 @@ Install pkg-config for library discovery:
 
 **Ubuntu/Debian:**
 ```sh
-sudo apt update && sudo apt install pkgconfig
+sudo apt update && sudo apt install pkg-config
 ```
 
 ### Build and Install
@@ -66,12 +66,14 @@ Key points in the code will call an internal API to set these "view state" statu
 
 ## Pause State
 
-The `ADUC_ServiceStatus_Paused` state will be returned from the `GetAduServiceStatus()` API before the agent enters `Idle` state.
+The `ADUC_ServiceStatus_Paused` state is returned from the `GetAduServiceStatus()` API after the agent has finished a deployment cycle and before it transitions to `Idle`.
 
 The pause period is controlled by the `IdlePauseMilliseconds` configuration in `du-config.json`.
-During this pause period, the agent will ignore any incoming C2D messages. Therefore, no cancel, replacement, or new update deployment can begin during this interval.
+During this pause period the agent will ignore any incoming C2D messages, so no cancel, replacement, or new update deployment can begin during this interval.
 
-Once the pause period timer has timed out and any queued reporting of results in C2D messaging have been sent, the API will then return `ADUC_ServiceStatus_Idle` and the agent would then be able to start processing any incoming push requests from IoTHub.
+Because new deployments cannot start while the agent is `Paused`, this is the state in which a caller may safely transition the device to a low-power mode without missing an update.
+
+Once the pause-period timer has expired and any queued reporting of results has been sent to IoT Hub, the API will return `ADUC_ServiceStatus_Idle` and the agent is again able to start processing incoming push requests from IoT Hub. While the agent is `Idle` it is actively eligible to receive new deployments, so a caller should NOT enter a low-power mode purely on the basis of an `Idle` reading — use `Paused` for that.
 
 ## The Cross-Proc wire protocol
 
@@ -79,12 +81,14 @@ The SDK libaducsdk.a static lib will write requests to the ADUC request FIFO and
 
 ### Request Format
 The request format is: `<ver><type><len><str>`
-where ver, type, len are 16-bit values and str is a non-null-terminated utf-8 encoded string of length len (can be 0)
-e.g. 00 01 00 01 00 13 '/data/resp1234.fifo' (note: the nibbles on the wire are in network order, i.e. big-endian).
-In the uint16_t local variables on a little-endian host, these will be 01 00 01 00 13 00
+where ver, type, len are 16-bit unsigned values in network byte order and str is a non-null-terminated UTF-8 encoded string of length `len` bytes (can be 0).
+e.g. on the wire: `00 01 00 01 00 13 '/data/resp1234.fifo'` — bytes are sent in network order (big-endian) for the three uint16 fields.
+On a little-endian host, the same fields read into local `uint16_t` variables would be stored as `01 00 01 00 13 00`.
 
 ### Response Format
-The Response consists of `<code><ret_val>`, both of which are a double word. e.g. 00 01 00 02 on the wire (01 00 02 00 on LE host) would indicate code 1 (response to query status) and ret_val 2 ([Downloading](../../src/sdk/inc/aduc/aducsdk.h))
+The response consists of `<code><ret_val>`, both of which are 16-bit unsigned values (uint16_t) sent in network byte order.
+e.g. `00 01 00 02` on the wire (`01 00 02 00` in memory on a little-endian host) indicates code 1 (response to GET_STATE) and ret_val 2 ([Downloading](../../src/sdk/inc/aduc/aducsdk.h)).
+The SDK validates that `code` matches the request type before returning `ret_val` to the caller; a mismatch is reported as `ADUC_ServiceStatus_ERROR_AgentServiceInternal`.
 
 ## Package Config
 
@@ -195,8 +199,8 @@ sequenceDiagram
     Note over ReqFIFO,ViewState: ADU Service Process
 
     Client->>SDK: GetAduServiceStatus()
-    SDK->>SDK: Create temp response FIFO
-    SDK->>ReqFIFO: Write "GET_STATE:/tmp/adu_status_12345"
+    SDK->>SDK: Create per-call response FIFO<br/>at /var/lib/adu/api/resp_<random>.fifo
+    SDK->>ReqFIFO: Write GET_STATE request<br/>(ver=1,type=1,len,&lt;respFifoPath&gt;)
 
     ReqFIFO->>ApiSvcReqHandler: Read request
     ApiSvcThread->>ApiSvcReqHandler: Process GET_STATE command
@@ -257,7 +261,7 @@ sequenceDiagram
 graph TB
     subgraph "Client Process"
         CA[Client Application]
-        IW[In-Proc Wrapper API<br/>libaducsdk.so]
+        IW[In-Proc Wrapper API<br/>libaducsdk.a]
         CA --> IW
     end
 
@@ -273,11 +277,11 @@ graph TB
     end
 
     subgraph "IPC Layer"
-        RF[Request FIFO<br/>/var/lib/adu/api/req.fifo]
+        RF[Request FIFO<br/>/var/lib/adu/api/apireq.fifo]
         RSF[Response FIFO<br/>/var/lib/adu/api/resp_XXXXX.fifo]
     end
 
-    IW -.->|"GET_STATE:/var/lib/adu/api/resp_XXXXX.fifo"| RF
+    IW -.->|"GET_STATE request, with respFifoPath=<br/>/var/lib/adu/api/resp_XXXXX.fifo"| RF
     RF --> CL
     CH -.->|"Status Code"| RSF
     RSF --> IW

--- a/src/agent/api/tests/CMakeLists.txt
+++ b/src/agent/api/tests/CMakeLists.txt
@@ -6,14 +6,25 @@ disablertti ()
 
 find_package (Catch2 REQUIRED)
 
+# SDK uses the same per-test data dir as the rest of this test (apisvc subdir).
+set (APISVC_TEST_DATA_DIR "${ADUC_TEST_DATA_FOLDER}/apisvc")
+
 add_executable (${target_name})
 target_sources (${target_name} PRIVATE apisvc_unit_tests.cpp)
 
+# Compile aducsdk.c privately so its hard-coded production paths can be
+# overridden to point at a writable test directory (matches the path the
+# test passes to init_api_svc).
+target_sources (${target_name} PRIVATE ${CMAKE_SOURCE_DIR}/src/sdk/src/aducsdk.c)
+target_include_directories (${target_name} PRIVATE ${CMAKE_SOURCE_DIR}/src/sdk/inc)
+
 target_compile_definitions (
-    ${target_name} PRIVATE ADUC_API_DEFAULT_FIFO_PATH="${ADUC_API_DEFAULT_FIFO_PATH}"
-                           ADUC_FILE_GROUP="${ADUC_FILE_GROUP}"
-                           ADUC_FILE_USER="${ADUC_FILE_USER}"
-                           ADUC_TEST_DATA_FOLDER="${ADUC_TEST_DATA_FOLDER}")
+    ${target_name}
+    PRIVATE ADUC_API_DEFAULT_FIFO_PATH="${APISVC_TEST_DATA_DIR}/test_req_fifo"
+            ADUC_DATA_FOLDER="${APISVC_TEST_DATA_DIR}"
+            ADUC_FILE_GROUP="${ADUC_FILE_GROUP}"
+            ADUC_FILE_USER="${ADUC_FILE_USER}"
+            ADUC_TEST_DATA_FOLDER="${ADUC_TEST_DATA_FOLDER}")
 
 target_link_libraries (
     ${target_name}
@@ -23,7 +34,6 @@ target_link_libraries (
             aduc::auto_utils
             aduc::config_utils
             aduc::logging
-            aduc::sdk
             aduc::viewstatemgr)
 
 include (CTest)

--- a/src/agent/api/tests/apisvc_unit_tests.cpp
+++ b/src/agent/api/tests/apisvc_unit_tests.cpp
@@ -154,4 +154,26 @@ TEST_CASE("apisvc crossproc tests")
 
         CHECK(uninit_api_svc());
     }
+
+    SECTION("GetAduServiceStatus via SDK API")
+    {
+        REQUIRE(viewstatemgr_svcstatus_set(&g_vsm, ADUC_ServiceStatus_Idle));
+
+        // The SDK was compiled with ADUC_API_DEFAULT_FIFO_PATH pointing at
+        // <TEST_DATA_DIR>/test_req_fifo and ADUC_DATA_FOLDER at TEST_DATA_DIR
+        // (see CMakeLists.txt). Match those paths here so the SDK and the
+        // service rendezvous on the same FIFO. The SDK creates response
+        // FIFOs at <ADUC_DATA_FOLDER>/api/, so make sure that exists.
+        const std::string reqFifoPath = TEST_DATA_DIR + "/test_req_fifo";
+        std::filesystem::create_directories(TEST_DATA_DIR + "/api");
+
+        REQUIRE(init_api_svc(reqFifoPath.c_str()));
+        // Give the apisvc thread a moment to open the request FIFO for read.
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        ADUC_ServiceStatus status = GetAduServiceStatus();
+        CHECK(status == ADUC_ServiceStatus_Idle);
+
+        CHECK(uninit_api_svc());
+    }
 }

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -53,3 +53,7 @@ configure_file(
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/aducsdk.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
+
+if (ADUC_BUILD_UNIT_TESTS)
+    add_subdirectory (tests)
+endif ()

--- a/src/sdk/README-Yocto-Integration.md
+++ b/src/sdk/README-Yocto-Integration.md
@@ -13,7 +13,7 @@ https://github.com/Azure/iot-hub-device-update-yocto/blob/scarthgap/README.md#qu
 ### Build and Run the status_monitor example using the Yocto toolchain here by following these steps:
 https://github.com/Azure/iot-hub-device-update-yocto/blob/scarthgap/README.md#build-and-run-status-monitor-for-arm64-using-yocto-toolchain
 
-The status monitor exercises the GetServiceStatus API from the SDK.
+The status monitor exercises the GetAduServiceStatus API from the SDK.
 
 ## Yocto Recipe Integration
 
@@ -24,8 +24,8 @@ DESCRIPTION = "IoT Power Management Application"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=..."
 
-# Add dependency on the ADU SDK
-DEPENDS += "aducsdk"
+# Add dependency on the ADU SDK (built and installed by the iot-hub-device-update recipe)
+DEPENDS += "iot-hub-device-update"
 
 # Use pkg-config to get compilation flags
 inherit pkgconfig
@@ -56,12 +56,14 @@ int main() {
 
     printf("Status: %s (%d)\n", statusStr, status);
 
-    if (status == ADUC_ServiceStatus_Idle || status == ADUC_ServiceStatus_Paused) {
-        printf("Agent is idle/paused - safe to power down to conserve battery\n");
+    if (status == ADUC_ServiceStatus_Paused) {
+        printf("Agent is in the post-update quiet period - safe to power down to conserve battery\n");
         // TODO: Initiate power down sequence here
     } else if (status >= ADUC_ServiceStatus_ERROR_UnsupportedApiVersion) {
         printf("Error communicating with agent: %s\n", statusStr);
         return 1;
+    } else if (status == ADUC_ServiceStatus_Idle) {
+        printf("Agent is idle and eligible to receive new deployments - do NOT power down\n");
     } else {
         printf("Agent is busy working on update deployment processing\n");
     }
@@ -73,11 +75,11 @@ int main() {
 ## ADU SDK Integration in Yocto
 
 ### Installing the SDK Package
-In a Yocto build, the ADU SDK will be built and installed as part of the `iot-hub-device-update` recipe, providing:
+In a Yocto build, the ADU SDK is built and installed as part of the `iot-hub-device-update` recipe, providing:
 
-- **Library**: `/usr/lib/libaducsdk.a`
-- **Header**: `/usr/include/aduc/aducsdk.h`
-- **pkg-config**: `/usr/lib/pkgconfig/aducsdk.pc`
+- **Library**: `${libdir}/libaducsdk.a` (e.g. `/usr/lib/libaducsdk.a` on most Yocto layers; check your machine's `libdir` for multilib targets)
+- **Header**: `${includedir}/aduc/aducsdk.h` (e.g. `/usr/include/aduc/aducsdk.h`)
+- **pkg-config**: `${libdir}/pkgconfig/aducsdk.pc`
 
 ### Runtime Dependencies
 The app would communicate with:

--- a/src/sdk/README.md
+++ b/src/sdk/README.md
@@ -6,7 +6,7 @@ The Azure Device Update (ADU) SDK provides a C ABI for external applications to 
 
 The SDK enables applications to:
 - Check if the ADU agent is actively processing updates
-- Determine when it's safe to enter low-power mode (There is a configurable pause interval when it enters Idle state)
+- Determine when it's safe to enter low-power mode (`Paused` is the safe state — see [GetAduServiceStatus.md](../../docs/agent-reference/GetAduServiceStatus.md#pause-state))
 
 The SDK communicates with the ADU agent through named pipes (FIFOs) and provides a simple, synchronous C ABI that handles the cross-proc comms.
 
@@ -42,19 +42,27 @@ const char* ADUC_ServiceStatusToString(ADUC_ServiceStatus status);
 - `ADUC_ServiceStatus_Initializing` - Agent starting up
 - `ADUC_ServiceStatus_Downloading` - Downloading update content
 - `ADUC_ServiceStatus_Installing` - Installing update
-- `ADUC_ServiceStatus_Rebooting` - System reboot in progress
+- `ADUC_ServiceStatus_Applying` - Applying update (post-install steps)
+- `ADUC_ServiceStatus_Cancelling` - Cancelling an in-progress deployment
 - `ADUC_ServiceStatus_Reporting` - Reporting results to IoT Hub
-- `ADUC_ServiceStatus_Paused` - Quiet period before idle
-- `ADUC_ServiceStatus_Idle` - Ready for new updates
+- `ADUC_ServiceStatus_Rebooting` - System reboot in progress
+- `ADUC_ServiceStatus_Paused` - Quiet period before idle (safe-to-power-down window)
+- `ADUC_ServiceStatus_Idle` - Ready for new updates (do NOT enter low-power mode)
+- `ADUC_ServiceStatus_Failed` - Last deployment failed
 
 #### Error States (10000+)
 - `ADUC_ServiceStatus_ERROR_UnsupportedApiVersion` - SDK/agent version mismatch
-- `ADUC_ServiceStatus_ERROR_AgentServiceNotRunning` - Agent service not running
-- `ADUC_ServiceStatus_ERROR_AgentServiceBrokenPipe` - Communication failure
-- `ADUC_ServiceStatus_ERROR_AgentServicePermission` - Permission denied
-- `ADUC_ServiceStatus_ERROR_AgentServiceTimeout` - Request timeout
-- `ADUC_ServiceStatus_ERROR_AgentServiceInternal` - Internal agent error
-- `ADUC_ServiceStatus_ERROR_Unknown` - Unknown error
+- `ADUC_ServiceStatus_ERROR_AgentServiceNotRunning` - Agent service not running (request FIFO missing or wrong permissions)
+- `ADUC_ServiceStatus_ERROR_AgentServiceBrokenPipe` - Communication failure on the request FIFO
+- `ADUC_ServiceStatus_ERROR_AgentServicePermission` - Permission denied on FIFO (caller is not in the `adu` group)
+- `ADUC_ServiceStatus_ERROR_AgentServiceTimeout` - Request timed out waiting for the agent
+- `ADUC_ServiceStatus_ERROR_AgentServiceInternal` - Agent returned an unexpected response
+- `ADUC_ServiceStatus_ERROR_AgentServiceReqFifoSvcEndNotOpenedYet` - Request FIFO has no reader (agent not ready)
+- `ADUC_ServiceStatus_ERROR_AgentServiceMkFifoFailed` - Could not create the per-call response FIFO
+- `ADUC_ServiceStatus_ERROR_AgentServiceChmodFailed` - Could not set permissions on the response FIFO
+- `ADUC_ServiceStatus_ERROR_AgentServiceSdkOpenRespFifoFailed` - Could not open the response FIFO created by the SDK
+- `ADUC_ServiceStatus_ERROR_RecvMsgFailed` - Failed to read the agent's response
+- `ADUC_ServiceStatus_ERROR_Unknown` - Unknown / unmapped error
 
 ## Building the SDK
 
@@ -62,11 +70,11 @@ const char* ADUC_ServiceStatusToString(ADUC_ServiceStatus status);
 
 ```bash
 # Ubuntu/Debian
-sudo apt update && sudo apt install build-essential cmake pkgconfig
+sudo apt update && sudo apt install build-essential cmake pkg-config
 
 # CentOS/RHEL/Fedora
 sudo yum install gcc cmake pkgconfig  # CentOS/RHEL 7
-sudo dnf install gcc cmake pkgconfig  # Fedora/RHEL 8+
+sudo dnf install gcc cmake pkgconf    # Fedora/RHEL 8+
 ```
 
 ### Build Instructions

--- a/src/sdk/src/aducsdk.c
+++ b/src/sdk/src/aducsdk.c
@@ -55,10 +55,15 @@ static void get_rnd_suffix(char* str, size_t length)
     }
 
     const char* charset = ALPHANUMERIC_CHARS;
+    // Bug fix: sizeof(ALPHANUMERIC_CHARS) includes the trailing '\0'. Using it
+    // directly as the modulus could pick the NUL byte and embed it in the
+    // generated suffix, which then truncates the response FIFO path. Use
+    // (sizeof - 1) so we only sample from the 62 alphanumeric characters.
+    const size_t charset_len = sizeof(ALPHANUMERIC_CHARS) - 1;
 
     for (size_t i = 0; i < length; ++i)
     {
-        str[i] = charset[rand() % (int)sizeof(ALPHANUMERIC_CHARS)];
+        str[i] = charset[(size_t)rand() % charset_len];
     }
     str[length] = '\0';
 }
@@ -107,10 +112,12 @@ static bool verify_fifo_security(const char* fifoPath)
 ADUC_ServiceStatus GetAduServiceStatus(void)
 {
     const char* reqFifoPath = ADUC_API_DEFAULT_FIFO_PATH;
+    const char* dataFolder = ADUC_DATA_FOLDER;
     char randomSuffix[13] = { 0 }; // 12 chars + null terminator
     char respFifoPath[512] = { 0 };
     int reqFifo = -1, respFifo = -1;
-    size_t respPathLen = -1;
+    bool respFifoCreated = false;  // tracks whether respFifoPath exists on disk
+    size_t respPathLen = 0;
     ssize_t n = -1;
     ApiWireRequestMsg req = { 0 };
     ApiWireResponseMsg resp = { 0 };
@@ -132,7 +139,7 @@ ADUC_ServiceStatus GetAduServiceStatus(void)
 
     get_rnd_suffix(randomSuffix, 12);
 
-    snprintf(respFifoPath, sizeof(respFifoPath), ADUC_DATA_FOLDER "/api/resp_%s.fifo", randomSuffix);
+    snprintf(respFifoPath, sizeof(respFifoPath), "%s/api/resp_%s.fifo", dataFolder, randomSuffix);
 
     if (mkfifo(respFifoPath, FIFO_FILE_MODE) < 0)
     {
@@ -140,12 +147,20 @@ ADUC_ServiceStatus GetAduServiceStatus(void)
         {
             return ADUC_ServiceStatus_ERROR_AgentServiceMkFifoFailed;
         }
+        // EEXIST: a stale file already exists at this path. Don't trust it.
+        // Remove it and recreate to ensure we own and control the FIFO.
+        if (unlink(respFifoPath) < 0 || mkfifo(respFifoPath, FIFO_FILE_MODE) < 0)
+        {
+            return ADUC_ServiceStatus_ERROR_AgentServiceMkFifoFailed;
+        }
     }
+    respFifoCreated = true;
 
     // mkfifo uses umask (typically 022) which creates a fifo with incorrect permissions, so fix it here
     if (fchmodat(AT_FDCWD, respFifoPath, 0660, 0) < 0)
     {
         unlink(respFifoPath);
+        respFifoCreated = false;
         return ADUC_ServiceStatus_ERROR_AgentServiceChmodFailed;
     }
 
@@ -260,6 +275,20 @@ ADUC_ServiceStatus GetAduServiceStatus(void)
         goto cleanup;
     }
 
+    // Validate response code matches the request type. Without this check, a
+    // malformed or spoofed response would be silently accepted and ret_val
+    // returned as a status enum.
+    if (resp.code != ApiRequestType_GETSTATE)
+    {
+        if (debug_enabled)
+        {
+            fprintf(stderr, "[ADUC SDK] Unexpected response code: %u (expected %u)\n",
+                    resp.code, (unsigned)ApiRequestType_GETSTATE);
+        }
+        result = ADUC_ServiceStatus_ERROR_AgentServiceInternal;
+        goto cleanup;
+    }
+
     result = (ADUC_ServiceStatus)(resp.ret_val);
 
     if (debug_enabled)
@@ -278,7 +307,14 @@ cleanup:
     {
         close(respFifo);
         respFifo = -1;
+    }
+    // Always unlink the response FIFO file we created, even if we never
+    // managed to open it (previously this leaked stale FIFO files on disk
+    // when the request-FIFO open failed after mkfifo had already created it).
+    if (respFifoCreated)
+    {
         unlink(respFifoPath);
+        respFifoCreated = false;
     }
 
     return result;

--- a/src/sdk/tests/CMakeLists.txt
+++ b/src/sdk/tests/CMakeLists.txt
@@ -1,0 +1,44 @@
+set (target_name aducsdk_unit_tests)
+
+include (agentRules)
+compileasc99 ()
+disablertti ()
+
+find_package (Catch2 REQUIRED)
+
+# Per-test data subdirectory under the project-wide test data folder, matching
+# the convention used elsewhere in the repo (e.g. apisvc_unit_tests).
+set (SDK_TEST_DATA_DIR "${ADUC_TEST_DATA_FOLDER}/aducsdk")
+
+add_executable (${target_name})
+
+# Compile aducsdk.c privately so we can override its hard-coded production
+# paths to point at a writable test directory. We deliberately do NOT link
+# aduc::sdk here because that target is built with the production paths.
+target_sources (
+    ${target_name} PRIVATE aducsdk_unit_tests.cpp
+                           ${CMAKE_SOURCE_DIR}/src/sdk/src/aducsdk.c)
+
+target_include_directories (${target_name} PRIVATE ${CMAKE_SOURCE_DIR}/src/sdk/inc)
+
+target_compile_definitions (
+    ${target_name}
+    PRIVATE ADUC_API_DEFAULT_FIFO_PATH="${SDK_TEST_DATA_DIR}/api/apireq.fifo"
+            ADUC_DATA_FOLDER="${SDK_TEST_DATA_DIR}"
+            ADUC_TEST_DATA_FOLDER="${ADUC_TEST_DATA_FOLDER}")
+
+target_link_libraries (
+    ${target_name}
+    PRIVATE Catch2::Catch2WithMain
+            aduc::apiproto_utils
+            aduc::apisvc
+            aduc::c_utils
+            aduc::viewstatemgr)
+
+include (CTest)
+include (Catch)
+if (NOT CMAKE_CROSSCOMPILING)
+    catch_discover_tests (${target_name})
+else ()
+    add_test (NAME ${target_name} COMMAND ${target_name})
+endif ()

--- a/src/sdk/tests/aducsdk_unit_tests.cpp
+++ b/src/sdk/tests/aducsdk_unit_tests.cpp
@@ -191,7 +191,8 @@ void fake_agent_thread(fake_agent_args* a)
         return;
     }
     uint16_t resp_net[2] = { htons(a->bogus_code), htons(a->bogus_ret_val) };
-    (void)write(wfd, resp_net, sizeof(resp_net));
+    ssize_t written = write(wfd, resp_net, sizeof(resp_net));
+    (void)written;
     close(wfd);
 }
 } // namespace

--- a/src/sdk/tests/aducsdk_unit_tests.cpp
+++ b/src/sdk/tests/aducsdk_unit_tests.cpp
@@ -1,0 +1,249 @@
+/**
+ * @file aducsdk_unit_tests.cpp
+ * @brief Unit tests for the public ADU Status SDK API (GetAduServiceStatus).
+ *
+ * These tests drive the real public SDK ABI end-to-end. To make that possible
+ * outside of a privileged production environment, the SDK source (aducsdk.c)
+ * is compiled privately into this test target with overridden values for
+ * ADUC_API_DEFAULT_FIFO_PATH and ADUC_DATA_FOLDER (see CMakeLists.txt).
+ *
+ * Bug regressions covered:
+ *   1. get_rnd_suffix used to embed '\0' bytes in the random suffix, which
+ *      truncated the response FIFO path and intermittently broke the call.
+ *      Verified by stress-running GetAduServiceStatus() many times against a
+ *      real init_api_svc() server.
+ *   2. The SDK used to leave orphaned resp_*.fifo files on disk when the
+ *      request-FIFO open failed after the response FIFO had been created.
+ *   3. The SDK used to accept any resp.code from the agent without validating
+ *      it matched the request type, allowing a spoofed response to be
+ *      returned as a status enum.
+ */
+#include "aduc/aducsdk.h"
+#include "aduc/apiproto.h"
+#include "aduc/apisvc.h"
+#include "aduc/viewstatemgr.h"
+
+#include <arpa/inet.h>
+#include <atomic>
+#include <catch2/catch_all.hpp>
+#include <chrono>
+#include <cstring>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <filesystem>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <thread>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+// apisvc.c references this global ViewStateManager symbol; the test owner
+// is responsible for defining it (matches the pattern in apisvc_unit_tests).
+ViewStateManager g_vsm = { 0 };
+
+// SDK test data subtree (must match SDK_TEST_DATA_DIR in CMakeLists.txt).
+static const std::string TEST_DATA_DIR = std::string{ ADUC_TEST_DATA_FOLDER } + "/aducsdk";
+static const std::string API_DIR = TEST_DATA_DIR + "/api";
+static const std::string REQ_FIFO_PATH = API_DIR + "/apireq.fifo";
+
+static int count_resp_fifos()
+{
+    int n = 0;
+    DIR* d = opendir(API_DIR.c_str());
+    if (d == nullptr)
+    {
+        return 0;
+    }
+    while (struct dirent* e = readdir(d))
+    {
+        if (std::strncmp(e->d_name, "resp_", 5) == 0)
+        {
+            ++n;
+        }
+    }
+    closedir(d);
+    return n;
+}
+
+static void reset_test_dir()
+{
+    std::error_code ec;
+    fs::remove_all(TEST_DATA_DIR, ec);
+    fs::create_directories(API_DIR, ec);
+}
+
+TEST_CASE("aducsdk: GetAduServiceStatus end-to-end via init_api_svc")
+{
+    reset_test_dir();
+
+    ViewStateManager vsm = { 0 };
+    REQUIRE(viewstatemgr_create(&vsm) == 0);
+    REQUIRE(viewstatemgr_svcstatus_set(&vsm, ADUC_ServiceStatus_Idle));
+    // apisvc.c reads from a global g_vsm - mirror the local one into it.
+    g_vsm = vsm;
+
+    REQUIRE(init_api_svc(REQ_FIFO_PATH.c_str()));
+    // Give the apisvc thread a moment to open the request FIFO for read.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    SECTION("happy path returns the configured status")
+    {
+        ADUC_ServiceStatus s = GetAduServiceStatus();
+        CHECK(s == ADUC_ServiceStatus_Idle);
+    }
+
+    SECTION("bug #1 regression: random suffix never truncates the response path")
+    {
+        // With the original bug (modulus = sizeof(charset) including the
+        // trailing NUL), each of the 12 suffix chars had a ~1.6% chance of
+        // being '\0'. With a NUL embedded, req.data is truncated server-side
+        // and the agent fails to open the response FIFO -> the SDK errors
+        // out. Probability of seeing AT LEAST one failure across 50 calls
+        // with the bug present is >99%. With the fix in place, all 50 must
+        // succeed.
+        const int N = 50;
+        int failures = 0;
+        for (int i = 0; i < N; ++i)
+        {
+            ADUC_ServiceStatus s = GetAduServiceStatus();
+            if (s != ADUC_ServiceStatus_Idle)
+            {
+                ++failures;
+            }
+        }
+        CHECK(failures == 0);
+    }
+
+    SECTION("bug #2 regression: no orphan resp_*.fifo files left on disk")
+    {
+        // Sanity check: stress-call the SDK and ensure cleanup happens after
+        // each successful call.
+        for (int i = 0; i < 20; ++i)
+        {
+            (void)GetAduServiceStatus();
+        }
+        CHECK(count_resp_fifos() == 0);
+    }
+
+    CHECK(uninit_api_svc());
+    viewstatemgr_destroy(&vsm);
+}
+
+namespace
+{
+struct fake_agent_args
+{
+    std::string req_fifo;
+    uint16_t bogus_code = 0;
+    uint16_t bogus_ret_val = 0;
+    std::atomic<int> ready{ 0 }; // 1 = req fifo opened, -1 = open failed
+};
+
+void fake_agent_thread(fake_agent_args* a)
+{
+    // O_RDWR so the open never blocks regardless of whether the writer is
+    // attached yet (avoids a startup race with O_RDONLY).
+    int rfd = open(a->req_fifo.c_str(), O_RDWR);
+    if (rfd < 0)
+    {
+        a->ready.store(-1);
+        return;
+    }
+    a->ready.store(1);
+
+    uint16_t hdr_net[3] = { 0 };
+    size_t total = 0;
+    while (total < sizeof(hdr_net))
+    {
+        ssize_t n = read(rfd, reinterpret_cast<char*>(hdr_net) + total, sizeof(hdr_net) - total);
+        if (n <= 0)
+        {
+            close(rfd);
+            return;
+        }
+        total += static_cast<size_t>(n);
+    }
+    uint16_t len = ntohs(hdr_net[2]);
+
+    char data[PIPE_BUF] = { 0 };
+    if (len > 0 && len < (uint16_t)sizeof(data))
+    {
+        total = 0;
+        while (total < len)
+        {
+            ssize_t n = read(rfd, data + total, len - total);
+            if (n <= 0)
+            {
+                break;
+            }
+            total += static_cast<size_t>(n);
+        }
+        data[len] = '\0';
+    }
+    close(rfd);
+
+    int wfd = open(data, O_WRONLY);
+    if (wfd < 0)
+    {
+        return;
+    }
+    uint16_t resp_net[2] = { htons(a->bogus_code), htons(a->bogus_ret_val) };
+    (void)write(wfd, resp_net, sizeof(resp_net));
+    close(wfd);
+}
+} // namespace
+
+TEST_CASE("aducsdk bug regressions (no apisvc)")
+{
+    reset_test_dir();
+
+    SECTION("bug #2 regression: orphan resp_*.fifo not left when reqFifo open fails")
+    {
+        // Create the request FIFO with the right mode but DO NOT have a
+        // reader attached. open(reqFifo, O_WRONLY|O_NONBLOCK) in the SDK
+        // will fail with ENXIO, exercising the early-exit cleanup path
+        // AFTER the response FIFO has been created.
+        REQUIRE(mkfifo(REQ_FIFO_PATH.c_str(), 0660) == 0);
+        REQUIRE(chmod(REQ_FIFO_PATH.c_str(), 0660) == 0);
+
+        ADUC_ServiceStatus s = GetAduServiceStatus();
+        // Some FIFO-side error is expected here.
+        CHECK(s >= ADUC_ServiceStatus_ERROR_UnsupportedApiVersion);
+        CHECK(count_resp_fifos() == 0);
+
+        unlink(REQ_FIFO_PATH.c_str());
+    }
+
+    SECTION("bug #3 regression: bogus response code rejected")
+    {
+        REQUIRE(mkfifo(REQ_FIFO_PATH.c_str(), 0660) == 0);
+        REQUIRE(chmod(REQ_FIFO_PATH.c_str(), 0660) == 0);
+
+        fake_agent_args args;
+        args.req_fifo = REQ_FIFO_PATH;
+        args.bogus_code = 0xBEEF; // NOT ApiRequestType_GETSTATE (0x0001)
+        args.bogus_ret_val = ADUC_ServiceStatus_Idle;
+
+        std::thread th(fake_agent_thread, &args);
+
+        // Wait for the fake agent to attach to the request FIFO.
+        for (int i = 0; i < 200 && args.ready.load() == 0; ++i)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        REQUIRE(args.ready.load() == 1);
+
+        ADUC_ServiceStatus s = GetAduServiceStatus();
+        th.join();
+
+        // The defensive SDK must NOT silently return the injected ret_val
+        // when resp.code does not match the request type.
+        CHECK(s != ADUC_ServiceStatus_Idle);
+        CHECK(s == ADUC_ServiceStatus_ERROR_AgentServiceInternal);
+
+        unlink(REQ_FIFO_PATH.c_str());
+    }
+}


### PR DESCRIPTION
Fixes three production bugs in the ADU Status SDK (aducsdk.c) that drives GetAduServiceStatus(), wires the SDK into the existing test infrastructure end-to-end for the first time, and corrects long-standing inaccuracies in the SDK reference docs.

Bug fixes (src/sdk/src/aducsdk.c)
- Random FIFO suffix could embed '\0' bytes (off-by-one on sizeof(ALPHANUMERIC_CHARS) vs strlen). With ~1.6% NUL probability per char and a 12-char suffix, ~18% of suffixes produced a truncated response-FIFO path, intermittently breaking the call. Use sizeof(charset)-1 as the modulus.
- Response FIFOs were orphaned on disk when the request FIFO open failed after mkfifo had already created the response FIFO. Track creation with an explicit flag and unlink on every error path. Also: on EEXIST, unlink and recreate the stale FIFO instead of trusting it.
- The SDK accepted any resp.code from the agent and returned the associated ret_val as a status enum without validation, allowing a malformed/spoofed response to be silently mapped to a normal state. Validate that resp.code == ApiRequestType_GETSTATE; mismatches return ADUC_ServiceStatus_ERROR_AgentServiceInternal.

No new compile-time flags or test-only seams were added to production code; all overrides are confined to the test targets.

Tests
- New Catch2 target src/sdk/tests/aducsdk_unit_tests:
  * happy-path GetAduServiceStatus end-to-end against the real init_api_svc server,
  * bug-#1 stress regression (50 iterations must all succeed),
  * bug-#2 orphan-FIFO regression,
  * bug-#3 spoofed-resp.code regression (custom fake-agent thread). Compiles aducsdk.c privately with ADUC_API_DEFAULT_FIFO_PATH and ADUC_DATA_FOLDER overridden to point under ADUC_TEST_DATA_FOLDER, so the tests run as a non-privileged user without /tmp dependence.

- apisvc_unit_tests.cpp gains a new SECTION "GetAduServiceStatus via SDK API" that exercises the public SDK ABI through the real apisvc. Previously the apisvc tests linked aduc::sdk only for the enum values and constructed the wire request manually, bypassing the SDK code path.

- Full suite: 706/706 pass (was 704).

Docs
- docs/agent-reference/GetAduServiceStatus.md
  * apt install pkgconfig -> pkg-config.
  * "nibbles on the wire" -> "bytes on the wire"; "double word" -> "16-bit value (uint16_t)".
  * Sequence diagram: replaced fictional "GET_STATE:/tmp/adu_status_12345" text with the real binary wire format and a real response-FIFO path.
  * State flow diagram: libaducsdk.so -> libaducsdk.a, req.fifo ->
    apireq.fifo (matches ADUC_API_DEFAULT_FIFO_PATH).
  * Pause-state guidance made consistent with the state diagram: Paused is the safe-to-power-down state; Idle is NOT, because the agent will accept new C2D deployments while in Idle.
  * Response-format section documents the new code-validation behavior.

- src/sdk/README.md
  * pkgconfig -> pkg-config / pkgconf.
  * Status-enum list extended with the missing V1.0 states (Applying, Cancelling, Failed).
  * Error-state list extended with the five missing codes (ReqFifoSvcEndNotOpenedYet, MkFifoFailed, ChmodFailed, SdkOpenRespFifoFailed, RecvMsgFailed).
  * Low-power guidance points at Paused only.

- src/sdk/README-Yocto-Integration.md
  * Typo fix: GetServiceStatus -> GetAduServiceStatus.
  * Recipe DEPENDS line standardized on "iot-hub-device-update" (matches the rest of the doc; no separate "aducsdk" recipe is published).
  * Sample power-management code powers down on Paused only.
  * Install-path examples use ${libdir}/${includedir} rather than hard-coded /usr/lib/usr/include.

Out of scope (latent, tracked for follow-up)
- Missing O_CLOEXEC on FIFO fds.
- mkfifo->fchmodat TOCTOU window.
- srand/rand thread-unsafety and weak nonce for the FIFO suffix.
- aducsdk-config.cmake template is not configured/installed yet.