### PR TITLE
Fix SIGSEGV on failed startup: do not join the api service thread when it was never started

### DIFF
--- a/src/agent/api/src/apisvc.c
+++ b/src/agent/api/src/apisvc.c
@@ -90,7 +90,15 @@ bool uninit_api_svc()
     void* threadRet = NULL;
     FifoThreadRetVal* retVal = NULL;
 
-    atomic_store(&g_api_svc_thread_running, false);
+    // The flag is set only after the thread was created, so a false value means
+    // g_api_svc_thread still holds the zero-initialized handle. Joining that
+    // dereferences a NULL thread descriptor.
+    if (!atomic_exchange(&g_api_svc_thread_running, false))
+    {
+        Log_Info("api service thread was not started, nothing to uninit");
+        return false;
+    }
+
     int res = pthread_join(g_api_svc_thread, (void**)&threadRet);
     if (res != 0)
     {

--- a/src/agent/api/tests/apisvc_unit_tests.cpp
+++ b/src/agent/api/tests/apisvc_unit_tests.cpp
@@ -16,12 +16,15 @@
 #include "aduc/viewstatemgr.h"
 
 #include <arpa/inet.h>
+#include <atomic>
 #include <catch2/catch_all.hpp>
 #include <chrono>
+#include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <filesystem>
 #include <poll.h>
+#include <pthread.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -83,6 +86,24 @@ static int open_fifo_with_timeout(const char* path, int flags, int timeout_ms)
 using Catch::Matchers::Equals;
 
 ViewStateManager g_vsm = { 0 };
+
+// Counts joins attempted on the zero-initialized thread handle. Joins of real
+// threads are forwarded to libc, so the other sections behave as before.
+static std::atomic<int> g_joinsOnZeroHandle{ 0 };
+
+extern "C" int pthread_join(pthread_t thread, void** retval)
+{
+    using JoinFn = int (*)(pthread_t, void**);
+    static auto realJoin = reinterpret_cast<JoinFn>(dlsym(RTLD_NEXT, "pthread_join"));
+
+    if (thread == static_cast<pthread_t>(0))
+    {
+        ++g_joinsOnZeroHandle;
+        return ESRCH;
+    }
+
+    return realJoin(thread, retval);
+}
 
 TEST_CASE("apisvc crossproc tests")
 {
@@ -153,6 +174,30 @@ TEST_CASE("apisvc crossproc tests")
         CHECK(resp.ret_val == (uint16_t)ADUC_ServiceStatus_Installing);
 
         CHECK(uninit_api_svc());
+    }
+
+    SECTION("uninit without init")
+    {
+        // Joining the zero-initialized handle dereferences a NULL thread
+        // descriptor, which crashes on aarch64 glibc (agent shutdown after a
+        // failed startup).
+        g_joinsOnZeroHandle = 0;
+
+        CHECK_FALSE(uninit_api_svc());
+        CHECK(g_joinsOnZeroHandle == 0);
+    }
+
+    SECTION("uninit twice")
+    {
+        const std::string reqFifoPath = TEST_DATA_DIR + "/test_req_fifo";
+
+        REQUIRE(init_api_svc(reqFifoPath.c_str()));
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        g_joinsOnZeroHandle = 0;
+
+        CHECK(uninit_api_svc());
+        CHECK_FALSE(uninit_api_svc());
+        CHECK(g_joinsOnZeroHandle == 0);
     }
 
     SECTION("GetAduServiceStatus via SDK API")


### PR DESCRIPTION
Fixes #911

### What
`uninit_api_svc()` joined `g_api_svc_thread` unconditionally. The handle is
zero-initialized and only set by `init_api_svc()`, so a shutdown that never started
the service passed a NULL thread descriptor to `pthread_join()`. On aarch64 glibc
that dereferences it and the agent dies with `SIGSEGV` (fault address `0xd0`, inside
the join implementation); x86 glibc happens to return `ESRCH`, so the crash only
shows on arm.

The agent hits this on every failed startup: `HealthCheck()` fails, `main()` goes to
`done`, `ShutdownAgent()` calls `uninit_api_svc()` although `StartupAgent()` never
ran. The unit restarts the agent after the failure, so the crash repeats until the
start limit stops the service.

### Fix
Take the running flag with `atomic_exchange()` and skip the teardown when it was
already false. A second `uninit_api_svc()` is a no-op too, matching the guard the
timer thread already has in `_stop_thread()` (`timer_utils/src/timer.c`).

### Tests
- New sections in `apisvc_unit_tests.cpp`: "uninit without init" and "uninit twice".
  They interpose `pthread_join()` (real handles forwarded to libc via
  `dlsym(RTLD_NEXT, ...)`) and assert that no join is attempted on the zero handle.
  A plain return-value check would not catch the bug on x86, where the faulty join
  just returns `ESRCH`.
- `apisvc_unit_tests`: 26/26 assertions pass with the fix; 2 assertions fail without
  it.
- Full `ctest` run on `develop`: the failing-test set is identical before and after
  this change (80 pre-existing failures in my container setup, none in apisvc).

Root-caused from a symbolized device core; details in #911.
