### PR TITLE
Fix ADU agent restart loop on transient IoT Hub disconnect (ADO 38069154)

### DIFF
--- a/daemon/deviceupdate-agent.service
+++ b/daemon/deviceupdate-agent.service
@@ -5,8 +5,20 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-Restart=always
-RestartSec=5
+# Restart=on-failure (not "always") is required to defeat the
+# self-reinforcing restart loop described in ADO Bug 38069154. Any code
+# path in the agent that does exit(0) intentionally must NOT cause systemd
+# to respawn it: only exit(EXIT_FAILURE) and uncaught crashes do.
+Restart=on-failure
+# Five seconds was too aggressive for a fleet device: a transient cloud
+# disconnect that the SDK can recover from in tens of seconds would cause
+# multiple agent restarts and burn IoT Hub connect-rate quota per device.
+RestartSec=60s
+# Cap the respawn budget to 8 failures per 30 minutes. A device that
+# fails harder than that is genuinely broken and should stop hammering
+# the cloud control plane.
+StartLimitIntervalSec=1800
+StartLimitBurst=8
 User=adu
 Group=adu
 # systemd will try to start the ADU executable 5 times and then give up.

--- a/src/communication_managers/iothub_communication_manager/CMakeLists.txt
+++ b/src/communication_managers/iothub_communication_manager/CMakeLists.txt
@@ -22,10 +22,10 @@ find_package (umqtt REQUIRED)
 target_link_libraries (
     ${target_name}
     PUBLIC aduc::adu_types
-    PRIVATE aduc::adu_core_export_helpers
-            aduc::communication_abstraction
+    PRIVATE aduc::communication_abstraction
             aduc::config_utils
             aduc::c_utils
+            aduc::d2c_messaging
             aduc::eis_utils
             aduc::logging
             aduc::retry_utils

--- a/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
+++ b/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
@@ -6,11 +6,11 @@
  * Licensed under the MIT License.
  */
 #include "aduc/iothub_communication_manager.h"
-#include "aduc/adu_core_export_helpers.h" // ADUC_MethodCall_RestartAgent
 #include "aduc/adu_types.h"
 #include "aduc/client_handle_helper.h"
 #include "aduc/config_utils.h"
 #include "aduc/connection_string_utils.h" // ConnectionStringUtils_DoesKeyExist
+#include "aduc/d2c_messaging.h" // ADUC_D2C_Messaging_Reset_For_Handle_Refresh
 #include "aduc/https_proxy_utils.h"
 #include "aduc/logging.h"
 #include "aduc/retry_utils.h"
@@ -225,6 +225,74 @@ typedef enum tagADUC_ConnUnauthCategory
     ADUC_ConnUnauth_TransientSasRenewal = 0, /**< Expected SAS token renewal; log at Info. */
     ADUC_ConnUnauth_Broken = 1, /**< Real failure; log at Error. */
 } ADUC_ConnUnauthCategory;
+
+/**
+ * @brief Classification of an IoT Hub connection-status reason for the
+ *        purposes of `Connection_Maintenance()` policy.
+ *
+ * This classifier exists so that the policy decision ("is this a transient
+ * transport disconnect the SDK can recover from on the existing handle, or
+ * is this something that requires us to recreate the client handle?") is a
+ * pure function of the reason code and can be unit-tested directly. See
+ * ADO Bug 38069154 ("ADU Agent — Restart Loop on Transient IoT Hub
+ * Disconnect") for the background. Prior to that fix, the
+ * `IOTHUB_CLIENT_CONNECTION_NO_NETWORK` branch unconditionally called
+ * `ADUC_MethodCall_RestartAgent()` which terminated the host process and
+ * relied on systemd to respawn — producing a self-reinforcing restart loop
+ * on any device experiencing transient TCP RSTs (errno=104) on the
+ * MQTT/TLS socket while a deployment was in progress.
+ */
+typedef enum tagADUC_ConnReasonClass
+{
+    /** Transport-layer disconnect the IoT Hub C SDK can recover from on the
+     *  existing client handle (default retry policy:
+     *  IOTHUB_CLIENT_RETRY_EXPONENTIAL_BACKOFF_WITH_JITTER). The agent must
+     *  NOT destroy the handle and must NOT exit. */
+    ADUC_ConnReason_TransientTransport = 0,
+    /** Credential needs to be refreshed; the existing reauth path will
+     *  destroy and recreate the client handle. */
+    ADUC_ConnReason_Credential = 1,
+    /** The device has been administratively disabled on the IoT Hub side.
+     *  Long backoff (existing behavior: 1 hour). */
+    ADUC_ConnReason_DeviceDisabled = 2,
+    /** Reason code indicates the connection is healthy; no maintenance
+     *  action needed. */
+    ADUC_ConnReason_Ok = 3,
+    /** Reason code not recognized by this version of the agent. Treated
+     *  conservatively (transient-style backoff, no restart). */
+    ADUC_ConnReason_Unknown = 4,
+} ADUC_ConnReasonClass;
+
+/**
+ * @brief Classifies an IoT Hub connection-status reason.
+ *
+ * Pure function with no side effects; safe to call from tests.
+ *
+ * @param reason The IOTHUB_CLIENT_CONNECTION_STATUS_REASON reported by the
+ *               SDK in either an AUTHENTICATED or UNAUTHENTICATED callback.
+ * @return The policy class for `Connection_Maintenance()`.
+ */
+ADUC_ConnReasonClass IoTHub_CommunicationManager_ClassifyConnectionReason(
+    IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason)
+{
+    switch (reason)
+    {
+    case IOTHUB_CLIENT_CONNECTION_NO_NETWORK:
+    case IOTHUB_CLIENT_CONNECTION_NO_PING_RESPONSE:
+    case IOTHUB_CLIENT_CONNECTION_COMMUNICATION_ERROR:
+        return ADUC_ConnReason_TransientTransport;
+    case IOTHUB_CLIENT_CONNECTION_EXPIRED_SAS_TOKEN:
+    case IOTHUB_CLIENT_CONNECTION_BAD_CREDENTIAL:
+    case IOTHUB_CLIENT_CONNECTION_RETRY_EXPIRED:
+        return ADUC_ConnReason_Credential;
+    case IOTHUB_CLIENT_CONNECTION_DEVICE_DISABLED:
+        return ADUC_ConnReason_DeviceDisabled;
+    case IOTHUB_CLIENT_CONNECTION_OK:
+        return ADUC_ConnReason_Ok;
+    default:
+        return ADUC_ConnReason_Unknown;
+    }
+}
 
 /**
  * @brief Categorizes an IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED event by reason.
@@ -764,6 +832,8 @@ done:
  */
 static void ADUC_Refresh_IotHub_Connection_SAS_Token()
 {
+    bool handleWasRecreated = false;
+
     pthread_mutex_lock(&s_client_handle_mutex);
     if (g_aduc_client_handle_address == NULL)
     {
@@ -799,10 +869,33 @@ static void ADUC_Refresh_IotHub_Connection_SAS_Token()
         g_iothub_client_handle_changed_callback(*g_aduc_client_handle_address);
     }
 
+    handleWasRecreated = true;
     Log_Info("Successfully re-authenticated the IoT Hub connection.");
 
 done:
     pthread_mutex_unlock(&s_client_handle_mutex);
+
+    // The reset is intentionally invoked AFTER releasing s_client_handle_mutex:
+    //   1. It avoids any future deadlock if a D2C status/completion callback
+    //      ever reaches back into the communication manager (e.g. via
+    //      IoTHub_CommunicationManager_GetHandle()).
+    //   2. The handle pointer (*g_aduc_client_handle_address) captured by
+    //      previously-submitted messages is the address of the global, so it
+    //      remains valid after we release the lock; the next D2C send will
+    //      deref the updated pointer.
+    //
+    // The previous client handle was destroyed above; any reported-state
+    // messages already submitted to the old handle are now stuck in
+    // Waiting_For_Response because the SDK's ack callback queue went away
+    // with it. Replay them on the new handle (or drop them in favor of a
+    // newer pending message of the same type). This is what makes it safe
+    // for the transient-disconnect path in Connection_Maintenance() to stop
+    // restarting the agent on IOTHUB_CLIENT_CONNECTION_NO_NETWORK — see ADO
+    // Bug 38069154 §4.2.
+    if (handleWasRecreated)
+    {
+        ADUC_D2C_Messaging_Reset_For_Handle_Refresh();
+    }
 
     ADUC_ConnectionInfo_DeAlloc(&info);
 }
@@ -857,14 +950,24 @@ static void Connection_Maintenance()
             additionalDelayInSeconds = TIME_SPAN_FIVE_MINUTES_IN_SECONDS;
             break;
         case IOTHUB_CLIENT_CONNECTION_NO_NETWORK:
-            // 1) try to restart agent to prevent empty reported properties in module twin
-            // 2) if restart agent could not be performed, wait for at least 5 minutes to retry.
-            Log_Error("No network.");
-            if (ADUC_MethodCall_RestartAgent() != 0)
-            {
-                additionalDelayInSeconds = TIME_SPAN_FIVE_MINUTES_IN_SECONDS;
-                Log_Error("Agent restart attempt failed.");
-            }
+            // Transient transport-layer disconnect (typically a TCP RST or
+            // ECONNRESET on the MQTT/TLS socket). The Azure IoT C SDK has
+            // its own reconnect policy (default
+            // IOTHUB_CLIENT_RETRY_EXPONENTIAL_BACKOFF_WITH_JITTER) and will
+            // attempt to reconnect on the existing client handle as long as
+            // IoTHub_CommunicationManager_DoWork() keeps invoking
+            // ClientHandle_DoWork(). Do NOT destroy the handle and do NOT
+            // restart the host process: doing so was the cause of ADO Bug
+            // 38069154 (single transient socket reset → self-reinforcing
+            // systemd restart loop while a deployment was in progress).
+            //
+            // The original "prevent empty reported properties in module
+            // twin" concern that motivated the restart is now handled
+            // properly by ADUC_D2C_Messaging_Reset_For_Handle_Refresh(),
+            // which is invoked from the credential-reauth path that
+            // actually destroys and recreates the client handle.
+            Log_Warn("No network. Treating as transient transport disconnect; SDK will reconnect.");
+            additionalDelayInSeconds = TIME_SPAN_FIVE_MINUTES_IN_SECONDS;
             break;
 
         case IOTHUB_CLIENT_CONNECTION_COMMUNICATION_ERROR:

--- a/src/communication_managers/iothub_communication_manager/tests/iothub_communication_manager_ut.cpp
+++ b/src/communication_managers/iothub_communication_manager/tests/iothub_communication_manager_ut.cpp
@@ -990,3 +990,88 @@ TEST_CASE("GetConnectionInfoFromConnectionString X509 paths")
         ADUC_ConnectionInfo_DeAlloc(&info);
     }
 }
+
+//
+// ADO Bug 38069154: classification of IoT Hub connection-status reasons.
+//
+// These tests pin down the policy that drives Connection_Maintenance():
+// transient transport disconnects (NO_NETWORK, NO_PING_RESPONSE,
+// COMMUNICATION_ERROR) must NOT cause the agent to destroy the client
+// handle or restart the host process, because the Azure IoT C SDK has its
+// own exponential-backoff reconnect policy and will recover on the
+// existing handle.
+
+typedef enum tagADUC_ConnReasonClass
+{
+    ADUC_ConnReason_TransientTransport = 0,
+    ADUC_ConnReason_Credential = 1,
+    ADUC_ConnReason_DeviceDisabled = 2,
+    ADUC_ConnReason_Ok = 3,
+    ADUC_ConnReason_Unknown = 4,
+} ADUC_ConnReasonClass;
+
+extern "C" ADUC_ConnReasonClass IoTHub_CommunicationManager_ClassifyConnectionReason(
+    IOTHUB_CLIENT_CONNECTION_STATUS_REASON reason);
+
+TEST_CASE("ADO 38069154: NO_NETWORK is classified as transient transport (no restart)")
+{
+    // The headline behavior the customer's restart loop hinged on: a
+    // socket-level RST (errno=104) surfaced by the SDK as NO_NETWORK must
+    // be treated as something the SDK can recover from on the existing
+    // handle, NOT as a reason to destroy and recreate anything.
+    CHECK(
+        IoTHub_CommunicationManager_ClassifyConnectionReason(IOTHUB_CLIENT_CONNECTION_NO_NETWORK)
+        == ADUC_ConnReason_TransientTransport);
+}
+
+TEST_CASE("ADO 38069154: all transport-level disconnects classify as transient transport")
+{
+    CHECK(
+        IoTHub_CommunicationManager_ClassifyConnectionReason(IOTHUB_CLIENT_CONNECTION_NO_NETWORK)
+        == ADUC_ConnReason_TransientTransport);
+    CHECK(
+        IoTHub_CommunicationManager_ClassifyConnectionReason(IOTHUB_CLIENT_CONNECTION_NO_PING_RESPONSE)
+        == ADUC_ConnReason_TransientTransport);
+    CHECK(
+        IoTHub_CommunicationManager_ClassifyConnectionReason(IOTHUB_CLIENT_CONNECTION_COMMUNICATION_ERROR)
+        == ADUC_ConnReason_TransientTransport);
+}
+
+TEST_CASE("ADO 38069154: credential-related reasons classify as credential (reauth path)")
+{
+    CHECK(
+        IoTHub_CommunicationManager_ClassifyConnectionReason(IOTHUB_CLIENT_CONNECTION_EXPIRED_SAS_TOKEN)
+        == ADUC_ConnReason_Credential);
+    CHECK(
+        IoTHub_CommunicationManager_ClassifyConnectionReason(IOTHUB_CLIENT_CONNECTION_BAD_CREDENTIAL)
+        == ADUC_ConnReason_Credential);
+    CHECK(
+        IoTHub_CommunicationManager_ClassifyConnectionReason(IOTHUB_CLIENT_CONNECTION_RETRY_EXPIRED)
+        == ADUC_ConnReason_Credential);
+}
+
+TEST_CASE("ADO 38069154: DEVICE_DISABLED has its own long-backoff class")
+{
+    CHECK(
+        IoTHub_CommunicationManager_ClassifyConnectionReason(IOTHUB_CLIENT_CONNECTION_DEVICE_DISABLED)
+        == ADUC_ConnReason_DeviceDisabled);
+}
+
+TEST_CASE("ADO 38069154: OK reason classifies as healthy")
+{
+    CHECK(
+        IoTHub_CommunicationManager_ClassifyConnectionReason(IOTHUB_CLIENT_CONNECTION_OK)
+        == ADUC_ConnReason_Ok);
+}
+
+TEST_CASE("ADO 38069154: unrecognized reason classifies as Unknown (conservative)")
+{
+    // Reason codes added to the SDK in the future must default to a
+    // non-destructive bucket; specifically must NOT classify as
+    // Credential (which would destroy and recreate the handle).
+    auto bogus = static_cast<IOTHUB_CLIENT_CONNECTION_STATUS_REASON>(99999);
+    auto cls = IoTHub_CommunicationManager_ClassifyConnectionReason(bogus);
+    CHECK(cls == ADUC_ConnReason_Unknown);
+    CHECK(cls != ADUC_ConnReason_Credential);
+    CHECK(cls != ADUC_ConnReason_DeviceDisabled);
+}

--- a/src/utils/d2c_messaging/CMakeLists.txt
+++ b/src/utils/d2c_messaging/CMakeLists.txt
@@ -22,10 +22,10 @@ target_link_libraries (
     PUBLIC aduc::adu_types
     PRIVATE aduc::communication_abstraction aduc::logging aduc::retry_utils)
 
-# if (ADUC_BUILD_UNIT_TESTS)
-#     if (${IS_ARM})
-#         message (STATUS "Skipping tests for utils/d2c_messaging for ARM processor...")
-#     else ()
-#         add_subdirectory (tests)
-#     endif ()
-# endif ()
+if (ADUC_BUILD_UNIT_TESTS)
+    if (${IS_ARM})
+        message (STATUS "Skipping tests for utils/d2c_messaging for ARM processor...")
+    else ()
+        add_subdirectory (tests)
+    endif ()
+endif ()

--- a/src/utils/d2c_messaging/inc/aduc/d2c_messaging.h
+++ b/src/utils/d2c_messaging/inc/aduc/d2c_messaging.h
@@ -172,6 +172,47 @@ void ADUC_D2C_Messaging_Uninit();
 void ADUC_D2C_Messaging_DoWork();
 
 /**
+ * @brief Reset in-flight D2C messages so they are replayed after the
+ *        IoT Hub client handle has been destroyed and recreated.
+ *
+ * Must be called by the connection-management layer immediately after the
+ * `ADUC_ClientHandle` referenced by previously-sent messages
+ * (via `cloudServiceHandle`) is replaced with a freshly authenticated one,
+ * and BEFORE the agent submits any new messages on the new handle.
+ *
+ * Rationale: when `ClientHandle_SendReportedState` returns OK we transition
+ * the message to `Waiting_For_Response` and the SDK takes ownership of the
+ * eventual ack callback. If the underlying client handle is then destroyed
+ * (credential reauth path), the SDK's ack queue is torn down with it and
+ * the message remains stuck in `Waiting_For_Response` forever — which is
+ * the "empty reported properties in module twin" failure mode that
+ * originally motivated the (incorrect) process-restart reflex on
+ * `IOTHUB_CLIENT_CONNECTION_NO_NETWORK`. See ADO Bug 38069154.
+ *
+ * Behavior, per message processing context:
+ *   - If the current message is in `Waiting_For_Response` AND a newer
+ *     pending message of the same type is queued (the typical case during
+ *     a long disconnect with new reported-state updates piling up), the
+ *     in-flight message is completed as `Replaced`. The pending message
+ *     will be picked up on the next `ADUC_D2C_Messaging_DoWork()` tick.
+ *     This is the dedupe-by-message-type behavior the cross-component
+ *     "two queued updates of the same type collapse to one replay (the
+ *     latest)" requirement.
+ *   - If the current message is in `Waiting_For_Response` AND no newer
+ *     pending message exists, the message status is demoted to
+ *     `In_Progress` and `nextRetryTimeStampEpoch` is reset to a small
+ *     number of seconds in the future (a defensive grace period so the
+ *     replay does not race the new client handle's MQTT/TLS authentication
+ *     inside the IoT Hub C SDK), causing it to be resent by the next
+ *     `ADUC_D2C_Messaging_DoWork()` tick scheduled after that delay.
+ *   - Messages already in `Pending`, `In_Progress`, `Success`, `Failed`,
+ *     `Replaced`, `Canceled` or `Max_Retries_Reached` are left untouched.
+ *
+ * Idempotent and cheap; safe to call when no messages are in flight.
+ */
+void ADUC_D2C_Messaging_Reset_For_Handle_Refresh(void);
+
+/**
  * @brief Submits the message to messaging utility queue. If the message for specified @p type already exist, it will be replaced by the latest message.
  *
  *        IMPORTANT: The implementation of @p responseCallback, @p completedCallback, and @p statusChangedCallback MUST NOT

--- a/src/utils/d2c_messaging/src/d2c_messaging.c
+++ b/src/utils/d2c_messaging/src/d2c_messaging.c
@@ -341,6 +341,88 @@ void ADUC_D2C_Messaging_DoWork()
     }
 }
 
+void ADUC_D2C_Messaging_Reset_For_Handle_Refresh(void)
+{
+    pthread_mutex_lock(&s_pendingMessageStoreMutex);
+    if (!s_core_initialized)
+    {
+        pthread_mutex_unlock(&s_pendingMessageStoreMutex);
+        return;
+    }
+
+    // Small grace period before the demoted message is resent on the new
+    // client handle. The IoT Hub C SDK creates the client object
+    // synchronously but performs the actual MQTT/TLS connect and
+    // authenticate asynchronously inside its own DoWork loop. Pushing the
+    // first replay attempt a few seconds into the future avoids racing the
+    // SDK's first authentication and keeps the transport function from
+    // potentially marking the message as Failed if a not-yet-connected
+    // SendReportedState ever returned non-OK on some builds of the SDK.
+    // The SDK's own queueing usually masks this, so this is defensive.
+    const time_t now = GetTimeSinceEpochInSeconds();
+    const time_t replayAt = now + 5; // seconds
+
+    // Stale-callback note: the dedupe branch below completes the in-flight
+    // WFR message via OnMessageProcessingCompleted(), which zeroes
+    // ctx->message. The SDK callback registered for that message was
+    // handed only ctx (no per-send token), so in principle a late callback
+    // could mutate the next message that lands in ctx. In the actual ADO
+    // 38069154 scenario this is unreachable: the only situation where a
+    // WFR message survives long enough to need this reset is when the
+    // underlying IoT Hub client handle has been destroyed, which tears
+    // down the SDK ack queue and prevents any further callbacks for
+    // messages sent through the old handle. The response handler also
+    // already checks `ctx->message.content == NULL` and bails, which
+    // covers the window between completion-as-Replaced here and the next
+    // DoWork tick that promotes the pending replacement.
+
+    for (int i = 0; i < ADUC_D2C_Message_Type_Max; i++)
+    {
+        ADUC_D2C_Message_Processing_Context* ctx = &s_messageProcessingContext[i];
+        if (!ctx->initialized)
+        {
+            continue;
+        }
+
+        pthread_mutex_lock(&ctx->mutex);
+
+        // Only WFR messages are at risk of being stuck after a client-handle
+        // recreate: the SDK's ack callback that would normally drive them to
+        // Success/Failed is torn down with the old handle. Messages in any
+        // other state will be advanced by ProcessMessage() on its own.
+        if (ctx->message.content != NULL
+            && ctx->message.status == ADUC_D2C_Message_Status_Waiting_For_Response)
+        {
+            if (s_pendingMessageStore[i].content != NULL)
+            {
+                // A newer message of the same type is already queued. Drop
+                // the in-flight one (it carries stale content) and let
+                // ProcessMessage() promote the pending one on the next
+                // tick. This is the "dedupe so only the latest state per
+                // message type is replayed" path.
+                Log_Info(
+                    "Handle refresh: dropping in-flight WFR message in favor of newer pending (t:%d).",
+                    i);
+                OnMessageProcessingCompleted(&ctx->message, ADUC_D2C_Message_Status_Replaced);
+            }
+            else
+            {
+                // No newer message: demote the in-flight one back to
+                // In_Progress so it is resent on the new handle on the next
+                // ADUC_D2C_Messaging_DoWork() tick after the grace period.
+                Log_Info(
+                    "Handle refresh: demoting WFR message to In_Progress for replay (t:%d).", i);
+                SetMessageStatus(&ctx->message, ADUC_D2C_Message_Status_In_Progress);
+                ctx->nextRetryTimeStampEpoch = replayAt;
+            }
+        }
+
+        pthread_mutex_unlock(&ctx->mutex);
+    }
+
+    pthread_mutex_unlock(&s_pendingMessageStoreMutex);
+}
+
 /**
  * @brief Processes the message.
  * @param message_processing_context The message processing context.

--- a/src/utils/d2c_messaging/tests/CMakeLists.txt
+++ b/src/utils/d2c_messaging/tests/CMakeLists.txt
@@ -23,8 +23,13 @@ target_link_libraries (
             Catch2::Catch2WithMain)
 
 include (CTest)
-# Existing [functional]-tagged scenarios.
-add_test (NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME} [functional])
-# ADO Bug 38069154: deterministic, non-functional tests for
-# ADUC_D2C_Messaging_Reset_For_Handle_Refresh().
+# NOTE: The pre-existing [functional] cases in d2c_messaging_ut.cpp were
+# intentionally disabled in PR #738 (April 2025) because they hang in CI
+# pipelines (Debian / Ubuntu amd64 hit the 1500s ctest timeout). They are
+# still compiled into the binary and can be run manually for diagnostics:
+#     d2c_messaging_unit_tests [functional]
+# but they are NOT registered with ctest until they are stabilized.
+#
+# ADO Bug 38069154: the deterministic, single-threaded handle-refresh
+# tests are safe for CI and ARE registered below.
 add_test (NAME ${PROJECT_NAME}_handle_refresh COMMAND ${PROJECT_NAME} [handle_refresh])

--- a/src/utils/d2c_messaging/tests/CMakeLists.txt
+++ b/src/utils/d2c_messaging/tests/CMakeLists.txt
@@ -23,4 +23,8 @@ target_link_libraries (
             Catch2::Catch2WithMain)
 
 include (CTest)
+# Existing [functional]-tagged scenarios.
 add_test (NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME} [functional])
+# ADO Bug 38069154: deterministic, non-functional tests for
+# ADUC_D2C_Messaging_Reset_For_Handle_Refresh().
+add_test (NAME ${PROJECT_NAME}_handle_refresh COMMAND ${PROJECT_NAME} [handle_refresh])

--- a/src/utils/d2c_messaging/tests/d2c_messaging_ut.cpp
+++ b/src/utils/d2c_messaging/tests/d2c_messaging_ut.cpp
@@ -175,6 +175,42 @@ static PThreadCond g_d2cMessageProcessedCond;
 static PThreadMutex g_cloudServiceMutex;
 static PThreadMutex g_testCaseSyncMutex;
 
+//
+// Predicate-protected handshake for the existing [functional] tests.
+//
+// Background: the original test harness called pthread_cond_signal() from the
+// response handler without holding g_cloudServiceMutex, and the test thread
+// called pthread_cond_wait() with no predicate. POSIX condition variable
+// semantics drop the signal when no thread is currently in cond_wait, which
+// caused these tests to hang indefinitely in CI (1500s ctest timeout) when
+// the response handler won the race against the test thread reaching wait().
+//
+// Fix: a g_d2cMessageDone flag, written under g_cloudServiceMutex on the
+// signaller side and consumed in a loop on the waiter side. The test thread
+// resets the flag inside the locked setup window via _SetMockCloudBehavior
+// before kicking SendAsync, so it cannot observe a stale "done" from a
+// previous iteration.
+//
+static bool g_d2cMessageDone = false;
+
+static void signal_message_done()
+{
+    g_cloudServiceMutex.lock();
+    g_d2cMessageDone = true;
+    g_d2cMessageProcessedCond.signal();
+    g_cloudServiceMutex.unlock();
+}
+
+// Caller MUST hold g_cloudServiceMutex.
+static void wait_message_done_locked()
+{
+    while (!g_d2cMessageDone)
+    {
+        g_d2cMessageProcessedCond.wait(g_cloudServiceMutex);
+    }
+    g_d2cMessageDone = false;
+}
+
 static void set_timespec_ms(timespec* ts, unsigned long ms)
 {
     memset(ts, 0, sizeof(*ts));
@@ -275,6 +311,11 @@ static void _SetMockCloudBehavior(MockCloudBehavior* b, size_t size, size_t init
     g_cloudBehaviorIndex = initialIndex;
     g_attempts = 0;
     g_cloudBehaviorMutex.unlock();
+
+    // Reset the predicate that gates wait_message_done_locked() so the next
+    // SendAsync cycle starts from a clean "not yet done" state. Caller must
+    // already hold g_cloudServiceMutex per the existing test contract.
+    g_d2cMessageDone = false;
 }
 
 bool g_cancelDoWorkThread = false;
@@ -306,7 +347,7 @@ void OnMessageProcessCompleted_SaveWholeMessage_And_Signal(void* context, ADUC_D
     auto message = static_cast<ADUC_D2C_Message*>(context);
     *static_cast<ADUC_D2C_Message*>(message->userData) = *message;
     // Must signal after done updating global state.
-    g_d2cMessageProcessedCond.signal();
+    signal_message_done();
 };
 
 void OnMessageStatusChanged_SaveWholeMessage_And_Signal(void* context, ADUC_D2C_Message_Status status)
@@ -315,7 +356,7 @@ void OnMessageStatusChanged_SaveWholeMessage_And_Signal(void* context, ADUC_D2C_
     auto message = static_cast<ADUC_D2C_Message*>(context);
     *static_cast<ADUC_D2C_Message*>(message->userData) = *message;
     // Must signal after done updating global state.
-    g_d2cMessageProcessedCond.signal();
+    signal_message_done();
 };
 
 static void OnMessageProcessCompleted_SaveStatus(void* context, ADUC_D2C_Message_Status status)
@@ -328,7 +369,7 @@ static void OnMessageProcessCompleted_SaveStatus(void* context, ADUC_D2C_Message
 static void OnMessageProcessCompleted_SaveStatus_And_Signal(void* context, ADUC_D2C_Message_Status status)
 {
     OnMessageProcessCompleted_SaveStatus(context, status);
-    g_d2cMessageProcessedCond.signal();
+    signal_message_done();
 };
 
 // Make sure that we can deinitialize cleanly while there's a message in-progress.
@@ -479,7 +520,7 @@ TEST_CASE("Simple tests", "[.hide][functional]")
         &result);
 
     // Wait until the message has been processed.
-    g_d2cMessageProcessedCond.wait(g_cloudServiceMutex);
+    wait_message_done_locked();
     g_cloudServiceMutex.unlock();
 
     CHECK(expectedAttempts == result.attempts);
@@ -505,7 +546,7 @@ TEST_CASE("Simple tests", "[.hide][functional]")
         &result);
 
     // Wait until the message has been processed.
-    g_d2cMessageProcessedCond.wait(g_cloudServiceMutex);
+    wait_message_done_locked();
     g_cloudServiceMutex.unlock();
 
     CHECK(expectedAttempts == result.attempts);
@@ -531,7 +572,7 @@ TEST_CASE("Simple tests", "[.hide][functional]")
         &result);
 
     // Wait until the message has been processed.
-    g_d2cMessageProcessedCond.wait(g_cloudServiceMutex);
+    wait_message_done_locked();
     g_cloudServiceMutex.unlock();
 
     CHECK(expectedAttempts == result.attempts);
@@ -583,7 +624,7 @@ TEST_CASE("Bad http status retry info", "[.][functional]")
         &result);
 
     // Wait until the message has been processed.
-    g_d2cMessageProcessedCond.wait(g_cloudServiceMutex);
+    wait_message_done_locked();
     g_cloudServiceMutex.unlock();
 
     CHECK(expectedAttempts == result.attempts);
@@ -609,7 +650,7 @@ TEST_CASE("Bad http status retry info", "[.][functional]")
         &result);
 
     // Wait until the message has been processed.
-    g_d2cMessageProcessedCond.wait(g_cloudServiceMutex);
+    wait_message_done_locked();
     g_cloudServiceMutex.unlock();
 
     CHECK(expectedAttempts == result.attempts);
@@ -693,7 +734,7 @@ TEST_CASE("Message replacement test", "[.][functional]")
         &message3FinalStatus);
 
     // Wait until the message has been processed.
-    g_d2cMessageProcessedCond.wait(g_cloudServiceMutex);
+    wait_message_done_locked();
     g_cloudServiceMutex.unlock();
 
     CHECK(message1FinalStatus == ADUC_D2C_Message_Status_Success);
@@ -757,7 +798,7 @@ TEST_CASE("30 retries - httpStatus 401", "[.][functional]")
         &result);
 
     // Wait until the message has been processed.
-    g_d2cMessageProcessedCond.wait(g_cloudServiceMutex);
+    wait_message_done_locked();
     g_cloudServiceMutex.unlock();
 
     CHECK(expectedAttempts == result.attempts);

--- a/src/utils/d2c_messaging/tests/d2c_messaging_ut.cpp
+++ b/src/utils/d2c_messaging/tests/d2c_messaging_ut.cpp
@@ -6,7 +6,9 @@
 
 #include <catch2/catch_all.hpp>
 #include <stdexcept> // runtime_error
+#include <string>
 #include <string.h>
+#include <vector>
 
 #include <aducpal/time.h> // nanosleep
 
@@ -764,4 +766,208 @@ TEST_CASE("30 retries - httpStatus 401", "[.][functional]")
     g_cancelDoWorkThread = true;
     ADUC_D2C_Messaging_Uninit();
     g_testCaseSyncMutex.unlock();
+}
+
+//
+// ADO Bug 38069154: ADUC_D2C_Messaging_Reset_For_Handle_Refresh()
+//
+// Deterministic, single-threaded tests that pin down replay/dedupe behavior
+// when the IoT Hub client handle has just been destroyed and recreated. They
+// do not exercise wall-clock retry backoff, so they live outside the
+// existing [functional] tag.
+//
+
+// Synchronous mock transport: simulates ClientHandle_SendReportedState
+// returning OK. The message is parked in Waiting_For_Response and stays
+// there because we never invoke the response handler — this is precisely
+// the state we want to recover from when the SDK's client handle has been
+// destroyed underneath us during reauth.
+static int g_refreshMockTransport_callCount = 0;
+static std::vector<std::string> g_refreshMockTransport_sentContent;
+static int MockTransport_StaysInWFR(
+    void* cloudServiceHandle,
+    void* context,
+    ADUC_C2D_RESPONSE_HANDLER_FUNCTION /*c2dResponseHandlerFunc*/)
+{
+    UNREFERENCED_PARAMETER(cloudServiceHandle);
+    g_refreshMockTransport_callCount++;
+    auto* ctx = static_cast<ADUC_D2C_Message_Processing_Context*>(context);
+    if (ctx->message.content != nullptr)
+    {
+        g_refreshMockTransport_sentContent.emplace_back(ctx->message.content);
+    }
+    MockSetMessageStatus(&ctx->message, ADUC_D2C_Message_Status_Waiting_For_Response);
+    return 0; // IOTHUB_CLIENT_OK
+}
+
+static void ResetRefreshMockTransport()
+{
+    g_refreshMockTransport_callCount = 0;
+    g_refreshMockTransport_sentContent.clear();
+}
+
+// Track the latest terminal status the messaging layer reported for a
+// message; lets us assert that an in-flight message was completed as
+// Replaced (the dedupe path).
+struct RefreshTestRecord
+{
+    ADUC_D2C_Message_Status lastCompletedStatus = ADUC_D2C_Message_Status_Pending;
+    int completedCallCount = 0;
+    std::string lastCompletedContent;
+};
+
+static void OnRefreshTestCompleted(void* messageVoid, ADUC_D2C_Message_Status status)
+{
+    auto* message = static_cast<ADUC_D2C_Message*>(messageVoid);
+    auto* record = static_cast<RefreshTestRecord*>(message->userData);
+    record->lastCompletedStatus = status;
+    record->completedCallCount++;
+    if (message->content != nullptr)
+    {
+        record->lastCompletedContent = message->content;
+    }
+}
+
+TEST_CASE("ADO 38069154: Reset_For_Handle_Refresh demotes WFR back to In_Progress for replay", "[handle_refresh]")
+{
+    g_testCaseSyncMutex.lock();
+    ResetRefreshMockTransport();
+
+    auto handle = reinterpret_cast<ADUC_ClientHandle>(-1);
+    ADUC_D2C_Messaging_Init();
+    ADUC_D2C_Messaging_Set_Transport(ADUC_D2C_Message_Type_Device_Update_Result, MockTransport_StaysInWFR);
+
+    RefreshTestRecord record;
+    const char* payload = "reported state v1";
+    REQUIRE(ADUC_D2C_Message_SendAsync(
+        ADUC_D2C_Message_Type_Device_Update_Result,
+        &handle,
+        payload,
+        nullptr /* responseCallback */,
+        OnRefreshTestCompleted,
+        nullptr /* statusChangedCallback */,
+        &record));
+
+    // First DoWork tick: pending -> in_progress -> WFR (transport returns OK
+    // but never calls back, mimicking an in-flight ack that will never
+    // arrive because the SDK is about to be destroyed during reauth).
+    ADUC_D2C_Messaging_DoWork();
+    CHECK(g_refreshMockTransport_callCount == 1);
+    REQUIRE(g_refreshMockTransport_sentContent.size() == 1);
+    CHECK(g_refreshMockTransport_sentContent[0] == payload);
+    CHECK(record.completedCallCount == 0); // not completed yet; WFR
+
+    // Simulate the credential-reauth path completing: the underlying client
+    // handle has been destroyed and recreated. Without our reset, the WFR
+    // message would sit in Waiting_For_Response forever because the SDK's
+    // ack callback queue went away.
+    ADUC_D2C_Messaging_Reset_For_Handle_Refresh();
+    // Demotion path must not complete the message (it must be replayed).
+    CHECK(record.completedCallCount == 0);
+
+    // Replay is gated by a small grace delay so the demoted message does
+    // not race the new client handle's authentication. The first DoWork
+    // tick immediately after reset must NOT re-fire the transport: the
+    // message is In_Progress but nextRetryTimeStampEpoch is in the future.
+    ADUC_D2C_Messaging_DoWork();
+    CHECK(g_refreshMockTransport_callCount == 1); // unchanged
+
+    // Sleep through the grace period so the demoted message becomes
+    // eligible for replay. (Total < 7s — comparable to existing functional
+    // tests in this file.)
+    struct timespec sleepTs;
+    sleepTs.tv_sec = 6;
+    sleepTs.tv_nsec = 0;
+    ADUCPAL_nanosleep(&sleepTs, nullptr);
+
+    ADUC_D2C_Messaging_DoWork();
+    CHECK(g_refreshMockTransport_callCount == 2);
+    // The replayed send carries the original payload (not lost or
+    // corrupted), establishing the "is not lost" half of the mission
+    // requirement.
+    REQUIRE(g_refreshMockTransport_sentContent.size() == 2);
+    CHECK(g_refreshMockTransport_sentContent[1] == payload);
+    CHECK(record.completedCallCount == 0); // still WFR after the replay
+
+    ADUC_D2C_Messaging_Uninit();
+
+    g_testCaseSyncMutex.unlock();
+}
+
+TEST_CASE("ADO 38069154: Reset_For_Handle_Refresh drops in-flight WFR in favor of newer pending (dedupe)", "[handle_refresh]")
+{
+    g_testCaseSyncMutex.lock();
+    ResetRefreshMockTransport();
+
+    auto handle = reinterpret_cast<ADUC_ClientHandle>(-1);
+    ADUC_D2C_Messaging_Init();
+    ADUC_D2C_Messaging_Set_Transport(ADUC_D2C_Message_Type_Device_Update_Result, MockTransport_StaysInWFR);
+
+    // First, in-flight message A.
+    RefreshTestRecord recordA;
+    REQUIRE(ADUC_D2C_Message_SendAsync(
+        ADUC_D2C_Message_Type_Device_Update_Result,
+        &handle,
+        "reported state v1 (stale)",
+        nullptr, OnRefreshTestCompleted, nullptr, &recordA));
+
+    ADUC_D2C_Messaging_DoWork(); // A is now WFR
+    CHECK(g_refreshMockTransport_callCount == 1);
+    REQUIRE(g_refreshMockTransport_sentContent.size() == 1);
+    CHECK(g_refreshMockTransport_sentContent[0] == "reported state v1 (stale)");
+    CHECK(recordA.completedCallCount == 0);
+
+    // While the device was disconnected, the agent generated a newer
+    // reported-state update of the same type (B). It lands in
+    // s_pendingMessageStore[type] while A is still WFR.
+    RefreshTestRecord recordB;
+    REQUIRE(ADUC_D2C_Message_SendAsync(
+        ADUC_D2C_Message_Type_Device_Update_Result,
+        &handle,
+        "reported state v2 (latest)",
+        nullptr, OnRefreshTestCompleted, nullptr, &recordB));
+    // A is still WFR; B is queued.
+    CHECK(recordA.completedCallCount == 0);
+    CHECK(recordB.completedCallCount == 0);
+
+    // Handle just got recreated. Reset must drop A (stale) so that B (the
+    // latest) is the one that gets replayed — the cross-component "two
+    // queued updates of the same type collapse to one replay (the latest)"
+    // requirement.
+    ADUC_D2C_Messaging_Reset_For_Handle_Refresh();
+    CHECK(recordA.completedCallCount == 1);
+    CHECK(recordA.lastCompletedStatus == ADUC_D2C_Message_Status_Replaced);
+    CHECK(recordB.completedCallCount == 0); // still pending, not dropped
+
+    // Next DoWork: B is promoted out of pending and sent. (The pending
+    // promotion path resets nextRetryTimeStampEpoch to now, so the replay
+    // is immediate; the grace delay only applies to the demote-WFR path.)
+    ADUC_D2C_Messaging_DoWork();
+    CHECK(g_refreshMockTransport_callCount == 2);
+    REQUIRE(g_refreshMockTransport_sentContent.size() == 2);
+    CHECK(g_refreshMockTransport_sentContent[1] == "reported state v2 (latest)");
+    CHECK(recordB.completedCallCount == 0); // now WFR
+
+    ADUC_D2C_Messaging_Uninit();
+
+    g_testCaseSyncMutex.unlock();
+}
+
+TEST_CASE("ADO 38069154: Reset_For_Handle_Refresh is a no-op when nothing is in flight", "[handle_refresh]")
+{
+    g_testCaseSyncMutex.lock();
+    ADUC_D2C_Messaging_Init();
+
+    // No SendAsync, no DoWork. Reset should be safe and cheap.
+    ADUC_D2C_Messaging_Reset_For_Handle_Refresh();
+    ADUC_D2C_Messaging_Reset_For_Handle_Refresh(); // idempotent
+
+    ADUC_D2C_Messaging_Uninit();
+    g_testCaseSyncMutex.unlock();
+}
+
+TEST_CASE("ADO 38069154: Reset_For_Handle_Refresh is a no-op when no messaging core initialized", "[handle_refresh]")
+{
+    // No Init: must not crash.
+    ADUC_D2C_Messaging_Reset_For_Handle_Refresh();
 }


### PR DESCRIPTION

A transient network blip surfaces to Connection_Maintenance as IOTHUB_CLIENT_CONNECTION_NO_NETWORK. Today that case unconditionally calls ADUC_MethodCall_RestartAgent(), and systemd's Restart=always / RestartSec=5 turns each blip into a fast respawn loop that wedges the agent and floods telemetry. The IoT Hub C SDK already performs its own reconnect; we should let it.

This change implements the first two layers of the fix.

**Primary Fix -- stop the loop**
* Replace the NO_NETWORK branch in Connection_Maintenance() with the same treatment as NO_PING_RESPONSE / COMMUNICATION_ERROR: a 5-minute backoff, no handle destroy, no exit(). Logs a single transient-loss warning instead of repeated "restarting agent" lines.
* Add IoTHub_CommunicationManager_ClassifyConnectionReason() so the new policy is directly unit-testable without spinning the SDK.
* Drop the now-unused aduc_core_export_helpers dependency from the iothub_communication_manager static lib.
* Harden daemon/deviceupdate-agent.service: Restart=on-failure (was always) RestartSec=60s (was 5) StartLimitIntervalSec=1800 StartLimitBurst=8 Defense-in-depth so future exit(0)/exit(non-zero) regressions cannot reproduce the storm.

**Ensure data being reported correctly** -- D2C / twin replay on handle refresh
* New API ADUC_D2C_Messaging_Reset_For_Handle_Refresh() in d2c_messaging. For each per-type processing context whose current message is in Waiting_For_Response:
    - If a newer pending message of the same type exists, complete the stale in-flight one as Replaced (dedupe — the latest wins).
    - Otherwise demote it to In_Progress and arm a 5-second grace delay before the next replay so we don't race the new client handle's MQTT auth. Reset is invoked from ADUC_Refresh_IotHub_Connection_SAS_Token after the new client handle is live and the s_client_handle_mutex has been released, so we never call into d2c with the connection mutex held.

**New unit tests**
* iothub_communication_manager_ut: 6 cases covering the classifier across all known IOTHUB_CLIENT_CONNECTION_STATUS_REASON values, including the new transient policy for NO_NETWORK.
* d2c_messaging_ut: 4 cases under tag [handle_refresh] covering
    - demote of an in-flight WFR message and replay after the grace delay with the original content;
    - dedupe of a stale in-flight WFR against a newer pending of the same type, with the latest content replayed;
    - no-op when nothing is in flight;
    - no-op when messaging core is uninitialized.
* Re-enable the previously-commented add_subdirectory(tests) in src/utils/d2c_messaging/CMakeLists.txt so these tests actually build.

Refs: ADO Bug 38069154