### PR TITLE
docs: fix incorrect IdlePauseMilliseconds in x509 config example

### DIFF
--- a/docs/agent-reference/how-to-x509-authentication.md
+++ b/docs/agent-reference/how-to-x509-authentication.md
@@ -75,8 +75,7 @@ Configure the ADU agent to use X.509 authentication by updating your `du-config.
                 "connectionX509CaCertFilePath": "/etc/adu/certs/ca.pem"
             },
             "manufacturer": "Contoso",
-            "model": "Smart-Box",
-            "IdlePauseMilliseconds": "300000" 
+            "model": "Smart-Box"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Removes the incorrect `IdlePauseMilliseconds` field from the X.509 authentication example in `how-to-x509-authentication.md`.

## Issues Fixed

The field had three problems:
1. **Wrong casing** — `IdlePauseMilliseconds` vs the actual config key `idlePauseMilliseconds`
2. **Wrong type** — string `"300000"` vs expected unsigned int `300000`
3. **Wrong location** — placed inside the agent object, but it's a top-level config field

## Rationale

Removed entirely rather than correcting in-place because `idlePauseMilliseconds` is a top-level config field (not per-agent), and is already documented correctly in `configuration-guide.md`. Including it in the agent-level X.509 example would mislead users about where to place it.