### PR TITLE
Fix SIGABRT on workflow step transition (re-entrant TrackWorker)

### DIFF
--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
@@ -63,13 +63,37 @@ LinuxPlatformLayer::~LinuxPlatformLayer()
     // operations (Download/Install/Apply) can return early, then wait for the
     // worker to finish. This prevents the detached-thread use-after-free of
     // workCompletionData / workflowData reported in issue #858.
+    //
+    // We must NOT call std::thread::join() while holding _activeWorkerMutex,
+    // because a worker thread that is in the middle of a synchronous workflow
+    // transition can call TrackWorker() and block on that same mutex; if we
+    // held the mutex and waited for the worker, both threads would wait
+    // forever. Instead, atomically take ownership of the active worker under
+    // the lock, drop the lock, join outside the lock, and loop in case the
+    // worker installed a successor (e.g. Download -> Install) during the join.
+    // If the worker we want to join is the current thread (which can only
+    // happen if ~LinuxPlatformLayer is invoked from within a worker callback,
+    // e.g. during teardown triggered by the workflow itself), detach rather
+    // than deadlock.
     _IsCancellationRequested = true;
+
+    while (true)
     {
-        std::lock_guard<std::mutex> lock(_activeWorkerMutex);
-        if (_activeWorker.joinable())
+        std::thread workerToJoin;
         {
-            _activeWorker.join();
+            std::lock_guard<std::mutex> lock(_activeWorkerMutex);
+            if (!_activeWorker.joinable())
+            {
+                break;
+            }
+            if (_activeWorker.get_id() == std::this_thread::get_id())
+            {
+                _activeWorker.detach();
+                break;
+            }
+            workerToJoin = std::move(_activeWorker);
         }
+        workerToJoin.join();
     }
 
     ExtensionManager::Uninit();

--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.hpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.hpp
@@ -459,15 +459,49 @@ private:
      *
      * The workflow engine only dispatches one async operation at a time, but we
      * still join defensively to make the ownership model explicit.
+     *
+     * Important: TrackWorker can be invoked re-entrantly on the very worker
+     * thread it is tracking. This happens during a normal successful workflow
+     * step transition: a worker finishes its operation (e.g. Download), calls
+     * WorkCompletionCallback, which synchronously transitions the workflow to
+     * the next step (e.g. Install) and invokes the next step's callback on the
+     * same thread. That callback then arrives here with
+     * _activeWorker.get_id() == std::this_thread::get_id(). Joining a thread on
+     * itself throws std::system_error (EDEADLK); allowing that exception to
+     * propagate caused the local std::thread in the caller to be destroyed
+     * while still joinable, which terminates the process. To avoid that, we
+     * detach the prior worker in the re-entrant case: it is already returning
+     * from its lambda and is no longer responsible for waiting on completion.
+     *
+     * We also avoid calling std::thread::join() while holding
+     * _activeWorkerMutex, so a worker trying to install its successor cannot
+     * deadlock against a shutdown thread holding the mutex.
      */
     void TrackWorker(std::thread&& worker)
     {
-        std::lock_guard<std::mutex> lock(_activeWorkerMutex);
-        if (_activeWorker.joinable())
+        std::thread previous;
         {
-            _activeWorker.join();
+            std::lock_guard<std::mutex> lock(_activeWorkerMutex);
+            if (_activeWorker.joinable()
+                && _activeWorker.get_id() == std::this_thread::get_id())
+            {
+                // Re-entrant install from inside the currently tracked worker
+                // (synchronous workflow transition). Detach so the running
+                // thread can finish unwinding its stack independently; the new
+                // worker we install here represents the in-flight work that
+                // the destructor must wait for.
+                _activeWorker.detach();
+            }
+            else if (_activeWorker.joinable())
+            {
+                previous = std::move(_activeWorker);
+            }
+            _activeWorker = std::move(worker);
         }
-        _activeWorker = std::move(worker);
+        if (previous.joinable())
+        {
+            previous.join();
+        }
     }
 };
 } // namespace ADUC

--- a/src/platform_layers/linux_platform_layer/tests/linux_adu_core_impl_ut.cpp
+++ b/src/platform_layers/linux_platform_layer/tests/linux_adu_core_impl_ut.cpp
@@ -650,3 +650,128 @@ TEST_CASE("LinuxPlatformLayer destructor blocks until an in-flight worker finish
     CHECK(unregisterReturned.load() == true);
     CHECK(probe.completions.load() == 1);
 }
+
+//
+// Regression for re-entrant TrackWorker (#xxx - APT deployment SIGABRT).
+//
+// Symptom on the device: every workflow attempt crashed with
+//   "terminate called without an active exception" -> SIGABRT
+// immediately after a download step's worker thread completed.
+//
+// Root cause: workflow_engine's WorkCompletionCallback synchronously
+// transitions to the next workflow step on the worker thread itself. That
+// next step's platform callback creates a new std::thread and calls
+// TrackWorker(std::move(worker)). The previously-tracked _activeWorker IS
+// the current thread; std::thread::join() on self throws
+// resource_deadlock_would_occur. The exception was caught by the catch
+// (std::exception) handler in InstallCallback, but the local std::thread in
+// the catching scope was still joinable -> its destructor called
+// std::terminate.
+//
+// This test simulates the workflow engine's behaviour by having the
+// WorkCompletionCallback re-enter the platform layer on the worker thread,
+// invoking a second async callback. With the fix in TrackWorker, the prior
+// worker is detached (not joined) when it is the current thread, so the
+// second callback returns InProgress without throwing and the process does
+// not terminate.
+//
+namespace
+{
+struct ReentrantTransitionProbe
+{
+    std::mutex mtx;
+    std::condition_variable cv;
+    std::atomic<int> firstCompletions{ 0 };
+    std::atomic<int> secondCompletions{ 0 };
+    std::atomic<int> reentrantResultCode{ -999 };
+    std::atomic<int> reentrantExtendedResultCode{ -999 };
+    std::atomic<bool> reentrantCallReturnedInProgress{ false };
+    std::atomic<bool> reentrantCallThrew{ false };
+
+    ADUC_UpdateActionCallbacks callbacks{};
+    ADUC_WorkflowData workflowData{};
+    ADUC_WorkCompletionData secondCompletionData{};
+
+    static void FirstOnComplete(const void* token, ADUC_Result /*result*/, bool /*isAsync*/)
+    {
+        auto* self =
+            const_cast<ReentrantTransitionProbe*>(static_cast<const ReentrantTransitionProbe*>(token));
+        {
+            std::lock_guard<std::mutex> lock(self->mtx);
+            ++self->firstCompletions;
+        }
+        self->cv.notify_all();
+
+        // Synchronously invoke the next async callback on this very thread,
+        // mirroring what ADUC_Workflow_AutoTransitionWorkflow does.
+        try
+        {
+            ADUC_Result r = self->callbacks.InstallCallback(
+                self->callbacks.PlatformLayerHandle,
+                &self->secondCompletionData,
+                &self->workflowData);
+            self->reentrantResultCode.store(r.ResultCode);
+            self->reentrantExtendedResultCode.store(r.ExtendedResultCode);
+            self->reentrantCallReturnedInProgress.store(r.ResultCode == ADUC_Result_Install_InProgress);
+        }
+        catch (...)
+        {
+            self->reentrantCallThrew.store(true);
+        }
+    }
+
+    static void SecondOnComplete(const void* token, ADUC_Result /*result*/, bool /*isAsync*/)
+    {
+        auto* self =
+            const_cast<ReentrantTransitionProbe*>(static_cast<const ReentrantTransitionProbe*>(token));
+        {
+            std::lock_guard<std::mutex> lock(self->mtx);
+            ++self->secondCompletions;
+        }
+        self->cv.notify_all();
+    }
+
+    bool WaitForSecondCompletion(std::chrono::milliseconds timeout)
+    {
+        std::unique_lock<std::mutex> lock(mtx);
+        return cv.wait_for(lock, timeout, [this] { return secondCompletions.load() >= 1; });
+    }
+};
+} // namespace
+
+TEST_CASE("LinuxPlatformLayer TrackWorker re-entered from worker thread does not terminate")
+{
+    ReentrantTransitionProbe probe;
+    REQUIRE(IsAducResultCodeSuccess(
+        ADUC_RegisterPlatformLayer(&probe.callbacks, 0, nullptr).ResultCode));
+
+    probe.workflowData.WorkflowHandle = nullptr; // fast-fail in GetUpdateManifestHandler
+
+    ADUC_WorkCompletionData firstCompletionData{};
+    firstCompletionData.WorkCompletionCallback = &ReentrantTransitionProbe::FirstOnComplete;
+    firstCompletionData.WorkCompletionToken = &probe;
+
+    probe.secondCompletionData.WorkCompletionCallback = &ReentrantTransitionProbe::SecondOnComplete;
+    probe.secondCompletionData.WorkCompletionToken = &probe;
+
+    // First async step (Download). Its worker will, on completion, synchronously
+    // invoke a second async step (Install) on the same thread.
+    ADUC_Result first = probe.callbacks.DownloadCallback(
+        probe.callbacks.PlatformLayerHandle, &firstCompletionData, &probe.workflowData);
+    REQUIRE(first.ResultCode == ADUC_Result_Download_InProgress);
+
+    // Both worker completions must fire without process termination.
+    REQUIRE(probe.WaitForSecondCompletion(std::chrono::seconds(10)));
+    CHECK(probe.firstCompletions.load() == 1);
+    CHECK(probe.secondCompletions.load() == 1);
+
+    // The re-entrant InstallCallback must have returned InProgress (i.e. the
+    // worker thread was spawned and TrackWorker succeeded), and must not have
+    // thrown back into FirstOnComplete.
+    INFO("reentrant ResultCode=" << probe.reentrantResultCode.load()
+         << " ERC=0x" << std::hex << probe.reentrantExtendedResultCode.load());
+    CHECK(probe.reentrantCallReturnedInProgress.load() == true);
+    CHECK(probe.reentrantCallThrew.load() == false);
+
+    ADUC_Unregister(probe.callbacks.PlatformLayerHandle);
+}


### PR DESCRIPTION
The APT-deployment E2E test was crashing with "terminate called without an active exception" -> SIGABRT immediately after the Download step's worker thread completed. The agent restart loop prevented the workflow from ever reaching the Install/Apply phases, so the deployment never finished.

Root cause:
  ADUC_Workflow_WorkCompletionCallback synchronously transitions the
  workflow to the next step on the SAME thread (see agent_workflow.c
  line 976 -> AutoTransitionWorkflow -> TransitionWorkflow line 885).
  The next step's platform callback (e.g. InstallCallback) creates a
  new std::thread and calls TrackWorker(std::move(worker)). Inside
  TrackWorker, _activeWorker.joinable() is true and _activeWorker IS
  std::this_thread, so .join() throws resource_deadlock_would_occur.
  The exception is caught by the callback's catch(std::exception) block,
  but the local std::thread in the catching scope is still joinable -
  its destructor calls std::terminate() (with no in-flight exception,
  hence the libstdc++ message).

Fix:
  - TrackWorker: detect when the previously tracked worker is the current thread (re-entrant install from synchronous workflow transition) and detach instead of joining itself. Joins are now performed OUTSIDE _activeWorkerMutex so a worker installing its successor cannot deadlock against a concurrent shutdown.
  - ~LinuxPlatformLayer: move the active worker out under the lock and join outside the lock, looping in case the joined worker installed a successor during shutdown. Detach (instead of deadlock) in the unlikely case the destructor itself runs on the worker thread.
  - Add regression unit test that simulates the synchronous workflow transition: the first worker's WorkCompletionCallback invokes a second async callback on the same thread; before the fix this terminated the test process.