### PR TITLE
E2E: move Linux test pipeline from Ubuntu 20.04 to 22.04

### DIFF
--- a/azurepipelines/e2e_test/e2etest.yaml
+++ b/azurepipelines/e2e_test/e2etest.yaml
@@ -1,10 +1,10 @@
 # E2E test pipeline - performs end-to-end tests on the following platforms
-#  - Ubuntu 20.04
+#  - Ubuntu 22.04
 
 resources:
     containers:
         - container: ubuntu
-          image: ubuntu:20.04
+          image: ubuntu:22.04
     repositories:
         - repository: 1ESPipelineTemplates
           type: git
@@ -37,11 +37,11 @@ variables:
     Test_InfraDeploymentName: "e2e-deployment-$(Build.BuildId)" #Composed of e2e-deployment-$(Build.BuildId)
     Test_VmHostname: "" # Set after the VM is created
     Test_Location: "westus3"
-    Test_DeviceName: "ubuntu-2004-x509-test-device"
-    Test_Distro: "ubuntu-20.04"
+    Test_DeviceName: "ubuntu-2204-x509-test-device"
+    Test_Distro: "ubuntu-22.04"
     Test_Arch: "amd64"
     Test_ArtifactUploadContainer: "gen1-debian-packages"
-    Test_Artifacts_Folder: "adu-client-ubuntu-2004-amd64"
+    Test_Artifacts_Folder: "adu-client-ubuntu-2204-amd64"
 
     Test_DeviceGroup: "gen1-test-devices"
     Test_DeploymentId: "aptdeployment-$(Build.BuildId)"
@@ -70,20 +70,20 @@ extends:
         - stage: PerformNativeBuilds
           displayName: Builds all the native architecture builds
           jobs:
-              - job: BuildUbuntu_2004_AMD64
-                displayName: Building the Device Update Package for Ubuntu 20.04 AMD64
+              - job: BuildUbuntu_2204_AMD64
+                displayName: Building the Device Update Package for Ubuntu 22.04 AMD64
                 continueOnError: False
                 pool: aduc_1es_client_pool
                 steps:
                     - template: /azurepipelines/build/templates/adu-native-build-steps.yml@self
                       parameters:
-                          targetOs: ubuntu2004
+                          targetOs: ubuntu2204
                           targetArch: amd64
         - stage: PublishPackageUnderTest
           displayName: Publish the Package under Test to the Storage
           jobs:
-              - job: PublishUbuntu2004_AMD64_Package
-                displayName: Publish the Ubuntu 20.04 AMD64 Package to the Storage
+              - job: PublishUbuntu2204_AMD64_Package
+                displayName: Publish the Ubuntu 22.04 AMD64 Package to the Storage
                 continueOnError: False
                 pool: aduc_1es_client_pool
                 steps:
@@ -93,7 +93,7 @@ extends:
                           source: "current"
                           project: "adu-linux-client"
                           pipeline: "Azure.adu-private-preview.e2e-test"
-                          itemPattern: "*ubuntu2004-amd64*/*.deb"
+                          itemPattern: "*ubuntu2204-amd64*/*.deb"
                           path: $(Build.ArtifactStagingDirectory)
                     - bash: |
                         ls -al $(Build.ArtifactStagingDirectory)
@@ -103,13 +103,13 @@ extends:
                       displayName: "Get the path to the package under test"
                       name: pathToPackageUnderTest
                     - task: AzureCLI@2
-                      displayName: "Publish the Ubuntu 20.04 AMD64 Package to the Storage"
+                      displayName: "Publish the Ubuntu 22.04 AMD64 Package to the Storage"
                       inputs:
                           azureSubscription: $(Adu_Arm_Service_Connection)
                           scriptType: bash
                           scriptLocation: inlineScript
                           inlineScript: |
-                              echo "Publishing the Ubuntu 20.04 AMD64 Package to the Storage"
+                              echo "Publishing the Ubuntu 22.04 AMD64 Package to the Storage"
                               az storage blob upload --auth-mode login --account-name $(AZURE_STORAGE_ACCOUNT_NAME) --container-name $(Test_ArtifactUploadContainer) --file $(pathToPackageUnderTest.packagePath) --name deviceupdate-$(Build.BuildId).deb --no-progress
                           failOnStandardError: true
                     - bash: |
@@ -121,12 +121,12 @@ extends:
         - stage: InitializeTestInfra
           displayName: Initializes the Infrastructure for the Automated Tests
           variables:
-              Test_PackageUnderTestName: $[ stageDependencies.PublishPackageUnderTest.PublishUbuntu2004_AMD64_Package.outputs['package_under_test_publisher.packageUnderTest'] ]
+              Test_PackageUnderTestName: $[ stageDependencies.PublishPackageUnderTest.PublishUbuntu2204_AMD64_Package.outputs['package_under_test_publisher.packageUnderTest'] ]
           pool: aduc_1es_client_pool
           jobs:
 
-              - job: SetupUbuntu2004_AMD64_VM
-                displayName: "Setting up VM for Ubuntu 20.04 AMD64 Test VM"
+              - job: SetupUbuntu2204_AMD64_VM
+                displayName: "Setting up VM for Ubuntu 22.04 AMD64 Test VM"
                 timeoutInMinutes: 360
                 cancelTimeoutInMinutes: 360
                 pool: aduc_1es_client_pool
@@ -171,14 +171,14 @@ extends:
                           failOnStandardError: true
 
                     - task: AzureCLI@2
-                      displayName: "Create the Ubuntu 20.04 VM for the E2E Test"
+                      displayName: "Create the Ubuntu 22.04 VM for the E2E Test"
                       inputs:
                           azureSubscription: $(Adu_Arm_Service_Connection)
                           scriptType: bash
                           scriptLocation: inlineScript
                           inlineScript: |
                               echo "Creating the VM for Test"
-                              az deployment group create --name $(Test_InfraDeploymentName) --resource-group "$(Test_ResourceGroupname)" --template-file ./azurepipelines/e2e_test/templates/az_vm.template.json --parameters adminUsername="$(Test_VmAdmin)" adminKey="$(set_ssh_key.Test_Vm_Ssh_PublicKey)" adminPassword="$(VM_ADMIN_PASS)" vmName="$(Test_VmName)" vmSize=Standard_DS1_v2 location=$(Test_Location) msi_resource_id="$(MSI_RESOURCE_ID)" msi_client_id="$(MSI_CLIENT_ID)" duSetupScriptFileUri="$(VM_SETUP_SCRIPT_URI)" duSetupScriptFileName="$(VM_SETUP_SCRIPT_FILE_NAME)" duSetupScriptFileArgs="--distro $(Test_Distro) --architecture $(Test_Arch) -s $(AZURE_STORAGE_ACCOUNT_NAME) -p $(Test_PackageUnderTestName)"
+                              az deployment group create --name $(Test_InfraDeploymentName) --resource-group "$(Test_ResourceGroupname)" --template-file ./azurepipelines/e2e_test/templates/az_vm.template.json --parameters adminUsername="$(Test_VmAdmin)" adminKey="$(set_ssh_key.Test_Vm_Ssh_PublicKey)" adminPassword="$(VM_ADMIN_PASS)" vmName="$(Test_VmName)" vmSize=Standard_DS1_v2 location=$(Test_Location) ubuntuOSVersion=Ubuntu-2204 msi_resource_id="$(MSI_RESOURCE_ID)" msi_client_id="$(MSI_CLIENT_ID)" duSetupScriptFileUri="$(VM_SETUP_SCRIPT_URI)" duSetupScriptFileName="$(VM_SETUP_SCRIPT_FILE_NAME)" duSetupScriptFileArgs="--distro $(Test_Distro) --architecture $(Test_Arch) -s $(AZURE_STORAGE_ACCOUNT_NAME) -p $(Test_PackageUnderTestName)"
                           failOnStandardError: true
                     - task: AzureCLI@2
                       displayName: "Get the Public Hostname of the VM"


### PR DESCRIPTION
## Problem

The E2E `Setting up VM for Ubuntu 20.04 AMD64 Test VM` step fails when the VM's custom-script extension tries to `apt install` the freshly built `deviceupdate-$(Build.BuildId).deb`:

```
The following packages have unmet dependencies:
 deviceupdate-agent : Depends: libc6 (>= 2.34) but 2.31-0ubuntu9.17 is to be installed
                      Depends: libssl3 (>= 3.0.0~~alpha1) but it is not installable
                      Depends: libstdc++6 (>= 11) but 10.5.0-1ubuntu1~20.04 is to be installed
E: Unable to correct problems, you have held broken packages.
cp: cannot create regular file '/etc/adu/du-config.json': No such file or directory
```

## Root cause

The native build job pool now runs **Ubuntu 22.04** (jammy) ? confirmed in the build log (`build-essential 12.9ubuntu3`, `libssl-dev 3.0.2-0ubuntu1.25`, etc.). So the produced `.deb` links against `glibc 2.35` / `libssl3` / `libstdc++ >= 11`.

The E2E test VM is still Ubuntu 20.04 (focal) ? `glibc 2.31` / `libssl 1.1` / `libstdc++ 10` ? so the dependency resolver rejects the package. The agent never installs and the rest of the VM setup script bails (`/etc/adu/du-config.json` is never written).

## Fix

Move the entire amd64 E2E flow to Ubuntu 22.04 so the test VM matches the build environment. This also aligns with **Ubuntu 20.04 reaching end-of-standard-support in April 2025**.

Changes (in `azurepipelines/e2e_test/e2etest.yaml` only):

| Setting | Before | After |
|---|---|---|
| container resource `image` | `ubuntu:20.04` | `ubuntu:22.04` |
| `Test_DeviceName` | `ubuntu-2004-x509-test-device` | `ubuntu-2204-x509-test-device` |
| `Test_Distro` | `ubuntu-20.04` | `ubuntu-22.04` |
| `Test_Artifacts_Folder` | `adu-client-ubuntu-2004-amd64` | `adu-client-ubuntu-2204-amd64` |
| Build job name + `targetOs` | `BuildUbuntu_2004_AMD64`, `ubuntu2004` | `BuildUbuntu_2204_AMD64`, `ubuntu2204` |
| Publish job name | `PublishUbuntu2004_AMD64_Package` | `PublishUbuntu2204_AMD64_Package` |
| Artifact `itemPattern` | `*ubuntu2004-amd64*/*.deb` | `*ubuntu2204-amd64*/*.deb` |
| VM setup job name | `SetupUbuntu2004_AMD64_VM` | `SetupUbuntu2204_AMD64_VM` |
| `az deployment group create` params | (no `ubuntuOSVersion` -> defaults to `Ubuntu-2004`) | adds `ubuntuOSVersion=Ubuntu-2204` |
| Display names / echo strings | "Ubuntu 20.04 ..." | "Ubuntu 22.04 ..." |

## No other changes required

- `templates/az_vm.template.json` already declares `Ubuntu-2204` as an `allowedValues` and maps it to the Canonical `0001-com-ubuntu-server-jammy` / `22_04-lts-gen2` image. Selecting it just needs the explicit `ubuntuOSVersion=Ubuntu-2204` parameter, which this PR adds.
- `scenarios/test_runner/vm_setup/x509_vm_setup.sh` and `sas_vm_setup.sh` already branch on the distro string and handle `ubuntu-22.04` for both the `packages.microsoft.com` apt config and the `microsoft/do-client` v1.1.0 `ubuntu2204_*` tarballs.

## Validation

Local validation of the deployment scripts is not possible (the failure was VM-side), so this needs the next E2E pipeline run to confirm. The change is a straightforward target-OS rename that exercises code paths already present in the repo.
