### PR TITLE
Pin vcpkg baseline and fix AducTimer thread lifecycle issues

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -671,6 +671,27 @@ do_install_azure_storage_sdk() {
 
     git checkout tags/"$azure_storage_sdk_tag_ref"
 
+    # Pin the vcpkg baseline used to resolve this SDK's manifest dependencies.
+    #
+    # The azure-sdk-for-cpp manifest at tag azure-core_1.6.0 does not declare a
+    # "builtin-baseline" in its vcpkg.json, so vcpkg falls back to whatever
+    # commit happens to be checked out in $VCPKG_ROOT (or HEAD when bootstrapped
+    # fresh). Newer vcpkg baselines ship libxml2 >= 2.13, which marks
+    # _xmlBuffer::content and _xmlBuffer::use as XML_DEPRECATED_MEMBER. The
+    # SDK's sdk/storage/azure-storage-common/src/xml_wrapper.cpp still accesses
+    # those fields directly and is built with -Werror, breaking the build.
+    #
+    # Pin the default registry to vcpkg release 2024.05.24, which still ships
+    # libxml2 2.11.7 (and is contemporaneous with azure-core_1.6.0).
+    cat > vcpkg-configuration.json <<'EOF'
+{
+    "default-registry": {
+        "kind": "builtin",
+        "baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625"
+    }
+}
+EOF
+
     # Apply patch to fix missing cstdint include for GCC 12+ (Ubuntu 24.04, Debian 12)
     # Check GCC version and apply patch only if GCC >= 12
     local gcc_version

--- a/src/utils/timer_utils/inc/aduc/timer.h
+++ b/src/utils/timer_utils/inc/aduc/timer.h
@@ -38,8 +38,23 @@ typedef struct tagAducTimer
     pthread_t timerThread;
     pthread_mutex_t mut;
     bool timerThreadRunning;
+    bool threadCreated;
     bool initialized;
 } AducTimer;
+
+/**
+ * Threading contract:
+ *  - Start/Stop are thread-safe with respect to each other and to Update.
+ *  - Stop blocks until the polling thread has exited (up to one
+ *    updateIntervalMs sleep cycle).
+ *  - Start is idempotent: if a previous Start has not been matched by a
+ *    Stop, Start will internally stop and join the previous polling
+ *    thread before starting a new one (the onStop callback is NOT
+ *    invoked in this case, only on an explicit Stop).
+ *  - Signal callbacks (onStart / onStop / onTimeout) MUST NOT call
+ *    Start, Stop, or uninit on the same timer. The timer thread joins
+ *    itself in that case, which is undefined behavior.
+ */
 
 int AducTimer_init(AducTimer* t, AducTimerSignals s, unsigned update_interval_ms);
 void AducTimer_uninit(AducTimer* t);

--- a/src/utils/timer_utils/src/timer.c
+++ b/src/utils/timer_utils/src/timer.c
@@ -54,10 +54,22 @@ static void* s_timerProc(void* context)
         return NULL;
     }
 
-    while (t->timerThreadRunning)
+    while (true)
     {
+        // Read the running flag and update interval under the mutex so we
+        // don't race with Start/Stop mutating them.
+        pthread_mutex_lock(&t->mut);
+        bool running = t->timerThreadRunning;
+        unsigned int interval_ms = t->updateIntervalMs;
+        pthread_mutex_unlock(&t->mut);
+
+        if (!running)
+        {
+            break;
+        }
+
         AducTimer_Update(t);
-        usleep(t->updateIntervalMs * 1000); // sleep for update interval
+        usleep(interval_ms * 1000); // sleep for update interval
     }
 
     return NULL;
@@ -80,6 +92,8 @@ int AducTimer_init(AducTimer* t, AducTimerSignals s, unsigned update_interval_ms
     t->waitTimeMs = 0;
     t->signals = s;
     t->updateIntervalMs = update_interval_ms;
+    t->timerThreadRunning = false;
+    t->threadCreated = false;
     t->initialized = true;
 
 #ifdef DBG_TIMER_UTILS
@@ -104,20 +118,56 @@ void AducTimer_uninit(AducTimer* t)
 
 bool AducTimer_IsTimedOut(AducTimer* t)
 {
-#ifdef DBG_TIMER_UTILS
-    Log_Debug("IsTimedOut called: result=%d", !_is_running(t) || _wait_exceeded(t));
-#endif
     pthread_mutex_lock(&t->mut);
     bool timed_out = !_is_running(t) || _wait_exceeded(t);
+#ifdef DBG_TIMER_UTILS
+    Log_Debug("IsTimedOut called: result=%d", timed_out);
+#endif
     pthread_mutex_unlock(&t->mut);
     return timed_out;
 }
 
+/**
+ * Internal: signal the polling thread to exit and join it. Does NOT
+ * invoke the onStop callback (that is done by AducTimer_Stop only).
+ * Used by both Stop (public) and Start (to ensure idempotency).
+ */
+static void _stop_thread(AducTimer* t)
+{
+    pthread_mutex_lock(&t->mut);
+    bool created = t->threadCreated;
+    pthread_t thr = t->timerThread;
+    t->timerThreadRunning = false;
+    t->threadCreated = false;
+    _reset(t);
+    pthread_mutex_unlock(&t->mut);
+
+    if (created)
+    {
+        // Join outside the mutex so the thread can finish its current
+        // iteration (which may itself take the mutex via AducTimer_Update).
+        pthread_join(thr, NULL);
+    }
+}
+
 int AducTimer_Start(AducTimer* t, unsigned w)
 {
+    if (t == NULL)
+    {
+        return -1;
+    }
+
 #ifdef DBG_TIMER_UTILS
     Log_Debug("Starting timer for %u ms", w);
 #endif
+
+    // Idempotent against a prior Start that wasn't matched by a Stop:
+    // tear down the previous polling thread before creating a new one.
+    // This avoids leaking the previous pthread_t handle and the data
+    // races / use-after-free that result from two threads polling the
+    // same AducTimer concurrently.
+    _stop_thread(t);
+
     pthread_mutex_lock(&t->mut);
     _reset(t);
     t->waitTimeMs = w;
@@ -125,13 +175,16 @@ int AducTimer_Start(AducTimer* t, unsigned w)
     if (w != 0 && t->updateIntervalMs != 0) // use zero if want to manually update pump the timer
     {
         t->timerThreadRunning = true;
-        int res = pthread_create(&t->timerThread, NULL, (void* (*)(void*))s_timerProc, t);
+        int res = pthread_create(&t->timerThread, NULL, s_timerProc, t);
         if (res != 0)
         {
             Log_Error("Failed to create timer thread");
             t->timerThreadRunning = false;
+            _reset(t);
+            pthread_mutex_unlock(&t->mut);
             return -1;
         }
+        t->threadCreated = true;
     }
     pthread_mutex_unlock(&t->mut);
 
@@ -147,17 +200,25 @@ void AducTimer_Update(AducTimer* t)
 #ifdef DBG_TIMER_UTILS
     Log_Debug("Updating timer");
 #endif
-    if (_is_running(t))
+    if (t == NULL)
     {
-        if (_wait_exceeded(t))
-        {
-            _reset(t); // auto-stop the timer until next start.
-            if (t->signals.onTimeout)
-            {
-                Log_Info("Timer timed out, invoking 'onTimeout' callback");
-                t->signals.onTimeout();
-            }
-        }
+        return;
+    }
+
+    AducTimerCallback onTimeout = NULL;
+
+    pthread_mutex_lock(&t->mut);
+    if (_is_running(t) && _wait_exceeded(t))
+    {
+        _reset(t); // auto-stop the timer until next start.
+        onTimeout = t->signals.onTimeout;
+    }
+    pthread_mutex_unlock(&t->mut);
+
+    if (onTimeout != NULL)
+    {
+        Log_Info("Timer timed out, invoking 'onTimeout' callback");
+        onTimeout();
     }
 }
 
@@ -170,11 +231,12 @@ void AducTimer_Stop(AducTimer* t)
     {
         return;
     }
-    pthread_mutex_lock(&t->mut);
-    t->timerThreadRunning = false;
-    _reset(t);
+
+    _stop_thread(t);
+
+    // signals is set at init time and never mutated, so reading
+    // onStop outside the lock is safe.
     AducTimerCallback onStop = t->signals.onStop;
-    pthread_mutex_unlock(&t->mut);
     if (onStop)
     {
 #ifdef DBG_TIMER_UTILS

--- a/src/utils/timer_utils/tests/timer_ut.cpp
+++ b/src/utils/timer_utils/tests/timer_ut.cpp
@@ -18,6 +18,19 @@ bool _g_start_called = false;
 bool _g_stop_called = false;
 bool _g_timeout_called = false;
 
+// Bounded poll for a flag set by the timer's polling thread. The thread
+// wakes every updateIntervalMs (50 in these tests), so a fixed usleep
+// shorter than that interval is racy. Poll up to ~500ms in 5ms slices
+// before giving up so the assertion still fails if the callback truly
+// never fires (e.g. under a real regression).
+static void s_wait_for_flag(volatile bool* flag)
+{
+    for (int i = 0; i < 100 && !*flag; ++i)
+    {
+        usleep(5 * 1000);
+    }
+}
+
 static void s_reset_test_metrics()
 {
     _g_start_called = false;
@@ -64,6 +77,7 @@ TEST_CASE("AducTimer callback on timeout", "[timer]")
     AducTimer_Start(&t, 200);
     usleep(250 * 1000);
     CHECK(_g_start_called);
+    s_wait_for_flag(&_g_timeout_called);
     CHECK(_g_timeout_called);
 
     AducTimer_Stop(&t);
@@ -94,7 +108,7 @@ TEST_CASE("AducTimer reuse", "[timer]")
     AducTimer_Start(&t, 100);
     CHECK(_g_start_called);
 
-    usleep(125 * 1000);
+    s_wait_for_flag(&_g_timeout_called);
     CHECK(_g_timeout_called);
 
     AducTimer_Stop(&t);
@@ -108,7 +122,7 @@ TEST_CASE("AducTimer reuse", "[timer]")
     s_reset_test_metrics();
     AducTimer_Start(&t, 25);
     CHECK(_g_start_called);
-    usleep(30 * 1000);
+    s_wait_for_flag(&_g_timeout_called);
     CHECK(_g_timeout_called);
 }
 


### PR DESCRIPTION
This pull request makes several improvements and bug fixes to the timer utilities, focusing on thread safety, timer lifecycle management, and more robust testing. The most significant changes include making `AducTimer_Start` idempotent, preventing timer thread leaks, and ensuring all timer operations are thread-safe. Tests have also been updated to be more reliable and less timing-dependent.

**Timer thread safety and lifecycle improvements:**

* Made `AducTimer_Start` idempotent by ensuring any previous polling thread is stopped and joined before starting a new one, preventing thread leaks and race conditions. Introduced an internal `_stop_thread` helper to encapsulate this logic. (`src/utils/timer_utils/src/timer.c`, `src/utils/timer_utils/inc/aduc/timer.h`) [[1]](diffhunk://#diff-e9744f8a56883303d0f424f83daa008f330b03ab8abc7620975ebc69cbdeeec9L107-R187) [[2]](diffhunk://#diff-e9744f8a56883303d0f424f83daa008f330b03ab8abc7620975ebc69cbdeeec9L173-L177) [[3]](diffhunk://#diff-c84fd838335cb46282594e8cdbba55af45f2ffbb45234f40c3fcc0cf60d47dddR41-R58)
* Added a `threadCreated` member to `AducTimer` to track thread state, ensuring proper joining and preventing undefined behavior. (`src/utils/timer_utils/inc/aduc/timer.h`, `src/utils/timer_utils/src/timer.c`) [[1]](diffhunk://#diff-c84fd838335cb46282594e8cdbba55af45f2ffbb45234f40c3fcc0cf60d47dddR41-R58) [[2]](diffhunk://#diff-e9744f8a56883303d0f424f83daa008f330b03ab8abc7620975ebc69cbdeeec9R95-R96)
* Improved thread safety by locking around all mutations and reads of timer state, and restructured the polling thread loop to avoid races with `Start`/`Stop`. (`src/utils/timer_utils/src/timer.c`) [[1]](diffhunk://#diff-e9744f8a56883303d0f424f83daa008f330b03ab8abc7620975ebc69cbdeeec9L57-R72) [[2]](diffhunk://#diff-e9744f8a56883303d0f424f83daa008f330b03ab8abc7620975ebc69cbdeeec9L150-R221)

**Testing improvements:**

* Updated tests to poll for callback flags with a bounded wait instead of fixed sleeps, making them more robust and less flaky due to timing variance. Added the `s_wait_for_flag` helper for this purpose. (`src/utils/timer_utils/tests/timer_ut.cpp`) [[1]](diffhunk://#diff-2ba2cdc3ceecd19ec533e57c5be548bb05082d66afc4ca5d6604386b2d3e1ef4R21-R33) [[2]](diffhunk://#diff-2ba2cdc3ceecd19ec533e57c5be548bb05082d66afc4ca5d6604386b2d3e1ef4R80) [[3]](diffhunk://#diff-2ba2cdc3ceecd19ec533e57c5be548bb05082d66afc4ca5d6604386b2d3e1ef4L97-R111) [[4]](diffhunk://#diff-2ba2cdc3ceecd19ec533e57c5be548bb05082d66afc4ca5d6604386b2d3e1ef4L111-R125)

**Documentation:**

* Added a detailed threading contract comment to `AducTimer`, clarifying the guarantees and requirements for safe use of the timer API. (`src/utils/timer_utils/inc/aduc/timer.h`)

**Build reliability:**

* Pinned the vcpkg baseline in the Azure Storage SDK install script to avoid build failures due to upstream changes in libxml2. (`scripts/install-deps.sh`)