### PR TITLE
Add regression tests for issue #765

### DIFF
--- a/src/extensions/extension_manager/tests/inc/extension_manager_download_test_case.hpp
+++ b/src/extensions/extension_manager/tests/inc/extension_manager_download_test_case.hpp
@@ -25,6 +25,12 @@ enum class DownloadTestScenario
     UnsupportedContractVersion,
     MissingDownloadProc,
     UnsupportedHashType,
+    // Regression coverage for issue #765: when a file already exists at the
+    // target download path but its hash does not match the manifest, the file
+    // must be removed and a real download must be attempted. The final result
+    // must reflect that download's outcome (never Success-without-download).
+    ExistingFileInvalidHashRedownload,
+    ExistingFileInvalidHashDownloadFails,
 };
 
 class ExtensionManagerDownloadTestCase
@@ -61,6 +67,11 @@ public:
     {
         return expected_result;
     }
+
+    // Accessors for issue #765 regression coverage: the number of times each
+    // mock download proc was invoked during the scenario.
+    int GetSuccessDownloadProcCallCount() const;
+    int GetFailureDownloadProcCallCount() const;
 
 private:
     void InitCommon();

--- a/src/extensions/extension_manager/tests/src/extension_manager_download_test_case.cpp
+++ b/src/extensions/extension_manager/tests/src/extension_manager_download_test_case.cpp
@@ -45,6 +45,12 @@ ADUC_ExtensionContractInfo mockContractInfo{ 1, 0 };
 const int32_t FailureERC = 0xD0070070;
 char mockTargetFilename[] = "mock_update_payload.txt";
 char mockPayloadContent[] = "hello";
+char mockCorruptedContent[] = "corrupted-bytes";
+
+// Counters used by issue #765 regression tests to verify that a real download
+// is attempted when a stale file with an invalid hash already exists.
+static int g_mockDownloadSuccessProcCallCount = 0;
+static int g_mockDownloadFailureProcCallCount = 0;
 
 const std::string testWorkfolder = std::string{ ADUC_TEST_DATA_FOLDER } + "/extension_manager";
 const std::string pnpMsgPath = testWorkfolder + "/pnpMsg.json";
@@ -66,6 +72,8 @@ static ADUC_Result MockDownloadSuccessProc(
     UNREFERENCED_PARAMETER(timeoutInSeconds);
     UNREFERENCED_PARAMETER(downloadProgressCallback);
 
+    ++g_mockDownloadSuccessProcCallCount;
+
     std::ofstream fileStream;
     fileStream.open(downloaded_file_path.c_str(), std::ios::out | std::ios::trunc);
     fileStream << mockPayloadContent;
@@ -86,6 +94,8 @@ static ADUC_Result MockDownloadFailureProc(
     UNREFERENCED_PARAMETER(workFolder);
     UNREFERENCED_PARAMETER(timeoutInSeconds);
     UNREFERENCED_PARAMETER(downloadProgressCallback);
+
+    ++g_mockDownloadFailureProcCallCount;
 
     ADUC_Result result{ 0, FailureERC };
     return result;
@@ -109,8 +119,14 @@ static DownloadProc nullDownloadProcResolver(void* lib)
     return nullptr;
 }
 
-static void setupWorkflowHandle(const char* msgJson, ADUC_WorkflowHandle* outWorkflowHandle)
+static void SeedCorruptedTargetFile()
 {
+    std::ofstream fileStream;
+    fileStream.open(downloaded_file_path.c_str(), std::ios::out | std::ios::trunc);
+    fileStream << mockCorruptedContent;
+}
+
+static void setupWorkflowHandle(const char* msgJson, ADUC_WorkflowHandle* outWorkflowHandle){
     ADUC_Result result{ workflow_init(msgJson, false /* validateManifest */, outWorkflowHandle) };
     REQUIRE(IsAducResultCodeSuccess(result.ResultCode));
 
@@ -125,6 +141,9 @@ static void setupWorkflowHandle(const char* msgJson, ADUC_WorkflowHandle* outWor
  */
 void ExtensionManagerDownloadTestCase::RunScenario()
 {
+    g_mockDownloadSuccessProcCallCount = 0;
+    g_mockDownloadFailureProcCallCount = 0;
+
     InitCommon();
 
     switch (download_scenario)
@@ -158,6 +177,25 @@ void ExtensionManagerDownloadTestCase::RunScenario()
         mockProcResolver = mockDownloadSuccessProcResolver;
         expected_result.ResultCode = ADUC_Result_Success;
         expected_result.ExtendedResultCode = ADUC_ERC_CONTENT_DOWNLOADER_FILE_HASH_TYPE_NOT_SUPPORTED;
+        break;
+
+    case DownloadTestScenario::ExistingFileInvalidHashRedownload:
+        // Pre-seed a stale file whose content hash will not match the manifest.
+        SeedCorruptedTargetFile();
+        mockProcResolver = mockDownloadSuccessProcResolver;
+        expected_result.ResultCode = 1;
+        expected_result.ExtendedResultCode = 0;
+        break;
+
+    case DownloadTestScenario::ExistingFileInvalidHashDownloadFails:
+        // Pre-seed a stale file whose content hash will not match the manifest.
+        // Issue #765: prior to the fix, the file would be removed and SUCCESS
+        // returned without calling the downloader at all. With the fix, the
+        // downloader is invoked and its (failing) result is propagated.
+        SeedCorruptedTargetFile();
+        mockProcResolver = mockDownloadFailureProcResolver;
+        expected_result.ResultCode = 0;
+        expected_result.ExtendedResultCode = FailureERC;
         break;
 
     default:
@@ -224,4 +262,14 @@ void ExtensionManagerDownloadTestCase::Cleanup()
 {
     remove(downloaded_file_path.c_str());
     workflow_free(workflowHandle);
+}
+
+int ExtensionManagerDownloadTestCase::GetSuccessDownloadProcCallCount() const
+{
+    return g_mockDownloadSuccessProcCallCount;
+}
+
+int ExtensionManagerDownloadTestCase::GetFailureDownloadProcCallCount() const
+{
+    return g_mockDownloadFailureProcCallCount;
 }

--- a/src/extensions/extension_manager/tests/src/extension_manager_ut.cpp
+++ b/src/extensions/extension_manager/tests/src/extension_manager_ut.cpp
@@ -90,6 +90,57 @@ TEST_CASE("ExtensionManager::Download failure should return failure ResultCode a
 }
 
 //
+// Regression tests for issue #765:
+// https://github.com/Azure/iot-hub-device-update/issues/765
+//
+// "Download function returns SUCCESS after deleting file it should have downloaded."
+//
+// When the target file already exists in the work folder but its hash does not
+// match the manifest, ExtensionManager::Download must:
+//   1) remove the stale file, AND
+//   2) actually attempt a fresh download, AND
+//   3) return a result that reflects that download's outcome.
+//
+// Prior to the fix in commit 9eff6612 (PR #856), the code returned ADUC_Result_Success
+// immediately after removing the stale file, without invoking the downloader.
+//
+
+TEST_CASE("ExtensionManager::Download redownloads when existing file has invalid hash (issue #765)")
+{
+    ExtensionManagerDownloadTestCase testCase{ DownloadTestScenario::ExistingFileInvalidHashRedownload };
+    REQUIRE_NOTHROW(testCase.RunScenario());
+
+    ADUC_Result actual_result = testCase.GetActualResult();
+    ADUC_Result expected_result = testCase.GetExpectedResult();
+
+    // The downloader MUST have been invoked exactly once. Before the fix this
+    // count would be 0, because Download returned Success after deleting the
+    // stale file without ever calling the downloader.
+    CHECK(testCase.GetSuccessDownloadProcCallCount() == 1);
+
+    CHECK(actual_result.ResultCode == expected_result.ResultCode);
+    CHECK(actual_result.ExtendedResultCode == expected_result.ExtendedResultCode);
+}
+
+TEST_CASE("ExtensionManager::Download must not return SUCCESS when stale file is deleted and redownload fails (issue #765)")
+{
+    ExtensionManagerDownloadTestCase testCase{ DownloadTestScenario::ExistingFileInvalidHashDownloadFails };
+    REQUIRE_NOTHROW(testCase.RunScenario());
+
+    ADUC_Result actual_result = testCase.GetActualResult();
+    ADUC_Result expected_result = testCase.GetExpectedResult();
+
+    // The downloader MUST have been invoked. Before the fix it was not called
+    // at all and the function erroneously returned Success.
+    CHECK(testCase.GetFailureDownloadProcCallCount() == 1);
+
+    // The result MUST reflect the (failed) download, not the stale-file removal.
+    CHECK(IsAducResultCodeFailure(actual_result.ResultCode));
+    CHECK(actual_result.ResultCode == expected_result.ResultCode);
+    CHECK(actual_result.ExtendedResultCode == expected_result.ExtendedResultCode);
+}
+
+//
 // V2 contract tests
 //
 


### PR DESCRIPTION
Adds two unit-test scenarios that exercise the case where the target download path already contains a file whose hash does not match the manifest:

  * ExistingFileInvalidHashRedownload — verifies that the stale file is removed and a fresh download is actually performed (mock downloader invocation count must be 1).
  * ExistingFileInvalidHashDownloadFails — verifies that when the redownload fails, ExtensionManager::Download propagates the failure rather than returning Success after deleting the stale file.

Both tests pass on the current code (after PR #856) and fail on the pre-fix code in the manner described by issue #765 (Success returned without invoking the downloader, file silently deleted).