### PR TITLE
Fix work-folder as parameter in build script.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -236,12 +236,6 @@ determine_distro() {
 
 determine_distro
 
-# Ensure work folder exists
-if [[ ! -d $work_folder ]]; then
-    echo "Creating work folder: $work_folder"
-    mkdir -p "$work_folder" || $ret 1
-fi
-
 while [[ $1 != "" ]]; do
     case $1 in
     -c | --clean)
@@ -418,6 +412,12 @@ while [[ $1 != "" ]]; do
     esac
     shift
 done
+
+# Ensure work folder exists
+if [[ ! -d $work_folder ]]; then
+    echo "Creating work folder: $work_folder"
+    mkdir -p "$work_folder" || $ret 1
+fi
 
 # Set cmake_dir_path if not explicitly provided via --cmake-path.
 # Note: This must be done after argument parsing is complete so that


### PR DESCRIPTION
Fix work-folder being created in default location even if `--work-folder` is passed.

Steps to reproduce:

```sh
$ rm -rf .workspace/
$ scripts/build.sh --work-folder /different_folder
Creating work folder: /workspaces/iot-hub-device-update/scripts/../.workspace
```

Notice how when passed `--work-folder` still created a folder in the default space rather than the passed parameter.

After this PR:
```sh
$ scripts/build.sh --work-folder /different_folder
Creating work folder: /different_folder
```