### PR TITLE
Pin vcpkg baseline for Azure Storage SDK build (fix install-deps)

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -671,6 +671,27 @@ do_install_azure_storage_sdk() {
 
     git checkout tags/"$azure_storage_sdk_tag_ref"
 
+    # Pin the vcpkg baseline used to resolve this SDK's manifest dependencies.
+    #
+    # The azure-sdk-for-cpp manifest at tag azure-core_1.6.0 does not declare a
+    # "builtin-baseline" in its vcpkg.json, so vcpkg falls back to whatever
+    # commit happens to be checked out in $VCPKG_ROOT (or HEAD when bootstrapped
+    # fresh). Newer vcpkg baselines ship libxml2 >= 2.13, which marks
+    # _xmlBuffer::content and _xmlBuffer::use as XML_DEPRECATED_MEMBER. The
+    # SDK's sdk/storage/azure-storage-common/src/xml_wrapper.cpp still accesses
+    # those fields directly and is built with -Werror, breaking the build.
+    #
+    # Pin the default registry to vcpkg release 2024.05.24, which still ships
+    # libxml2 2.11.7 (and is contemporaneous with azure-core_1.6.0).
+    cat > vcpkg-configuration.json <<'EOF'
+{
+    "default-registry": {
+        "kind": "builtin",
+        "baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625"
+    }
+}
+EOF
+
     # Apply patch to fix missing cstdint include for GCC 12+ (Ubuntu 24.04, Debian 12)
     # Check GCC version and apply patch only if GCC >= 12
     local gcc_version


### PR DESCRIPTION
## Problem

The `Install ADUC dependencies` step (running `DeviceUpdate/scripts/install-deps.sh --install-all-deps`) fails when building the Azure Storage SDK from source:

```
azure_storage_sdk_dir/sdk/storage/azure-storage-common/src/xml_wrapper.cpp:616:62:
  error: '_xmlBuffer::content' is deprecated [-Werror=deprecated-declarations]
  error: '_xmlBuffer::use'     is deprecated [-Werror=deprecated-declarations]
    return std::string(reinterpret_cast<const char*>(buffer->content), buffer->use);
cc1plus: all warnings being treated as errors
```

## Root cause

`do_install_azure_storage_sdk` checks out `azure-sdk-for-cpp` at tag `azure-core_1.6.0`. The SDK manifest at that tag (`vcpkg.json`) does **not** declare a `builtin-baseline`, so vcpkg resolves transitive ports against whatever default baseline is currently active in the build environment. Recent vcpkg baselines ship **libxml2 >= 2.13**, which annotated `_xmlBuffer::content` and `_xmlBuffer::use` as `XML_DEPRECATED_MEMBER`. The SDK's `xml_wrapper.cpp` accesses those fields directly and is built with `-Werror`, so the build fails.

Nothing in our repo changed ? a floating third-party dependency baseline regressed the build.

## Fix

After the `git checkout tags/$azure_storage_sdk_tag_ref`, write a `vcpkg-configuration.json` into the SDK tree that pins the default registry to a known-good vcpkg commit (`f7423ee180c4b7f40d43402c2feb3859161ef625`, vcpkg release `2024.05.24`). That baseline still ships libxml2 **2.11.7**, which predates the `XML_DEPRECATED_MEMBER` annotations.

## Validation

Reproduced locally on WSL Ubuntu 24.04 / GCC 12.4 with **vcpkg HEAD** (i.e., the worst case that triggers the original failure):

- vcpkg manifest install honored the pin and produced `vcpkg_installed/vcpkg/info/libxml2_2.11.7_x64-linux.list` (not the HEAD libxml2 >= 2.13)
- `sdk/storage/azure-storage-common/src/xml_wrapper.cpp.o` compiled cleanly
- `libazure-storage-common.a` linked

Without this change, the same build with vcpkg HEAD fails with the deprecation errors above.
