### PR TITLE
Default ADUC_BUILD_WITH_DELIVERY_OPTIMIZATION to OFF (curl is the new default downloader)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,7 +541,7 @@ option (
     "Build the Microsoft Delta Download Handler with iot-hub-device-update-delta library support"
     OFF)
 option (ADUC_BUILD_WITH_DELIVERY_OPTIMIZATION
-        "Build with Delivery Optimization support" ON)
+        "Build with Delivery Optimization support" OFF)
 option (ADUC_ENABLE_CONSOLE_LOG "Enable console logging" ON)
 option (ADUC_ENABLE_FILE_LOG "Enable file logging" ON)
 

--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -51,8 +51,11 @@ set (CPACK_DEBIAN_PACKAGE_PRIORITY "extra")
 set (CPACK_DEBIAN_PACKAGE_SECTION "admin")
 
 # Component-specific settings for main agent package (Unspecified component)
-# Note: deliveryoptimization-agent creates DO user and group, that expected by preinst maintainer script.
-# If remove deliveryoptimization-agent from dependencies, preinst script must be updated accordingly.
+# Note: When ADUC_BUILD_WITH_DELIVERY_OPTIMIZATION is ON, deliveryoptimization-agent
+# creates the 'do' user and group that the postinst script expects when wiring up
+# the DO content downloader. If you build with DO support but remove the
+# deliveryoptimization-agent dependency below, the DO-related steps in
+# packages/debian/postinst (currently gated on `getent passwd 'do'`) become no-ops.
 
 # See https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps
 set (CPACK_DEBIAN_UNSPECIFIED_PACKAGE_DEPENDS "curl")


### PR DESCRIPTION
## Summary

Flip the CMake default for `ADUC_BUILD_WITH_DELIVERY_OPTIMIZATION` from `ON` to `OFF` so the manual cmake build path matches what `scripts/build.sh` has long defaulted to (`support_delivery_optimization=false`, [build.sh:62](../blob/develop/scripts/build.sh#L62)). The active E2E pipeline (ADU.Gen2.E2EPipeline) and `build.sh`-driven builds already produce a curl-only .deb; this change brings cmake-direct builds in line.

## Why now

* Delivery Optimization is becoming a maintenance liability: `microsoft/do-client` only ships v1.1.0 packages for Ubuntu 20.04/22.04 + Debian 10/11. Newer distros (Ubuntu 24.04 noble, Debian 13 trixie) cannot install a DO-linked agent at all. `build.sh` already force-disables DO on those targets ([build.sh:483-495](../blob/develop/scripts/build.sh#L483-L495)).
* The agent has had a fully functional curl content downloader for a long time; curl is also the only `Depends` declared by the .deb regardless of build mode ([packages/CMakeLists.txt:58](../blob/develop/packages/CMakeLists.txt#L58)).

## Why postinst does NOT need to split

The Debian maintainer scripts already support both modes in a single set of files:

| File | Behavior |
|---|---|
| `packages/debian/templates` | Default = `curl` |
| `packages/debian/config` | Only prompts in interactive frontends; `noninteractive` installs keep the curl default |
| `packages/debian/postinst:16` | Defaults to `curl` if debconf returns nothing |
| `packages/debian/postinst:240-281` (`register_reference_extensions`) | Picks the downloader by checking which `.so` exists in `/var/lib/adu/extensions/sources/` |
| `packages/debian/postinst:345-353` | DO-specific side effects (add `do` user to `adu` group, restart `deliveryoptimization-agent.service`) are gated on `getent passwd 'do'` -- no-op when DO not installed |
| `src/extensions/content_downloaders/CMakeLists.txt:4` | `libdeliveryoptimization_content_downloader.so` is only built when DO=ON, so the postinst dispatcher takes the curl branch naturally |
| `cmake/agentRules.cmake:67` | `target_link_dosdk` is a no-op when DO=OFF, so `AducIotAgent` does not link `libdeliveryoptimization` and `dpkg-shlibdeps` does not auto-add it as a hard runtime `Depends` |
| `packages/CMakeLists.txt:59-62` | `Recommends`/`Suggests` for DO debs only added when DO=ON |

## Regression analysis

* **Builds that explicitly pass** `--support-delivery-optimization` (build.sh) or `-DADUC_BUILD_WITH_DELIVERY_OPTIMIZATION=ON` (cmake) are unchanged: same binary, same `Recommends`, same postinst behavior.
* **In-place upgrades:** debconf remembers the previously chosen downloader, so existing devices keep using DO if they chose it. The flip only affects fresh builds.
* **Active E2E pipeline (ADU.Gen2.E2EPipeline)** invokes `build.sh` without `--support-delivery-optimization`, so its .deb content is unchanged. The recent focal->jammy VM-setup failure that motivated this investigation was actually a `libc6`/`libssl3`/`libstdc++6` mismatch (jammy build deb on a focal VM), not a DO dependency -- that is being fixed separately by migrating the gen1 E2E VM to Ubuntu 22.04.

## Also in this PR

Fix the stale "DO user expected by preinst" comment in `packages/CMakeLists.txt`. `preinst` does not reference the `do` user at all; the dependency was always on `postinst`'s optional DO wiring, which is now correctly described as "no-op when DO is not installed".

## Files changed

* `CMakeLists.txt` -- flip default`CMakeLists.txt:543`.
* `packages/CMakeLists.txt` -- corrected comment.