### PR TITLE
Upgrade azure-iot-sdk-c from LTS_08_2023 to LTS_03_2025

### DIFF
--- a/docs/agent-reference/how-to-build-agent-code.md
+++ b/docs/agent-reference/how-to-build-agent-code.md
@@ -81,7 +81,7 @@ These major components are built from source during the build process:
 #### Azure IoT C SDK
 - **Repository**: [Azure/azure-iot-sdk-c](https://github.com/Azure/azure-iot-sdk-c)
 - **Purpose**: Connect to IoT Hub and call Azure IoT Plug and Play APIs
-- **Default Branch**: `LTS_08_2023`
+- **Default Branch**: `LTS_03_2025`
 - **Required For**: All Azure IoT Hub communication (MQTT, device authentication, telemetry)
 - **Customization**: Use `--azure-iot-sdk-ref <branch/tag>` to specify version
 
@@ -309,7 +309,7 @@ The [`scripts/install-deps.sh`](../../scripts/install-deps.sh) script provides e
 
 | Option | Purpose | Default Version | Customization |
 |--------|---------|-----------------|---------------|
-| `--install-azure-iot-sdk` | Azure IoT C SDK | `LTS_08_2023` | `--azure-iot-sdk-ref <branch>` |
+| `--install-azure-iot-sdk` | Azure IoT C SDK | `LTS_03_2025` | `--azure-iot-sdk-ref <branch>` |
 | `--install-do` | Delivery Optimization SDK | `develop` | `--do-ref <branch/tag>` |
 | `--install-azure-storage-sdk` | Azure SDK for C++ | Latest | For blob storage features |
 | `--install-catch2` | Testing framework | `v2.13.9` | `--catch2-ref <version>` |
@@ -1118,7 +1118,7 @@ All platforms: cmake 3.23.2  # Guaranteed compatibility
 
 The ADU project builds several key dependencies from source for similar cross-platform reliability:
 
-#### Azure IoT C SDK (LTS_08_2023)
+#### Azure IoT C SDK (LTS_03_2025)
 - **Reason**: Specific LTS branch with known stability
 - **Benefit**: Consistent Azure connectivity across all platforms
 - **Alternative**: System packages often have different versions/patches

--- a/licenses/cgmanifest.json
+++ b/licenses/cgmanifest.json
@@ -17,8 +17,8 @@
         "Type": "git",
         "git": {
           "RepositoryUrl": "https://github.com/Azure/azure-iot-sdk-c",
-          "CommitHash_Comment": "LTS_07_2021_Ref01",
-          "CommitHash": "808a5595f98853a5f2eae2c67dd9b3608a2338ea"
+          "CommitHash_Comment": "LTS_03_2025",
+          "CommitHash": "79145b2cf2050b3a10d22003156db86f6e9c5c5e"
         }
       },
       "DevelopmentDependency": false

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -54,7 +54,7 @@ use_ssh=false
 
 install_aduc_deps=false
 install_azure_iot_sdk=false
-azure_sdk_ref=LTS_08_2023
+azure_sdk_ref=LTS_03_2025
 
 # ADUC Diagnostics Deps
 azure_storage_sdk_branch_ref=main


### PR DESCRIPTION
Addresses customer request in https://github.com/Azure/iot-hub-device-update/issues/863. Bumps the Azure IoT C SDK dependency to the latest LTS release.

- scripts/install-deps.sh: default azure_sdk_ref now LTS_03_2025
- licenses/cgmanifest.json: refresh azure-iot-sdk-c registration to LTS_03_2025 commit
- docs/agent-reference/how-to-build-agent-code.md: update version references