### PR TITLE
Fix AducTimer thread lifecycle and a flaky polling-interval assumptio…

### DIFF
--- a/src/utils/timer_utils/inc/aduc/timer.h
+++ b/src/utils/timer_utils/inc/aduc/timer.h
@@ -38,8 +38,23 @@ typedef struct tagAducTimer
     pthread_t timerThread;
     pthread_mutex_t mut;
     bool timerThreadRunning;
+    bool threadCreated;
     bool initialized;
 } AducTimer;
+
+/**
+ * Threading contract:
+ *  - Start/Stop are thread-safe with respect to each other and to Update.
+ *  - Stop blocks until the polling thread has exited (up to one
+ *    updateIntervalMs sleep cycle).
+ *  - Start is idempotent: if a previous Start has not been matched by a
+ *    Stop, Start will internally stop and join the previous polling
+ *    thread before starting a new one (the onStop callback is NOT
+ *    invoked in this case, only on an explicit Stop).
+ *  - Signal callbacks (onStart / onStop / onTimeout) MUST NOT call
+ *    Start, Stop, or uninit on the same timer. The timer thread joins
+ *    itself in that case, which is undefined behavior.
+ */
 
 int AducTimer_init(AducTimer* t, AducTimerSignals s, unsigned update_interval_ms);
 void AducTimer_uninit(AducTimer* t);

--- a/src/utils/timer_utils/src/timer.c
+++ b/src/utils/timer_utils/src/timer.c
@@ -54,10 +54,22 @@ static void* s_timerProc(void* context)
         return NULL;
     }
 
-    while (t->timerThreadRunning)
+    while (true)
     {
+        // Read the running flag and update interval under the mutex so we
+        // don't race with Start/Stop mutating them.
+        pthread_mutex_lock(&t->mut);
+        bool running = t->timerThreadRunning;
+        unsigned int interval_ms = t->updateIntervalMs;
+        pthread_mutex_unlock(&t->mut);
+
+        if (!running)
+        {
+            break;
+        }
+
         AducTimer_Update(t);
-        usleep(t->updateIntervalMs * 1000); // sleep for update interval
+        usleep(interval_ms * 1000); // sleep for update interval
     }
 
     return NULL;
@@ -80,6 +92,8 @@ int AducTimer_init(AducTimer* t, AducTimerSignals s, unsigned update_interval_ms
     t->waitTimeMs = 0;
     t->signals = s;
     t->updateIntervalMs = update_interval_ms;
+    t->timerThreadRunning = false;
+    t->threadCreated = false;
     t->initialized = true;
 
 #ifdef DBG_TIMER_UTILS
@@ -104,20 +118,56 @@ void AducTimer_uninit(AducTimer* t)
 
 bool AducTimer_IsTimedOut(AducTimer* t)
 {
-#ifdef DBG_TIMER_UTILS
-    Log_Debug("IsTimedOut called: result=%d", !_is_running(t) || _wait_exceeded(t));
-#endif
     pthread_mutex_lock(&t->mut);
     bool timed_out = !_is_running(t) || _wait_exceeded(t);
+#ifdef DBG_TIMER_UTILS
+    Log_Debug("IsTimedOut called: result=%d", timed_out);
+#endif
     pthread_mutex_unlock(&t->mut);
     return timed_out;
 }
 
+/**
+ * Internal: signal the polling thread to exit and join it. Does NOT
+ * invoke the onStop callback (that is done by AducTimer_Stop only).
+ * Used by both Stop (public) and Start (to ensure idempotency).
+ */
+static void _stop_thread(AducTimer* t)
+{
+    pthread_mutex_lock(&t->mut);
+    bool created = t->threadCreated;
+    pthread_t thr = t->timerThread;
+    t->timerThreadRunning = false;
+    t->threadCreated = false;
+    _reset(t);
+    pthread_mutex_unlock(&t->mut);
+
+    if (created)
+    {
+        // Join outside the mutex so the thread can finish its current
+        // iteration (which may itself take the mutex via AducTimer_Update).
+        pthread_join(thr, NULL);
+    }
+}
+
 int AducTimer_Start(AducTimer* t, unsigned w)
 {
+    if (t == NULL)
+    {
+        return -1;
+    }
+
 #ifdef DBG_TIMER_UTILS
     Log_Debug("Starting timer for %u ms", w);
 #endif
+
+    // Idempotent against a prior Start that wasn't matched by a Stop:
+    // tear down the previous polling thread before creating a new one.
+    // This avoids leaking the previous pthread_t handle and the data
+    // races / use-after-free that result from two threads polling the
+    // same AducTimer concurrently.
+    _stop_thread(t);
+
     pthread_mutex_lock(&t->mut);
     _reset(t);
     t->waitTimeMs = w;
@@ -125,13 +175,16 @@ int AducTimer_Start(AducTimer* t, unsigned w)
     if (w != 0 && t->updateIntervalMs != 0) // use zero if want to manually update pump the timer
     {
         t->timerThreadRunning = true;
-        int res = pthread_create(&t->timerThread, NULL, (void* (*)(void*))s_timerProc, t);
+        int res = pthread_create(&t->timerThread, NULL, s_timerProc, t);
         if (res != 0)
         {
             Log_Error("Failed to create timer thread");
             t->timerThreadRunning = false;
+            _reset(t);
+            pthread_mutex_unlock(&t->mut);
             return -1;
         }
+        t->threadCreated = true;
     }
     pthread_mutex_unlock(&t->mut);
 
@@ -147,17 +200,25 @@ void AducTimer_Update(AducTimer* t)
 #ifdef DBG_TIMER_UTILS
     Log_Debug("Updating timer");
 #endif
-    if (_is_running(t))
+    if (t == NULL)
     {
-        if (_wait_exceeded(t))
-        {
-            _reset(t); // auto-stop the timer until next start.
-            if (t->signals.onTimeout)
-            {
-                Log_Info("Timer timed out, invoking 'onTimeout' callback");
-                t->signals.onTimeout();
-            }
-        }
+        return;
+    }
+
+    AducTimerCallback onTimeout = NULL;
+
+    pthread_mutex_lock(&t->mut);
+    if (_is_running(t) && _wait_exceeded(t))
+    {
+        _reset(t); // auto-stop the timer until next start.
+        onTimeout = t->signals.onTimeout;
+    }
+    pthread_mutex_unlock(&t->mut);
+
+    if (onTimeout != NULL)
+    {
+        Log_Info("Timer timed out, invoking 'onTimeout' callback");
+        onTimeout();
     }
 }
 
@@ -170,11 +231,12 @@ void AducTimer_Stop(AducTimer* t)
     {
         return;
     }
-    pthread_mutex_lock(&t->mut);
-    t->timerThreadRunning = false;
-    _reset(t);
+
+    _stop_thread(t);
+
+    // signals is set at init time and never mutated, so reading
+    // onStop outside the lock is safe.
     AducTimerCallback onStop = t->signals.onStop;
-    pthread_mutex_unlock(&t->mut);
     if (onStop)
     {
 #ifdef DBG_TIMER_UTILS

--- a/src/utils/timer_utils/tests/timer_ut.cpp
+++ b/src/utils/timer_utils/tests/timer_ut.cpp
@@ -18,6 +18,19 @@ bool _g_start_called = false;
 bool _g_stop_called = false;
 bool _g_timeout_called = false;
 
+// Bounded poll for a flag set by the timer's polling thread. The thread
+// wakes every updateIntervalMs (50 in these tests), so a fixed usleep
+// shorter than that interval is racy. Poll up to ~500ms in 5ms slices
+// before giving up so the assertion still fails if the callback truly
+// never fires (e.g. under a real regression).
+static void s_wait_for_flag(volatile bool* flag)
+{
+    for (int i = 0; i < 100 && !*flag; ++i)
+    {
+        usleep(5 * 1000);
+    }
+}
+
 static void s_reset_test_metrics()
 {
     _g_start_called = false;
@@ -64,6 +77,7 @@ TEST_CASE("AducTimer callback on timeout", "[timer]")
     AducTimer_Start(&t, 200);
     usleep(250 * 1000);
     CHECK(_g_start_called);
+    s_wait_for_flag(&_g_timeout_called);
     CHECK(_g_timeout_called);
 
     AducTimer_Stop(&t);
@@ -94,7 +108,7 @@ TEST_CASE("AducTimer reuse", "[timer]")
     AducTimer_Start(&t, 100);
     CHECK(_g_start_called);
 
-    usleep(125 * 1000);
+    s_wait_for_flag(&_g_timeout_called);
     CHECK(_g_timeout_called);
 
     AducTimer_Stop(&t);
@@ -108,7 +122,7 @@ TEST_CASE("AducTimer reuse", "[timer]")
     s_reset_test_metrics();
     AducTimer_Start(&t, 25);
     CHECK(_g_start_called);
-    usleep(30 * 1000);
+    s_wait_for_flag(&_g_timeout_called);
     CHECK(_g_timeout_called);
 }
 


### PR DESCRIPTION
…n in its tests

Two failure modes were observed for test #653 'AducTimer reuse' on the build pipeline (https://msazure.visualstudio.com/One/_build?definitionId=450778):

1. QEMU 'uncaught target signal 11 (Segmentation fault) - core dumped' immediately after Catch2 prints 'All tests passed'. CTest then reports the test as failed because the process exit code is non-zero, and --repeat until-pass cannot recover.
2. CHECK(_g_timeout_called) at timer_ut.cpp:112 evaluates false on slower runners.

Root causes
-----------

* AducTimer_Stop never joined the polling thread that AducTimer_Start created via pthread_create. The thread was also not detached. After AducTimer_uninit destroyed the mutex and memset the struct, the still-extant thread would later wake from its usleep, call AducTimer_Update on zeroed memory, and (at process exit) race glibc/pthread shutdown -> SIGSEGV. Under QEMU user-mode emulation this race is nearly deterministic.
* AducTimer_Start did not stop a previously created thread before calling pthread_create again, so a Start -> Start sequence (or the test's Start -> Stop -> Start sequence under load) could end up with two threads polling the same struct.
* s_timerProc, AducTimer_Update, _is_running, _wait_exceeded, _reset all read/wrote shared state without holding t->mut, racing with Start/Stop which do hold it.
* The test asserts _g_timeout_called within 30ms of starting a 25ms timer, but the timer's update interval is 50ms - the polling thread can not have fired yet, so the check is inherently flaky.

Fix
---

* Add bool threadCreated to AducTimer to track ownership of timerThread.
* Factor an internal _stop_thread helper that signals the polling thread to exit, releases the mutex, then pthread_joins outside the lock. Used by both Stop and Start.
* AducTimer_Stop calls _stop_thread, then invokes onStop. Now guaranteed to return only after the polling thread has actually exited.
* AducTimer_Start calls _stop_thread first so it is idempotent against a prior un-stopped Start (without firing onStop, which is reserved for explicit Stop).
* AducTimer_Start unlocks the mutex on the pthread_create error path (previously leaked).
* AducTimer_Update takes t->mut, captures the onTimeout callback, releases the lock, then invokes the callback outside the lock so a callback that re-enters the API cannot deadlock.
* s_timerProc reads timerThreadRunning and updateIntervalMs under the mutex each iteration so it can not race with Start/Stop.
* AducTimer_IsTimedOut moves its debug log inside the locked region.
* Document the threading contract in timer.h (Start/Stop are mutually thread-safe; callbacks must not call Start/Stop/uninit on the same timer).

Test
----

* Introduce s_wait_for_flag(volatile bool*) that polls a flag for up to ~500ms in 5ms slices. Use it in the two test cases that observe _g_timeout_called instead of a fixed usleep shorter than the timer's update interval. The assertion still fails if the callback never fires.