### PR TITLE
Fix test to work with relative workfolder parameter in build

### DIFF
--- a/src/extensions/step_handlers/apt_handler/tests/CMakeLists.txt
+++ b/src/extensions/step_handlers/apt_handler/tests/CMakeLists.txt
@@ -34,7 +34,8 @@ target_compile_definitions (
     ${PROJECT_NAME}
     PRIVATE ADUC_INSTALLEDCRITERIA_FILE_PATH="/${ADUC_TMP_DIR_PATH}/adu-test-installedcriteria"
             ADUSHELL_FILE_PATH="${ADUSHELL_FILE_PATH}"
-            ADUC_TEST_DATA_FOLDER="${ADUC_TEST_DATA_FOLDER}")
+            ADUC_TEST_DATA_FOLDER="${ADUC_TEST_DATA_FOLDER}"
+            ADUC_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
 target_link_libraries (
     ${PROJECT_NAME}

--- a/src/extensions/step_handlers/apt_handler/tests/apt_handler_ut.cpp
+++ b/src/extensions/step_handlers/apt_handler/tests/apt_handler_ut.cpp
@@ -258,8 +258,8 @@ TEST_CASE("APT handler install/apply/cancel paths with local apt manifest", "[ap
     REQUIRE(stepHandle != nullptr);
 
     const std::string aptManifestDir =
-        std::string(ADUC_TEST_DATA_FOLDER)
-        + "/../../../src/extensions/component_enumerators/examples/contoso_component_enumerator/demo/sample-updates/data-files/APT";
+        std::string(ADUC_SOURCE_DIR)
+        + "/src/extensions/component_enumerators/examples/contoso_component_enumerator/demo/sample-updates/data-files/APT";
     REQUIRE(workflow_set_workfolder(stepHandle, aptManifestDir.c_str()));
 
     std::unique_ptr<ContentHandler> handler(AptHandlerImpl::CreateContentHandler());


### PR DESCRIPTION
Fix test that fails if adu tests are built with workfolder.

Steps to reproduce:

```sh
$ scripts/build.sh -c -u -f /somefolder
$ cd out; ctest -T test --output-on-failure -R "^APT handler install\/apply\/"
```


Logs before the fix

```sh
$ scripts/build.sh -c -u -f /somefolder
(...)
$ cd out; ctest -T test --output-on-failure -R "^APT handler install\/apply\/"
   Site: andre-ThinkPad-T14-Gen-5
   Build name: Linux-g++
Create new tag: 20260703-1021 - Experimental
Test project /workspaces/iot-hub-device-update/out
    Start 372: APT handler install/apply/cancel paths with local apt manifest
1/1 Test #372: APT handler install/apply/cancel paths with local apt manifest ...***Failed    0.00 sec
Filters: "APT handler install/apply/cancel paths with local apt manifest"
Randomness seeded to: 2221336659
2026-07-03T10:21:39.0099Z 188246[188246] [D] Log file created: /var/log/adu/apt-handler.20260703-102139.log [zlog_init:185]
2026-07-03T10:21:39.0100Z 188246[188246] [I] Instantiating a Step Handler for 'microsoft/apt:1' [CreateUpdateContentHandlerExtension:57]
2026-07-03T10:21:39.0100Z 188246[188246] [I] Setting handler for 'microsoft/apt:1'. [SetUpdateContentHandlerExtension:371]
2026-07-03T10:21:39.0100Z 188246[188246] [D] Creating workflow for 1 step(s). Parent's level: 0 [PrepareStepsWorkflowDataObject:167]
2026-07-03T10:21:39.0100Z 188246[188246] [D] Creating workflow for level#0 step#0.
Selected components:
=====
(null)
=====
 [PrepareStepsWorkflowDataObject:179]
2026-07-03T10:21:39.0100Z 188246[188246] [D] Processing current step:
{
    "handler": "microsoft\/apt:1",
    "files": [
        "f483750ebb885d32c"
    ],
    "handlerProperties": {
        "installedCriteria": "apt-update-tree-1.0"
    }
} [workflow_create_from_inline_step:2780]
2026-07-03T10:21:39.0101Z 188246[188246] [D] set prop '_workFolder' to '/var/lib/adu/downloads/dcb112da-bfc9-47b7-b7ed-617feba1e6c4' [workflow_set_string_property:1756]
2026-07-03T10:21:39.0101Z 188246[188246] [D] set prop '_selectedComponents' to null [workflow_set_string_property:1760]
2026-07-03T10:21:39.0101Z 188246[188246] [I] Uninitializing config info. [ADUC_ConfigInfo_UnInit:686]
2026-07-03T10:21:39.0101Z 188246[188246] [D] set prop '_workFolder' to '/somefolder/adu/testdata/../../../src/extensions/component_enumerators/examples/contoso_component_enumerator/demo/sample-updates/data-files/APT' [workflow_set_string_property:1756]
2026-07-03T10:21:39.0101Z 188246[188246] [D] Property '_workFolder' not NULL - returning cached workfolder '/somefolder/adu/testdata/../../../src/extensions/component_enumerators/examples/contoso_component_enumerator/demo/sample-updates/data-files/APT' [workflow_get_workfolder:1981]
2026-07-03T10:21:39.0101Z 188246[188246] [E] Failed to parse specified APT file (/somefolder/adu/testdata/../../../src/extensions/component_enumerators/examples/contoso_component_enumerator/demo/sample-updates/data-files/APT/apt-manifest-tree-1.0.json). [ParseAptContentFromFile:131]
2026-07-03T10:21:39.0102Z 188246[188246] [E] An error occurred while parsing APT manifest. Cannot parse specified APT file. [ParseContent:125]

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
apt_handler_unit_tests is a Catch2 v3.8.0 host application.
Run with -? for options

-------------------------------------------------------------------------------
APT handler install/apply/cancel paths with local apt manifest
-------------------------------------------------------------------------------
/workspaces/iot-hub-device-update/src/extensions/step_handlers/apt_handler/tests/apt_handler_ut.cpp:251
...............................................................................

/workspaces/iot-hub-device-update/src/extensions/step_handlers/apt_handler/tests/apt_handler_ut.cpp:274: FAILED:
  CHECK( installResult.ExtendedResultCode != MAKE_ADUC_EXTENDEDRESULTCODE_FOR_COMPONENT_ADUC_CONTENT_HANDLER_COMMON(104) )
with expansion:
  805306472 (0x30000068)
  !=
  805306472 (0x30000068)

2026-07-03T10:21:39.0102Z 188246[188246] [D] Property '_workFolder' not NULL - returning cached workfolder '/somefolder/adu/testdata/../../../src/extensions/component_enumerators/examples/contoso_component_enumerator/demo/sample-updates/data-files/APT' [workflow_get_workfolder:1981]
2026-07-03T10:21:39.0103Z 188246[188246] [E] Failed to parse specified APT file (/somefolder/adu/testdata/../../../src/extensions/component_enumerators/examples/contoso_component_enumerator/demo/sample-updates/data-files/APT/apt-manifest-tree-1.0.json). [ParseAptContentFromFile:131]
2026-07-03T10:21:39.0104Z 188246[188246] [E] An error occurred while parsing APT manifest. Cannot parse specified APT file. [ParseContent:125]
2026-07-03T10:21:39.0102Z 188246[188246] [D] Saving installedCriteria: apt-update-tree-1.0  [PersistInstalledCriteria:114]
/workspaces/iot-hub-device-update/src/extensions/step_handlers/apt_handler/tests/apt_handler_ut.cpp:277: FAILED:
  CHECK( applyResult.ExtendedResultCode != MAKE_ADUC_EXTENDEDRESULTCODE_FOR_COMPONENT_ADUC_CONTENT_HANDLER_COMMON(104) )
with expansion:
  805306472 (0x30000068)
  !=
  805306472 (0x30000068)

2026-07-03T10:21:39.0104Z 188246[188246] [D] Property '_workFolder' not NULL - returning cached workfolder '/somefolder/adu/testdata/../../../src/extensions/component_enumerators/examples/contoso_component_enumerator/demo/sample-updates/data-files/APT' [workflow_get_workfolder:1981]
2026-07-03T10:21:39.0104Z 188246[188246] [I] Requesting cancel operation (workflow id '0', level 1, step 0). [Cancel:476]
2026-07-03T10:21:39.0104Z 188246[188246] [D] Deleting handler for 'microsoft/apt:1'. [UnloadAllUpdateContentHandlers:396]
===============================================================================
test cases: 1 | 1 failed
assertions: 8 | 6 passed | 2 failed



0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.02 sec

The following tests FAILED:
        372 - APT handler install/apply/cancel paths with local apt manifest (Failed)
Errors while running CTest
```

After the change

```sh
$ scripts/build.sh -c -u -f /somefolder
(...)
$ cd out; ctest -T test --output-on-failure -R "^APT handler install\/apply\/"
   Site: andre-ThinkPad-T14-Gen-5
   Build name: Linux-g++
Create new tag: 20260703-1024 - Experimental
Test project /workspaces/iot-hub-device-update/out
    Start 372: APT handler install/apply/cancel paths with local apt manifest
1/1 Test #372: APT handler install/apply/cancel paths with local apt manifest ...   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.02 sec
```