### PR TITLE
Fix #811: preserve sandbox on restart so downloads can resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `edgegatewayCertPath` overwriting X.509 / EIS-x509 auth state — the gateway cert is now applied as a post-processing step that preserves the original authType so client cert, private key, and engine SDK options keep getting set on the IoT Hub handle (previously a non-Edge regression replaced authType with NestedEdgeCert and skipped all mTLS options)
 * Fix AIS + EIS-x509 (no Edge gateway) regression where the EIS-issued identity certificate was never installed as `SU_OPTION_X509_CERT` and was mis-installed as `OPTION_TRUSTED_CERT`, causing the IoT Hub mTLS handshake to fail and the agent to restart-loop during deployments
+* Fix `AducIotAgent` destroying in-progress downloads on restart ([#811](https://github.com/Azure/iot-hub-device-update/issues/811)) — `LinuxPlatformLayer::SandboxCreate` no longer wipes the current workflow's work folder when it already exists, so partial payloads survive an agent or `deviceupdate-agent.service` restart and the curl (`-C -`) and DO downloaders can resume from the existing bytes instead of starting over
 
 ## Release 1.3.0
 

--- a/docs/agent-reference/architecture-overview.md
+++ b/docs/agent-reference/architecture-overview.md
@@ -349,6 +349,50 @@ agent crashes, the stale lock is removed immediately and the reboot proceeds.
 
 ---
 
+## Download Resume Across Agent / Service Restarts
+
+The agent's download sandbox at `/var/lib/adu/downloads/<workflowId>/` is
+preserved across restarts of the `AducIotAgent` process or the
+`deviceupdate-agent.service` unit so that an interrupted download can resume
+from where it left off instead of starting from byte 0.
+
+### How it works
+
+1. On startup of the next workflow step, `Cleanup_Previous_Sandboxes`
+   (`src/adu_workflow/src/agent_workflow.c`) walks `/var/lib/adu/downloads/`
+   and removes every directory **except** the one matching the current
+   `workflowId`. Sandboxes from prior workflows are still purged — only the
+   *current* workflow's folder is kept.
+2. When the Download step calls `SandboxCreateCallback`, the Linux platform
+   layer (`LinuxPlatformLayer::SandboxCreate` in
+   `src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp`)
+   detects the existing folder and reuses it as-is rather than wiping and
+   recreating it.
+3. The shipped content downloaders then pick up the partial files
+   automatically:
+   - `curl_downloader` invokes `curl -L -C -` — `-C -` tells curl to auto-resume
+     from the local file size using an HTTP Range request.
+   - The Delivery Optimization client resumes natively via the
+     `deliveryoptimization-agent` service.
+4. After the resumed download completes, the workflow's existing post-download
+   SHA-256 hash check (`ADUC_HashUtils_IsValidFileHash`) verifies the file
+   against the value declared in the signed manifest before installation, so
+   a corrupted resume cannot silently end up applied.
+
+### Operational notes
+
+- Disk hygiene is unchanged: `Cleanup_Previous_Sandboxes` still runs on the
+  `ProcessDeployment` step of every new deployment, so a failed deployment's
+  sandbox is purged the moment the next deployment arrives.
+- File ownership and permissions on the work folder are set to `adu:adu` /
+  `rwx,rwx,---` on first creation and preserved on reuse; no operator action
+  is needed.
+- If you previously worked around the wipe-on-restart behavior by deleting
+  `/var/lib/adu/downloads/` manually before restarting the agent, that is no
+  longer necessary (and now actively prevents the resume).
+
+---
+
 ## Further Reading
 
 - [how-to-build-agent-code.md](how-to-build-agent-code.md) — Building the agent from source

--- a/docs/how-to-troubleshoot-guide.md
+++ b/docs/how-to-troubleshoot-guide.md
@@ -34,6 +34,7 @@ Delivery Optimization logs (when using DO content downloader):
 | Symptom | Likely Cause | Resolution |
 |---------|-------------|------------|
 | Download fails | Network issue, storage URL expired, or content downloader error | Check network connectivity; review DO or curl downloader logs |
+| Download appears slow but is making progress after an agent or `deviceupdate-agent.service` restart | Expected — the download is **resuming** from the previous byte offset rather than restarting | No action needed. See [Download Resume Across Agent / Service Restarts](agent-reference/architecture-overview.md#download-resume-across-agent--service-restarts). Do not manually delete `/var/lib/adu/downloads/`; that prevents resume. |
 | Delta download handler errors | Missing delta dependencies or source file not cached | See [Building with Delta Handler](agent-reference/building-with-delta-handler.md) for setup |
 | Installation stuck at "In Progress" | Handler script timeout or crash | Check handler logs; review script permissions |
 | Update reports failure with ExtendedResultCode | Handler or agent error | Decode the result code (see below) |

--- a/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
+++ b/src/platform_layers/linux_platform_layer/src/linux_adu_core_impl.cpp
@@ -405,18 +405,17 @@ ADUC_Result LinuxPlatformLayer::SandboxCreate(const char* workflowId, char* work
         return ADUC_Result{ ADUC_Result_Failure, ADUC_ERC_NOTRECOVERABLE };
     }
 
-    // Try to delete existing directory.
-    int dir_result;
+    // If the work folder already exists, preserve its contents so that any partially
+    // downloaded payloads can be resumed by the underlying downloaders (curl uses
+    // '-C -' to auto-resume; the DO client resumes natively). Cleanup_Previous_Sandboxes
+    // has already removed sandboxes belonging to prior workflowIds before we get here,
+    // so an existing folder at this path belongs to the current workflowId and was
+    // left over from a prior agent/service restart.
     struct stat sb;
-
     if (stat(workFolder, &sb) == 0 && S_ISDIR(sb.st_mode))
     {
-        dir_result = ADUC_SystemUtils_RmDirRecursive(workFolder);
-        if (dir_result != 0)
-        {
-            // Not critical if failed.
-            Log_Info("Unable to remove folder %s, error %d", workFolder, dir_result);
-        }
+        Log_Info("Reusing existing sandbox %s to allow download resume", workFolder);
+        return ADUC_Result{ ADUC_Result_SandboxCreate_Success };
     }
 
     // Note: the return value may point to a static area,
@@ -447,7 +446,7 @@ ADUC_Result LinuxPlatformLayer::SandboxCreate(const char* workflowId, char* work
     // Create the sandbox folder with adu:adu ownership.
     // Permissions are set to u=rwx,g=rwx. We grant read/write/execute to group owner so that partner
     // processes like the DO daemon can download files to our sandbox.
-    dir_result =
+    int dir_result =
         ADUC_SystemUtils_MkDirRecursive(workFolder, aduUserId, aduGroupId, S_IRWXU | S_IRGRP | S_IWGRP | S_IXGRP);
     if (dir_result != 0)
     {

--- a/src/platform_layers/linux_platform_layer/tests/linux_adu_core_impl_ut.cpp
+++ b/src/platform_layers/linux_platform_layer/tests/linux_adu_core_impl_ut.cpp
@@ -10,6 +10,8 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -191,6 +193,64 @@ TEST_CASE("LinuxPlatformLayer SandboxCreate callback tests")
             callbacks.SandboxDestroyCallback(callbacks.PlatformLayerHandle, "ut-valid-wf-001", workFolder);
         }
         CHECK(true); // exercised the path
+    }
+
+    SECTION("SandboxCreate preserves existing folder contents to allow download resume (issue #811)")
+    {
+        // Regression test for https://github.com/Azure/iot-hub-device-update/issues/811:
+        // when the agent restarts mid-download, SandboxCreate must NOT wipe the
+        // pre-existing work folder, otherwise partial downloads are destroyed and
+        // curl '-C -' / DO-client resume cannot take effect.
+        //
+        // Use std::filesystem::temp_directory_path() (the same pattern as
+        // adushell_ut.cpp:211) so the test honors TMPDIR/TMP/TEMP and works on
+        // build targets where /tmp is not writable or is not the platform temp dir.
+        namespace fs = std::filesystem;
+        const fs::path workFolderPath = fs::temp_directory_path() / "adu-ut-sandbox-resume";
+
+        // Start clean, then create the folder and drop a sentinel file simulating
+        // a partial download from a previous agent run.
+        std::error_code ec;
+        fs::remove_all(workFolderPath, ec);
+        REQUIRE(fs::create_directories(workFolderPath, ec));
+
+        const fs::path sentinelPath = workFolderPath / "partial.bin";
+        const std::string payload = "partial download data";
+        {
+            std::ofstream sentinel(sentinelPath, std::ios::binary);
+            REQUIRE(sentinel.good());
+            sentinel.write(payload.data(), static_cast<std::streamsize>(payload.size()));
+        }
+        REQUIRE(fs::exists(sentinelPath));
+        const auto originalSize = fs::file_size(sentinelPath);
+
+        // SandboxCreate's signature takes a mutable C-string for workFolder; copy
+        // the resolved path into a fixed-size buffer matching the other sections.
+        char workFolder[256] = {};
+        const std::string workFolderStr = workFolderPath.string();
+        REQUIRE(workFolderStr.size() < sizeof(workFolder));
+        std::strncpy(workFolder, workFolderStr.c_str(), sizeof(workFolder) - 1);
+
+        // Call SandboxCreate against the existing folder, mimicking the
+        // post-restart Download step that previously wiped the folder.
+        ADUC_Result sandboxResult =
+            callbacks.SandboxCreateCallback(callbacks.PlatformLayerHandle, "ut-resume-wf-001", workFolder);
+
+        // The fix returns success early when the folder already exists, regardless
+        // of whether the 'adu' user/group is present on the test host.
+        CHECK(IsAducResultCodeSuccess(sandboxResult.ResultCode));
+
+        // The sentinel must still be there with its contents intact so the
+        // downloader can resume from where it left off.
+        const bool sentinelExists = fs::exists(sentinelPath);
+        CHECK(sentinelExists);
+        if (sentinelExists)
+        {
+            CHECK(fs::file_size(sentinelPath) == originalSize);
+        }
+
+        // Cleanup
+        fs::remove_all(workFolderPath, ec);
     }
 
     ADUC_Unregister(callbacks.PlatformLayerHandle);


### PR DESCRIPTION
LinuxPlatformLayer::SandboxCreate was unconditionally wiping the work folder of the current workflow on every invocation, which destroyed any partial download present when AducIotAgent / deviceupdate-agent.service restarted mid-download. This directly defeated the resume support already present in both shipped downloaders (curl '-C -' and the DO client) and contradicted the intent of Cleanup_Previous_Sandboxes, which explicitly preserves the current workflow's folder across restarts.

If the work folder already exists when SandboxCreate runs, reuse it as-is. Cleanup_Previous_Sandboxes guarantees that any directory present at this point belongs to the current workflowId, so reuse is safe. First-time creation still applies adu:adu ownership and the existing permission mask.

Also:
- Added regression test in linux_adu_core_impl_ut.cpp using std::filesystem::temp_directory_path() so the test honors TMPDIR/TMP on any build target.
- Updated docs/agent-reference/architecture-overview.md with a new 'Download Resume Across Agent / Service Restarts' section next to the existing Graceful Reboot Flow.
- Added a troubleshooting-guide row clarifying the new resume behavior.
- CHANGELOG.md entry under Release 1.3.1.

Refs: https://github.com/Azure/iot-hub-device-update/issues/811