### PR TITLE
install-deps: pre-seed bzip2 tarball for vcpkg under 1ES network isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ No changes are required if you do not author script-handler `CancelUpdate()` log
 * Upgrade `azure-iot-sdk-c` from `LTS_08_2023` to `LTS_03_2025` ([#882](https://github.com/Azure/iot-hub-device-update/pull/882)). This is a significant transport-stack dependency change; validate your authentication and connectivity modes (SAS, X.509, EIS/AIS, nested Edge, proxy) when upgrading.
 * Pin the vcpkg baseline for the Azure Storage SDK build ([#891](https://github.com/Azure/iot-hub-device-update/pull/891))
 * `install-deps`: pin the delta build to a newer GCC on Ubuntu 20.04 arm64 ([#881](https://github.com/Azure/iot-hub-device-update/pull/881))
+* `install-deps`: pre-seed the bzip2 source archive from an allowlisted distro mirror so vcpkg delta-dependency builds succeed under 1ES network isolation ([#910](https://github.com/Azure/iot-hub-device-update/pull/910))
 * CI: retry docker-build apt steps to absorb transient mirror failures ([#885](https://github.com/Azure/iot-hub-device-update/pull/885))
 
 ### Documentation

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -952,6 +952,58 @@ EOF
             --x-install-root="$vcpkg_root/installed" || return 1
     }
 
+    # ---------------------------------------------------------------------
+    # Network-isolation workaround: pre-seed the bzip2 source archive.
+    #
+    # Every vcpkg port installed below fetches its sources from github.com
+    # EXCEPT bzip2, whose port downloads bzip2-<ver>.tar.gz from sourceware.org
+    # (with a www.mirrorservice.org fallback). Under 1ES network isolation the
+    # amd64 build pool only reaches an allowlist of mirrors; neither sourceware
+    # host is on it, so the fetch times out and "vcpkg install bzip2" fails with
+    # BUILD_FAILED, breaking the whole dependency install.
+    #
+    # Drop the byte-for-byte identical tarball into vcpkg's download cache under
+    # the exact name the port expects. The distro archive pools carry it as
+    # bzip2_<ver>.orig.tar.gz and are on the isolation allowlist -- deb.debian.org
+    # for Debian containers, azure.archive.ubuntu.com for Ubuntu containers -- so
+    # one of the mirrors below is always reachable. vcpkg then validates the
+    # SHA512 and skips its upstream download. If no mirror is reachable or the
+    # hash mismatches we leave the cache untouched and let vcpkg try upstream
+    # (no worse than before).
+    #
+    # bzip2 1.0.8 has been the latest release since 2019; if the pinned vcpkg
+    # baseline ever bumps the version, update bzip2_ver / bzip2_sha512.
+    # ---------------------------------------------------------------------
+    local bzip2_ver="1.0.8"
+    local bzip2_sha512="083f5e675d73f3233c7930ebe20425a533feedeaaa9d8cc86831312a6581cefbe6ed0d08d2fa89be81082f2a5abdabca8b3c080bf97218a1bd59dc118a30b9f3"
+    local vcpkg_downloads="$vcpkg_root/downloads"
+    local bzip2_cache="$vcpkg_downloads/bzip2-${bzip2_ver}.tar.gz"
+    if [[ -f $bzip2_cache ]] && echo "${bzip2_sha512}  ${bzip2_cache}" | sha512sum --check --status; then
+        echo "bzip2-${bzip2_ver}.tar.gz already cached for vcpkg; skipping pre-seed."
+    else
+        echo "Pre-seeding vcpkg download cache with bzip2-${bzip2_ver}.tar.gz from an allowlisted distro mirror..."
+        mkdir -p "$vcpkg_downloads"
+        local bzip2_mirror bzip2_seeded=false
+        for bzip2_mirror in \
+            "http://deb.debian.org/debian/pool/main/b/bzip2/bzip2_${bzip2_ver}.orig.tar.gz" \
+            "http://azure.archive.ubuntu.com/ubuntu/pool/main/b/bzip2/bzip2_${bzip2_ver}.orig.tar.gz" \
+            "http://archive.ubuntu.com/ubuntu/pool/main/b/bzip2/bzip2_${bzip2_ver}.orig.tar.gz" \
+            "https://sourceware.org/pub/bzip2/bzip2-${bzip2_ver}.tar.gz"; do
+            echo "  trying ${bzip2_mirror}"
+            if curl -fsSL --connect-timeout 15 --max-time 180 "$bzip2_mirror" -o "${bzip2_cache}.tmp" \
+                && echo "${bzip2_sha512}  ${bzip2_cache}.tmp" | sha512sum --check --status; then
+                mv -f "${bzip2_cache}.tmp" "$bzip2_cache"
+                echo "  pre-seeded ${bzip2_cache} (SHA512 verified)"
+                bzip2_seeded=true
+                break
+            fi
+            rm -f "${bzip2_cache}.tmp"
+        done
+        if [[ $bzip2_seeded != "true" ]]; then
+            echo "  WARNING: could not pre-seed bzip2; vcpkg will attempt its normal upstream download."
+        fi
+    fi
+
     # Install required packages
     vcpkg_install_classic zlib || return
     vcpkg_install_classic zstd || return


### PR DESCRIPTION
## Problem

The platform build's amd64 legs (`debian11/12/13-amd64`, `ubuntu2204/2404-amd64`) fail in **Install additional dependencies** because of **1ES network isolation** on the amd64 build pool.

`do_install_delta()` in `scripts/install-deps.sh` builds a set of vcpkg ports in classic mode (`zlib`, `zstd`, `bzip2`, `gtest`, `openssl`, `e2fsprogs`, `jsoncpp`, `libconfig`, `fmt`, `bsdiff`). Every one of those ports fetches its sources from **github.com** — which the pipeline reaches fine — **except `bzip2`**, whose vcpkg portfile downloads `bzip2-1.0.8.tar.gz` from **`sourceware.org`** (with a `www.mirrorservice.org` fallback).

Under 1ES isolation the amd64 pool only reaches an allowlist of package mirrors. Neither sourceware host is on it, so the download times out and `vcpkg install bzip2` fails with `BUILD_FAILED`, which aborts the entire dependency install and fails every amd64 leg.

```
Downloading https://sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz -> bzip2-1.0.8.tar.gz...
...
error: curl failed to download ... Connection timed out after ... ms
Building bzip2:x64-linux failed with: BUILD_FAILED
```

> Note: this only became visible after the sibling apt-mirror fix let the build progress past the earlier `apt` failure. The delta/vcpkg git clones already succeed, confirming github.com is reachable — bzip2's non-github distfile is the lone gap.

## Fix

Pre-seed vcpkg's download cache with the **byte-for-byte identical** tarball fetched from an **allowlisted distro archive pool** before running the vcpkg installs:

- Debian containers reach `deb.debian.org`; Ubuntu containers reach `azure.archive.ubuntu.com` — both carry `bzip2_1.0.8.orig.tar.gz`, which is identical to sourceware's `bzip2-1.0.8.tar.gz` (verified: 810029 bytes, same SHA512).
- The file is written to `$VCPKG_ROOT/downloads/bzip2-1.0.8.tar.gz` — the **exact filename** the port's `vcpkg_download_distfile(... FILENAME "bzip2-${VERSION}.tar.gz")` expects. vcpkg then validates the SHA512 and **skips its upstream download**.

Properties:
- **SHA512-verified** against the value pinned in the vcpkg baseline (`e0edebd`, bzip2 `1.0.8` port-version 6) — `083f5e67…a30b9f3`. A mismatch discards the file.
- **Idempotent** — skips if the cache is already present and valid.
- **Soft-fail** — if no mirror is reachable, it warns and lets vcpkg attempt its normal upstream download (no worse than today).
- **No-op on non-isolated pools** — the cache pre-seed simply saves vcpkg a download.

Only `bzip2` is affected because it is the only delta dependency whose vcpkg port pulls from a non-github, non-allowlisted host.

## Validation

- `bash -n scripts/install-deps.sh` passes.
- Functional dry-run of the pre-seed block against a temp `VCPKG_ROOT`: cold cache downloads from `deb.debian.org`, SHA512 verifies, warm cache skips, no leftover `.tmp`.
- Confirmed the vcpkg baseline pinned by this script (`e0edebd1dc2d03cf7d02349df91de74ef4d0c00e`) resolves bzip2 to `1.0.8` with `FILENAME "bzip2-1.0.8.tar.gz"` and SHA512 `083f5e67…a30b9f3`, matching the pre-seed exactly.
- End-to-end pipeline validation of the amd64 legs is in progress.

/cc @adu-client